### PR TITLE
Rename FlowTransport to NetTransport

### DIFF
--- a/moonpool-transport/README.md
+++ b/moonpool-transport/README.md
@@ -38,9 +38,9 @@ Build your transport once with provider traits. In production, inject tokio-base
 ```text
 ┌─────────────────────────────────────────────────┐
 │              Application Code                    │
-│         Uses FlowTransport + RPC                 │
+│         Uses NetTransport + RPC                  │
 ├─────────────────────────────────────────────────┤
-│     FlowTransport (endpoint routing)            │
+│     NetTransport (endpoint routing)             │
 │     • Multiplexes connections per endpoint      │
 │     • Request/response with correlation         │
 ├─────────────────────────────────────────────────┤

--- a/moonpool-transport/examples/calculator.rs
+++ b/moonpool-transport/examples/calculator.rs
@@ -1,7 +1,7 @@
 //! Calculator Example: Multi-method RPC interface using Moonpool.
 //!
 //! This example demonstrates:
-//! - `FlowTransportBuilder` for cleaner transport setup (Step 9)
+//! - `NetTransportBuilder` for cleaner transport setup (Step 9)
 //! - `register_handler_at` for multi-method interfaces (Step 10b)
 //! - `recv_with_transport` for embedded transport in replies (Step 11)
 //! - Using `tokio::select!` to handle multiple request types
@@ -20,7 +20,7 @@ use std::env;
 use std::time::Duration;
 
 use moonpool_transport::{
-    Endpoint, FlowTransportBuilder, JsonCodec, NetworkAddress, ReplyFuture, TimeProvider,
+    Endpoint, JsonCodec, NetTransportBuilder, NetworkAddress, ReplyFuture, TimeProvider,
     TokioNetworkProvider, TokioTaskProvider, TokioTimeProvider, UID, send_request,
 };
 use serde::{Deserialize, Serialize};
@@ -102,9 +102,9 @@ async fn run_server() -> Result<(), Box<dyn std::error::Error>> {
     let local_addr = NetworkAddress::parse(SERVER_ADDR)?;
 
     // ========================================================================
-    // NEW API: FlowTransportBuilder eliminates Rc/set_weak_self boilerplate
+    // NEW API: NetTransportBuilder eliminates Rc/set_weak_self boilerplate
     // ========================================================================
-    let transport = FlowTransportBuilder::new(network, time, task)
+    let transport = NetTransportBuilder::new(network, time, task)
         .local_address(local_addr)
         .build_listening()
         .await?;
@@ -184,8 +184,8 @@ async fn run_client() -> Result<(), Box<dyn std::error::Error>> {
     let local_addr = NetworkAddress::parse(CLIENT_ADDR)?;
     let server_addr = NetworkAddress::parse(SERVER_ADDR)?;
 
-    // Use FlowTransportBuilder (same as server)
-    let transport = FlowTransportBuilder::new(network, time.clone(), task)
+    // Use NetTransportBuilder (same as server)
+    let transport = NetTransportBuilder::new(network, time.clone(), task)
         .local_address(local_addr)
         .build_listening()
         .await?;
@@ -336,7 +336,7 @@ fn main() {
         _ => {
             println!("Calculator Example: Multi-method RPC with Moonpool\n");
             println!("This example demonstrates the improved Phase 12C APIs:\n");
-            println!("  - FlowTransportBuilder (eliminates Rc/set_weak_self boilerplate)");
+            println!("  - NetTransportBuilder (eliminates Rc/set_weak_self boilerplate)");
             println!("  - register_handler_at (multi-method interface registration)");
             println!("  - recv_with_transport (no closure callback needed)\n");
             println!("Usage:");

--- a/moonpool-transport/examples/ping_pong.rs
+++ b/moonpool-transport/examples/ping_pong.rs
@@ -16,7 +16,7 @@
 //! # Architecture
 //!
 //! The example shows:
-//! - `FlowTransportBuilder` for clean transport setup
+//! - `NetTransportBuilder` for clean transport setup
 //! - `register_handler` for single-step endpoint registration
 //! - `recv_with_transport` for embedded transport in replies
 //! - Server: listening, receiving typed requests, sending responses
@@ -26,7 +26,7 @@ use std::env;
 use std::time::Duration;
 
 use moonpool_transport::{
-    Endpoint, FlowTransportBuilder, JsonCodec, NetworkAddress, ReplyFuture, TimeProvider,
+    Endpoint, JsonCodec, NetTransportBuilder, NetworkAddress, ReplyFuture, TimeProvider,
     TokioNetworkProvider, TokioTaskProvider, TokioTimeProvider, UID, send_request,
 };
 use serde::{Deserialize, Serialize};
@@ -81,10 +81,10 @@ async fn run_server() -> Result<(), Box<dyn std::error::Error>> {
     let local_addr = NetworkAddress::parse(SERVER_ADDR)?;
 
     // ========================================================================
-    // FlowTransportBuilder handles Rc wrapping, set_weak_self(), and listen()
+    // NetTransportBuilder handles Rc wrapping, set_weak_self(), and listen()
     // No more runtime panics from forgetting set_weak_self()!
     // ========================================================================
-    let transport = FlowTransportBuilder::new(network, time, task)
+    let transport = NetTransportBuilder::new(network, time, task)
         .local_address(local_addr)
         .build_listening()
         .await?;
@@ -151,7 +151,7 @@ async fn run_client() -> Result<(), Box<dyn std::error::Error>> {
     // Client also uses build_listening() because it needs to receive responses
     // The builder makes this requirement clear in the method name
     // ========================================================================
-    let transport = FlowTransportBuilder::new(network, time.clone(), task)
+    let transport = NetTransportBuilder::new(network, time.clone(), task)
         .local_address(local_addr)
         .build_listening()
         .await?;

--- a/moonpool-transport/src/lib.rs
+++ b/moonpool-transport/src/lib.rs
@@ -4,16 +4,16 @@
 //!
 //! This crate provides networking primitives that work identically in
 //! simulation and production environments, following FoundationDB's
-//! FlowTransport patterns.
+//! NetTransport patterns.
 //!
 //! ## Architecture
 //!
 //! ```text
 //! ┌─────────────────────────────────────────────────┐
 //! │              Application Code                    │
