### PR TITLE
fix: add version constraints to workspace path dependencies

### DIFF
--- a/moonpool-sim/Cargo.toml
+++ b/moonpool-sim/Cargo.toml
@@ -9,7 +9,7 @@ description = "Simulation engine for the moonpool framework"
 documentation = "https://docs.rs/moonpool-sim"
 
 [dependencies]
-moonpool-core = { path = "../moonpool-core" }
+moonpool-core = { path = "../moonpool-core", version = "0.2.0" }
 
 async-trait = "0.1"
 crc32c = "0.6"

--- a/moonpool-transport/Cargo.toml
+++ b/moonpool-transport/Cargo.toml
@@ -9,8 +9,8 @@ description = "FDB-style transport layer for the moonpool framework"
 documentation = "https://docs.rs/moonpool-transport"
 
 [dependencies]
-moonpool-core = { path = "../moonpool-core" }
-moonpool-sim = { path = "../moonpool-sim" }
+moonpool-core = { path = "../moonpool-core", version = "0.2.0" }
+moonpool-sim = { path = "../moonpool-sim", version = "0.2.0" }
 
 async-trait = "0.1"
 crc32c = "0.6"
@@ -23,7 +23,7 @@ tokio-util = "0.7"
 tracing = "0.1"
 
 [dev-dependencies]
-moonpool-sim = { path = "../moonpool-sim" }
+moonpool-sim = { path = "../moonpool-sim", version = "0.2.0" }
 tracing-subscriber = "0.3"
 
 [[example]]

--- a/moonpool/Cargo.toml
+++ b/moonpool/Cargo.toml
@@ -9,6 +9,6 @@ repository.workspace = true
 edition.workspace = true
 
 [dependencies]
-moonpool-core = { path = "../moonpool-core" }
-moonpool-sim = { path = "../moonpool-sim" }
-moonpool-transport = { path = "../moonpool-transport" }
+moonpool-core = { path = "../moonpool-core", version = "0.2.0" }
+moonpool-sim = { path = "../moonpool-sim", version = "0.2.0" }
+moonpool-transport = { path = "../moonpool-transport", version = "0.2.0" }


### PR DESCRIPTION
Path dependencies require version numbers when publishing to crates.io. This adds version = "0.2.0" to all internal workspace dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)