### PR TITLE
fix(docs): add docs.rs config and README for each crate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,13 @@
 - Default: `UntilAllSometimesReached(1000)` for comprehensive chaos testing
 - Debug faulty seeds: `FixedCount(1)` with specific seed and ERROR log level
 
+## Commit Messages
+Follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/):
+
+Format: `<type>(<crate>): <description>`
+
+Types: `fix` (bugfix), `feat` (new feature), `build`, `chore`, `ci`, `docs`, `style`, `refactor`, `perf`, `test`
+
 ## Core Constraints
 - Single-core execution (no Send/Sync)
 - No `unwrap()` - use `Result<T, E>` with `?`

--- a/moonpool-core/Cargo.toml
+++ b/moonpool-core/Cargo.toml
@@ -7,6 +7,10 @@ license.workspace = true
 repository.workspace = true
 description = "Core abstractions for the moonpool simulation framework"
 documentation = "https://docs.rs/moonpool-core"
+readme = "README.md"
+
+[package.metadata.docs.rs]
+rustflags = ["--cfg", "tokio_unstable"]
 
 [dependencies]
 async-trait = "0.1"

--- a/moonpool-core/README.md
+++ b/moonpool-core/README.md
@@ -1,0 +1,44 @@
+# moonpool-core
+
+Core abstractions for the moonpool simulation framework.
+
+## Why: Interface Swapping
+
+The same application code runs in both simulation and production. The only difference is which provider implementations you use.
+
+This is FoundationDB's core insight: no mocks, no stubs—real code runs in both environments. A global network pointer switches between production (real TCP via tokio) and simulation (fake connections to in-memory buffers).
+
+## How: Provider Traits
+
+Application code depends on traits, not concrete implementations:
+
+| Trait | Purpose | Production | Simulation |
+|-------|---------|------------|------------|
+| `TimeProvider` | Sleep, timeout, now() | Wall clock | Logical time |
+| `NetworkProvider` | Connect, listen, accept | Real TCP | Simulated TCP |
+| `TaskProvider` | Spawn async tasks | Tokio spawn | Event-driven |
+| `RandomProvider` | Random numbers | System RNG | Seeded RNG |
+
+## The Golden Rule
+
+**Never call tokio directly in application code.**
+
+Instead of `tokio::time::sleep()`, use `time_provider.sleep()`. This ensures your code works identically in simulation and production.
+
+## Core Types
+
+FDB-compatible types for endpoint addressing:
+
+- `UID`: 128-bit unique identifier (deterministically generated in simulation)
+- `Endpoint`: Network address + token for direct addressing
+- `NetworkAddress`: IP address + port
+- `WellKnownToken`: Reserved tokens for system services
+
+## Documentation
+
+- [API Documentation](https://docs.rs/moonpool-core)
+- [Repository](https://github.com/PierreZ/moonpool)
+
+## License
+
+Apache 2.0

--- a/moonpool-sim/Cargo.toml
+++ b/moonpool-sim/Cargo.toml
@@ -7,6 +7,10 @@ license.workspace = true
 repository.workspace = true
 description = "Simulation engine for the moonpool framework"
 documentation = "https://docs.rs/moonpool-sim"
+readme = "README.md"
+
+[package.metadata.docs.rs]
+rustflags = ["--cfg", "tokio_unstable"]
 
 [dependencies]
 moonpool-core = { path = "../moonpool-core", version = "0.2.0" }

--- a/moonpool-sim/README.md
+++ b/moonpool-sim/README.md
@@ -1,0 +1,51 @@
+# moonpool-sim
+
+Deterministic simulation engine for distributed systems, inspired by [FoundationDB's simulation testing](https://apple.github.io/foundationdb/testing.html).
+
+## Why: Discovery Testing, Not Prevention Testing
+
+Traditional testing asks: *"Did we break what used to work?"* This is **prevention testing**—regression detection through test coverage.
+
+Simulation testing asks: *"What else is broken that we haven't found yet?"* This is **discovery testing**—actively hunting for unknown bugs.
+
+Bugs hide in rare combinations of events. An API with just six variables creates thousands of unique test cases for happy paths alone. Every new feature multiplies the complexity. Traditional testing cannot cover these combinations—but simulation can explore them autonomously.
+
+## How: Deterministic Simulation
+
+**Same seed = identical execution.** Given the same seed, the system makes identical decisions every time. When a bug surfaces after millions of simulated operations, you can replay that exact sequence to debug it.
+
+**Time compression.** A single-threaded event loop advances simulated time when all actors block. Years of uptime can be simulated in seconds. A simulated day passes instantly when nothing is scheduled.
+
+**Chaos injection.** The simulator deliberately biases execution toward rare code paths. Network delays, disconnects, partitions, bit flips—failures that might take months to occur in production happen continuously in simulation.
+
+## Controlled Failure Injection: BUGGIFY
+
+Rather than hoping rare bugs surface, moonpool deliberately triggers them. `buggify!` points fire with 25% probability during testing, creating a combinatorial explosion across configurations.
+
+Strategic placement at error-prone points ensures deep bugs—those needing rare combinations of events—actually get tested.
+
+## The Assertion System
+
+**`always_assert!`**: Invariants that must never fail. These guard correctness properties that should hold regardless of chaos.
+
+**`sometimes_assert!`**: Verify that edge cases actually occur. This is the key insight:
+
+- Prevention testing tells you *"this line was reached"*
+- Sometimes assertions verify *"this interesting scenario actually happened"*
+
+If your error handling code exists but `sometimes_assert!` never fires, you haven't actually tested it. The goal is 100% sometimes coverage—proof that every error path was exercised.
+
+## Multi-Seed Testing
+
+Different seeds explore different execution orderings. `UntilAllSometimesReached(N)` runs simulations with different seeds until all `sometimes_assert!` statements have triggered at least once, up to N iterations.
+
+This transforms testing from "check known behaviors" to "explore the unknown until confident."
+
+## Documentation
+
+- [API Documentation](https://docs.rs/moonpool-sim)
+- [Repository](https://github.com/PierreZ/moonpool)
+
+## License
+
+Apache 2.0

--- a/moonpool-transport/Cargo.toml
+++ b/moonpool-transport/Cargo.toml
@@ -7,6 +7,10 @@ license.workspace = true
 repository.workspace = true
 description = "FDB-style transport layer for the moonpool framework"
 documentation = "https://docs.rs/moonpool-transport"
+readme = "README.md"
+
+[package.metadata.docs.rs]
+rustflags = ["--cfg", "tokio_unstable"]
 
 [dependencies]
 moonpool-core = { path = "../moonpool-core", version = "0.2.0" }

--- a/moonpool-transport/README.md
+++ b/moonpool-transport/README.md
@@ -1,0 +1,64 @@
+# moonpool-transport
+
+FDB-style transport layer for the moonpool simulation framework.
+
+## Why: Same Code, Different Environments
+
+Networking primitives that work identically in simulation and production. Your application code doesn't change—only the provider implementation does.
+
+This follows FoundationDB's FlowTransport patterns, where the same fdbserver code runs in both real deployments and the simulator.
+
+## How: Provider Swapping
+
+The transport layer depends on `NetworkProvider` and `TimeProvider` traits from moonpool-core:
+
+| Environment | NetworkProvider | TimeProvider |
+|-------------|-----------------|--------------|
+| Production | `TokioNetworkProvider` | `TokioTimeProvider` |
+| Simulation | `SimNetworkProvider` | `SimTimeProvider` |
+
+Build your transport once with provider traits. In production, inject tokio-based providers for real TCP. In simulation, inject sim providers that route through the deterministic event loop.
+
+## RPC Semantics
+
+**Request/Response with Correlation**: Every request gets a unique correlation ID. Responses are routed back to the correct waiting caller.
+
+**Automatic Reconnection**: When connections drop, peers reconnect with exponential backoff. Messages queue during disconnection and drain when connectivity returns.
+
+**Message Queuing**: The transport buffers outbound messages during network failures rather than failing immediately. This matches real-world patterns where brief outages shouldn't cause application errors.
+
+## Wire Format
+
+- Length-prefixed packets for framing
+- CRC32C checksums for integrity
+- Corruption detection triggers reconnection rather than silent failures
+
+## Architecture
+
+```text
+┌─────────────────────────────────────────────────┐
+│              Application Code                    │
+│         Uses FlowTransport + RPC                 │
+├─────────────────────────────────────────────────┤
+│     FlowTransport (endpoint routing)            │
+│     • Multiplexes connections per endpoint      │
+│     • Request/response with correlation         │
+├─────────────────────────────────────────────────┤
+│     Peer (connection management)                │
+│     • Automatic reconnection with backoff       │
+│     • Message queuing during disconnection      │
+├─────────────────────────────────────────────────┤
+│     Wire Format (serialization)                 │
+│     • Length-prefixed packets                   │
+│     • CRC32C checksums                          │
+└─────────────────────────────────────────────────┘
+```
+
+## Documentation
+
+- [API Documentation](https://docs.rs/moonpool-transport)
+- [Repository](https://github.com/PierreZ/moonpool)
+
+## License
+
+Apache 2.0

--- a/moonpool/Cargo.toml
+++ b/moonpool/Cargo.toml
@@ -7,6 +7,10 @@ documentation.workspace = true
 license.workspace = true
 repository.workspace = true
 edition.workspace = true
+readme = "README.md"
+
+[package.metadata.docs.rs]
+rustflags = ["--cfg", "tokio_unstable"]
 
 [dependencies]
 moonpool-core = { path = "../moonpool-core", version = "0.2.0" }

--- a/moonpool/README.md
+++ b/moonpool/README.md
@@ -1,0 +1,35 @@
+# moonpool
+
+Deterministic simulation testing for distributed systems in Rust.
+
+Inspired by [FoundationDB's simulation testing](https://apple.github.io/foundationdb/testing.html).
+
+> **Note:** This is a hobby-grade project under active development.
+
+## Architecture
+
+```text
+┌─────────────────────────────────────────────────┐
+│           moonpool (this crate)                 │
+│         Re-exports all functionality            │
+├─────────────────────────────────────────────────┤
+│  moonpool-transport    │    moonpool-sim        │
+│  • Peer connections    │    • SimWorld runtime  │
+│  • Wire format         │    • Chaos testing     │
+│  • FlowTransport       │    • Buggify macros    │
+│  • RPC primitives      │    • Assertions        │
+├─────────────────────────────────────────────────┤
+│              moonpool-core                      │
+│  Provider traits: Time, Task, Network, Random   │
+│  Core types: UID, Endpoint, NetworkAddress      │
+└─────────────────────────────────────────────────┘
+```
+
+## Documentation
+
+- [API Documentation](https://docs.rs/moonpool)
+- [Repository](https://github.com/PierreZ/moonpool)
+
+## License
+
+Apache 2.0


### PR DESCRIPTION
- Add [package.metadata.docs.rs] with tokio_unstable rustflags to all crates to fix docs.rs build failure
- Add README.md to each crate for crates.io display
- Add readme field to each Cargo.toml

🤖 Generated with [Claude Code](https://claude.com/claude-code)