-//! │         Uses FlowTransport + RPC                 │
+//! │         Uses NetTransport + RPC                 │
 //! ├─────────────────────────────────────────────────┤
-//! │     FlowTransport (endpoint routing)            │
+//! │     NetTransport (endpoint routing)            │
 //! │     • Multiplexes connections per endpoint      │
 //! │     • Request/response with correlation         │
 //! ├─────────────────────────────────────────────────┤
@@ -32,17 +32,17 @@
 //! | Component | Purpose |
 //! |-----------|---------|
 //! | [`Peer`] | Resilient connection with automatic reconnection |
-//! | [`FlowTransport`] | Endpoint routing and connection multiplexing |
+//! | [`NetTransport`] | Endpoint routing and connection multiplexing |
 //! | [`wire`] | Binary serialization with CRC32C checksums |
 //! | [`rpc`] | Request/response patterns with typed messaging |
 //!
 //! ## Quick Start
 //!
 //! ```ignore
-//! use moonpool_transport::{FlowTransportBuilder, send_request};
+//! use moonpool_transport::{NetTransportBuilder, send_request};
 //!
 //! // Build transport with network provider
-//! let transport = FlowTransportBuilder::new(network_provider, time_provider)
+//! let transport = NetTransportBuilder::new(network_provider, time_provider)
 //!     .build();
 //!
 //! // Send typed request, get typed response
