### PR TITLE
fix(docs): use correct docs.rs metadata keys for tokio_unstable

### DIFF
--- a/moonpool-core/Cargo.toml
+++ b/moonpool-core/Cargo.toml
@@ -10,7 +10,8 @@ documentation = "https://docs.rs/moonpool-core"
 readme = "README.md"
 
 [package.metadata.docs.rs]
-rustflags = ["--cfg", "tokio_unstable"]
+rustdoc-args = ["--cfg", "tokio_unstable"]
+rustc-args = ["--cfg", "tokio_unstable"]
 
 [dependencies]
 async-trait = "0.1"

--- a/moonpool-sim/Cargo.toml
+++ b/moonpool-sim/Cargo.toml
@@ -10,7 +10,8 @@ documentation = "https://docs.rs/moonpool-sim"
 readme = "README.md"
 
 [package.metadata.docs.rs]
-rustflags = ["--cfg", "tokio_unstable"]
+rustdoc-args = ["--cfg", "tokio_unstable"]
+rustc-args = ["--cfg", "tokio_unstable"]
 
 [dependencies]
 moonpool-core = { path = "../moonpool-core", version = "0.2.1" }

--- a/moonpool-transport/Cargo.toml
+++ b/moonpool-transport/Cargo.toml
@@ -10,7 +10,8 @@ documentation = "https://docs.rs/moonpool-transport"
 readme = "README.md"
 
 [package.metadata.docs.rs]
-rustflags = ["--cfg", "tokio_unstable"]
+rustdoc-args = ["--cfg", "tokio_unstable"]
+rustc-args = ["--cfg", "tokio_unstable"]
 
 [dependencies]
 moonpool-core = { path = "../moonpool-core", version = "0.2.1" }

--- a/moonpool/Cargo.toml
+++ b/moonpool/Cargo.toml
@@ -10,7 +10,8 @@ edition.workspace = true
 readme = "README.md"
 
 [package.metadata.docs.rs]
-rustflags = ["--cfg", "tokio_unstable"]
+rustdoc-args = ["--cfg", "tokio_unstable"]
+rustc-args = ["--cfg", "tokio_unstable"]
 
 [dependencies]
 moonpool-core = { path = "../moonpool-core", version = "0.2.1" }


### PR DESCRIPTION
Replace invalid `rustflags` with `rustc-args` and `rustdoc-args` to fix docs.rs build failure. The tokio::task::Builder API requires the tokio_unstable cfg flag, which was not being passed correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)