@@ -94,6 +94,6 @@ pub use wire::{
 
 // RPC exports
 pub use rpc::{
-    EndpointMap, FlowTransport, FlowTransportBuilder, MessageReceiver, NetNotifiedQueue,
-    ReplyError, ReplyFuture, ReplyPromise, RequestEnvelope, RequestStream, send_request,
+    EndpointMap, MessageReceiver, NetNotifiedQueue, NetTransport, NetTransportBuilder, ReplyError,
+    ReplyFuture, ReplyPromise, RequestEnvelope, RequestStream, send_request,
 };

--- a/moonpool-transport/src/rpc/mod.rs
+++ b/moonpool-transport/src/rpc/mod.rs
@@ -3,7 +3,7 @@
 //! This module implements FoundationDB's proven patterns for endpoint-based messaging:
 //!
 //! - **EndpointMap**: Token → receiver routing with O(1) well-known lookup
-//! - **FlowTransport**: Central coordinator managing peers and dispatch
+//! - **NetTransport**: Central coordinator managing peers and dispatch
 //! - **`NetNotifiedQueue<T>`**: Type-safe message queue with async notification
 //!
 //! # Design Philosophy
@@ -13,8 +13,8 @@
 //! Dynamic endpoints are allocated at runtime but still have fixed lifetimes.
 
 mod endpoint_map;
-mod flow_transport;
 mod net_notified_queue;
+mod net_transport;
 mod reply_error;
 mod reply_future;
 mod reply_promise;
@@ -22,8 +22,8 @@ mod request;
 mod request_stream;
 
 pub use endpoint_map::{EndpointMap, MessageReceiver};
-pub use flow_transport::{FlowTransport, FlowTransportBuilder};
 pub use net_notified_queue::{NetNotifiedQueue, RecvFuture, SharedNetNotifiedQueue};
+pub use net_transport::{NetTransport, NetTransportBuilder};
 pub use reply_error::ReplyError;
 pub use reply_future::ReplyFuture;
 pub use reply_promise::ReplyPromise;

--- a/moonpool-transport/src/rpc/reply_promise.rs
+++ b/moonpool-transport/src/rpc/reply_promise.rs
@@ -64,7 +64,7 @@ struct ReplyPromiseInner<T, C: MessageCodec> {
     codec: C,
 
     /// Sender function - sends serialized bytes to the endpoint.
-    /// This is injected to decouple from FlowTransport.
+    /// This is injected to decouple from NetTransport.
     sender: Option<ReplySender>,
 
     /// Whether the promise has been fulfilled.

--- a/moonpool-transport/src/rpc/request.rs
+++ b/moonpool-transport/src/rpc/request.rs
@@ -6,7 +6,7 @@
 //! # Example
 //!
 //! ```rust,ignore
-//! use moonpool::{send_request, FlowTransport, ReplyFuture};
+//! use moonpool::{send_request, NetTransport, ReplyFuture};
 //!
 //! // Send a request and get a future for the response
 //! let future: ReplyFuture<PingResponse, JsonCodec> = send_request(
@@ -26,8 +26,8 @@ use crate::{Endpoint, MessageCodec, NetworkProvider, TaskProvider, TimeProvider,
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 
-use super::flow_transport::FlowTransport;
 use super::net_notified_queue::NetNotifiedQueue;
+use super::net_transport::NetTransport;
 use super::reply_error::ReplyError;
 use super::reply_future::ReplyFuture;
 use super::request_stream::RequestEnvelope;
@@ -43,7 +43,7 @@ use crate::error::MessagingError;
 ///
 /// # Arguments
 ///
-/// * `transport` - The FlowTransport to use for sending
+/// * `transport` - The NetTransport to use for sending
 /// * `destination` - The server endpoint to send the request to
 /// * `request` - The request payload
 /// * `codec` - The codec for serialization
@@ -56,7 +56,7 @@ use crate::error::MessagingError;
 ///
 /// Returns `MessagingError` if the request cannot be sent.
 pub fn send_request<Req, Resp, N, T, TP, C>(
-    transport: &FlowTransport<N, T, TP>,
+    transport: &NetTransport<N, T, TP>,
     destination: &Endpoint,
     request: Req,
     codec: C,
@@ -198,8 +198,8 @@ mod tests {
     }
 
     fn create_test_transport()
-    -> FlowTransport<MockNetworkProvider, TokioTimeProvider, TokioTaskProvider> {
-        FlowTransport::new(
+    -> NetTransport<MockNetworkProvider, TokioTimeProvider, TokioTaskProvider> {
+        NetTransport::new(
             test_address(),
             MockNetworkProvider,
             TokioTimeProvider::new(),

--- a/moonpool-transport/src/rpc/request_stream.rs
+++ b/moonpool-transport/src/rpc/request_stream.rs
@@ -26,8 +26,8 @@ use crate::{Endpoint, MessageCodec, NetworkProvider, TaskProvider, TimeProvider}
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 
-use super::flow_transport::FlowTransport;
 use super::net_notified_queue::NetNotifiedQueue;
+use super::net_transport::NetTransport;
 use super::reply_promise::ReplyPromise;
 
 /// Envelope wrapping a request with its reply endpoint.
@@ -77,7 +77,7 @@ where
 
     /// Get a reference to the internal queue for registration.
     ///
-    /// This is used to register the stream with FlowTransport.
+    /// This is used to register the stream with NetTransport.
     pub fn queue(&self) -> Rc<NetNotifiedQueue<RequestEnvelope<Req>, C>> {
         self.queue.clone()
     }
@@ -87,7 +87,7 @@ where
     /// Returns `None` if the stream is closed.
     ///
     /// The `sender` function is used to send the reply back to the client.
-    /// Typically this is provided by the FlowTransport.
+    /// Typically this is provided by the NetTransport.
     pub async fn recv<F, Resp>(&self, sender: F) -> Option<(Req, ReplyPromise<Resp, C>)>
     where
         Resp: Serialize,
@@ -134,7 +134,7 @@ where
     /// ```
     pub async fn recv_with_transport<N, T, TP, Resp>(
         &self,
-        transport: &Rc<FlowTransport<N, T, TP>>,
+        transport: &Rc<NetTransport<N, T, TP>>,
     ) -> Option<(Req, ReplyPromise<Resp, C>)>
     where
         N: NetworkProvider + Clone + 'static,
@@ -154,7 +154,7 @@ where
     /// Non-blocking version of [`recv_with_transport`](Self::recv_with_transport).
     pub fn try_recv_with_transport<N, T, TP, Resp>(
         &self,
-        transport: &Rc<FlowTransport<N, T, TP>>,
+        transport: &Rc<NetTransport<N, T, TP>>,
     ) -> Option<(Req, ReplyPromise<Resp, C>)>
     where
         N: NetworkProvider + Clone + 'static,
@@ -334,7 +334,7 @@ mod tests {
     // Phase 12C API Tests: recv_with_transport / try_recv_with_transport
     // =========================================================================
 
-    use crate::{FlowTransportBuilder, TokioTaskProvider, TokioTimeProvider};
+    use crate::{NetTransportBuilder, TokioTaskProvider, TokioTimeProvider};
 
     // Simple mock network provider for testing
     #[derive(Clone)]
@@ -406,8 +406,8 @@ mod tests {
     }
 
     fn create_test_transport()
-    -> Rc<crate::FlowTransport<MockNetworkProvider, TokioTimeProvider, TokioTaskProvider>> {
-        FlowTransportBuilder::new(
+    -> Rc<crate::NetTransport<MockNetworkProvider, TokioTimeProvider, TokioTaskProvider>> {
+        NetTransportBuilder::new(
             MockNetworkProvider,
             TokioTimeProvider::new(),
             TokioTaskProvider,

--- a/moonpool-transport/tests/rpc_integration.rs
+++ b/moonpool-transport/tests/rpc_integration.rs
@@ -10,7 +10,7 @@ use std::net::{IpAddr, Ipv4Addr};
 use std::rc::Rc;
 
 use moonpool_transport::{
-    Endpoint, FlowTransport, JsonCodec, NetworkAddress, NetworkProvider, ReplyError, ReplyFuture,
+    Endpoint, JsonCodec, NetTransport, NetworkAddress, NetworkProvider, ReplyError, ReplyFuture,
     RequestEnvelope, RequestStream, TokioTaskProvider, TokioTimeProvider, UID, send_request,
 };
 use serde::{Deserialize, Serialize};
@@ -90,8 +90,8 @@ fn test_address() -> NetworkAddress {
     NetworkAddress::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 4500)
 }
 
-fn create_transport() -> FlowTransport<MockNetworkProvider, TokioTimeProvider, TokioTaskProvider> {
-    FlowTransport::new(
+fn create_transport() -> NetTransport<MockNetworkProvider, TokioTimeProvider, TokioTaskProvider> {
+    NetTransport::new(
         test_address(),
         MockNetworkProvider,
         TokioTimeProvider::new(),

--- a/moonpool-transport/tests/simulation/mod.rs
+++ b/moonpool-transport/tests/simulation/mod.rs
@@ -1,6 +1,6 @@
 //! Simulation test infrastructure for moonpool messaging layer.
 //!
-//! Provides shared utilities for testing EndpointMap, FlowTransport,
+//! Provides shared utilities for testing EndpointMap, NetTransport,
 //! and NetNotifiedQueue under chaos conditions.
 
 pub mod invariants;
@@ -11,7 +11,7 @@ pub mod workloads;
 
 use serde::{Deserialize, Serialize};
 
-/// Test message format for tracking delivery via FlowTransport.
+/// Test message format for tracking delivery via NetTransport.
 ///
 /// Uses JSON serialization since NetNotifiedQueue uses serde_json.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -53,7 +53,7 @@ impl TestMessage {
         }
     }
 
-    /// Serialize to JSON bytes for sending via FlowTransport.
+    /// Serialize to JSON bytes for sending via NetTransport.
     pub fn to_bytes(&self) -> Vec<u8> {
         serde_json::to_vec(self).expect("TestMessage serialization should not fail")
     }

--- a/moonpool-transport/tests/simulation/test_scenarios.rs
+++ b/moonpool-transport/tests/simulation/test_scenarios.rs
@@ -1,6 +1,6 @@
 //! Simulation tests for moonpool messaging layer.
 //!
-//! Tests EndpointMap, FlowTransport, and NetNotifiedQueue under chaos conditions
+//! Tests EndpointMap, NetTransport, and NetNotifiedQueue under chaos conditions
 //! using the FoundationDB-inspired simulation framework.
 
 use std::time::Duration;
@@ -493,12 +493,12 @@ use super::{
     CalcSubResponse, calculator,
 };
 use moonpool_sim::{RandomProvider, sometimes_assert};
-use moonpool_transport::{FlowTransportBuilder, JsonCodec, ReplyPromise, send_request};
+use moonpool_transport::{JsonCodec, NetTransportBuilder, ReplyPromise, send_request};
 
 /// Local multi-method interface workload for testing register_handler_at().
 ///
 /// This workload:
-/// 1. Creates a FlowTransport with multiple handlers using register_handler_at
+/// 1. Creates a NetTransport with multiple handlers using register_handler_at
 /// 2. Sends requests to different methods (add, sub, mul)
 /// 3. Validates correct routing by checking request_id matches in responses
 async fn multi_method_workload<N, T, TP>(
@@ -522,8 +522,8 @@ where
         4500,
     );
 
-    // Phase 12C: Use FlowTransportBuilder
-    let transport = FlowTransportBuilder::new(network, time.clone(), task)
+    // Phase 12C: Use NetTransportBuilder
+    let transport = NetTransportBuilder::new(network, time.clone(), task)
         .local_address(local_addr.clone())
         .build();
 
@@ -792,7 +792,7 @@ fn slow_simulation_multi_method() {
 
 /// Verify build_listening() works correctly with SimNetworkProvider.
 ///
-/// This test explicitly validates that FlowTransportBuilder integrates properly
+/// This test explicitly validates that NetTransportBuilder integrates properly
 /// with the simulation infrastructure.
 async fn build_listening_sim_workload<N, T, TP>(
     _random: moonpool_sim::SimRandomProvider,
@@ -807,7 +807,7 @@ where
     T: moonpool_transport::TimeProvider + Clone + 'static,
     TP: moonpool_transport::TaskProvider + Clone + 'static,
 {
-    use moonpool_transport::FlowTransportBuilder;
+    use moonpool_transport::NetTransportBuilder;
 
     // Create local address from topology
     let port = 4500u16;
@@ -815,7 +815,7 @@ where
     let local_addr = moonpool_transport::NetworkAddress::new(ip, port);
 
     // Test: build_listening() should succeed with SimNetworkProvider
-    let transport = FlowTransportBuilder::new(network, time, task)
+    let transport = NetTransportBuilder::new(network, time, task)
         .local_address(local_addr.clone())
         .build_listening()
         .await

--- a/moonpool/README.md
+++ b/moonpool/README.md
@@ -16,7 +16,7 @@ Inspired by [FoundationDB's simulation testing](https://apple.github.io/foundati
 │  moonpool-transport    │    moonpool-sim        │
 │  • Peer connections    │    • SimWorld runtime  │
 │  • Wire format         │    • Chaos testing     │
-│  • FlowTransport       │    • Buggify macros    │
+│  • NetTransport        │    • Buggify macros    │
 │  • RPC primitives      │    • Assertions        │
 ├─────────────────────────────────────────────────┤
 │              moonpool-core                      │

--- a/moonpool/src/lib.rs
+++ b/moonpool/src/lib.rs
@@ -18,7 +18,7 @@
 //! │  moonpool-transport    │    moonpool-sim        │
 //! │  • Peer connections    │    • SimWorld runtime  │
 //! │  • Wire format         │    • Chaos testing     │
-//! │  • FlowTransport       │    • Buggify macros    │
+//! │  • NetTransport        │    • Buggify macros    │
 //! │  • RPC primitives      │    • Assertions        │
 //! ├─────────────────────────────────────────────────┤
 //! │              moonpool-core                      │


### PR DESCRIPTION
Rename the central transport coordinator from FlowTransport to NetTransport for clearer naming. The structure still follows FoundationDB's FlowTransport patterns but the name is now distinct.

Changes:
- Rename flow_transport.rs to net_transport.rs
- Rename FlowTransport struct to NetTransport
- Rename FlowTransportBuilder to NetTransportBuilder
- Update all imports, exports, and documentation references