### PR TITLE
chore: remove false FDB-compatible protocol claims

### DIFF
--- a/moonpool-core/README.md
+++ b/moonpool-core/README.md
@@ -27,7 +27,7 @@ Instead of `tokio::time::sleep()`, use `time_provider.sleep()`. This ensures you
 
 ## Core Types
 
-FDB-compatible types for endpoint addressing:
+Types for endpoint addressing:
 
 - `UID`: 128-bit unique identifier (deterministically generated in simulation)
 - `Endpoint`: Network address + token for direct addressing

--- a/moonpool-core/src/lib.rs
+++ b/moonpool-core/src/lib.rs
@@ -45,7 +45,7 @@
 //!
 //! ## Core Types
 //!
-//! FDB-compatible types for endpoint addressing:
+//! Types for endpoint addressing:
 //!
 //! - [`UID`]: 128-bit unique identifier (deterministically generated in simulation)
 //! - [`Endpoint`]: Network address + token for direct addressing

--- a/moonpool-core/src/types.rs
+++ b/moonpool-core/src/types.rs
@@ -1,7 +1,7 @@
-//! Core types for FDB-compatible endpoint addressing.
+//! Core types for endpoint addressing.
 //!
 //! This module provides the fundamental types for network addressing in moonpool:
-//! - [`UID`]: 128-bit unique identifier for endpoints (FDB-compatible)
+//! - [`UID`]: 128-bit unique identifier for endpoints
 //! - [`NetworkAddress`]: IP address + port + flags
 //! - [`Endpoint`]: Complete destination = address + token
 
@@ -11,10 +11,10 @@ use serde::{Deserialize, Serialize};
 
 use crate::well_known::WellKnownToken;
 
-/// 128-bit unique identifier (FDB-compatible).
+/// 128-bit unique identifier.
 ///
-/// FDB pattern: well-known UIDs use `first = u64::MAX` (equivalent to -1 in C++).
-/// Random UIDs have both parts randomly generated.
+/// Well-known UIDs use `first = u64::MAX`. Random UIDs have both parts
+/// randomly generated.
 ///
 /// # Examples
 ///
@@ -94,7 +94,7 @@ impl std::fmt::Display for UID {
     }
 }
 
-/// Address flags (FDB-compatible).
+/// Address flags.
 pub mod flags {
     /// Connection uses TLS encryption.
     pub const FLAG_TLS: u16 = 1;
@@ -207,7 +207,7 @@ pub enum NetworkAddressParseError {
     MissingPort,
 }
 
-/// Endpoint = Address + Token (FDB-compatible).
+/// Endpoint = Address + Token.
 ///
 /// Represents a unique destination for messages. The combination of
 /// network address and UID token allows direct addressing without

--- a/moonpool-core/src/well_known.rs
+++ b/moonpool-core/src/well_known.rs
@@ -6,7 +6,7 @@
 
 use crate::types::UID;
 
-/// Well-known endpoint tokens (FDB-compatible pattern).
+/// Well-known endpoint tokens.
 ///
 /// These tokens are used for system services that need deterministic addressing
 /// without service discovery. Clients can construct endpoints directly using

--- a/moonpool-transport/src/lib.rs
+++ b/moonpool-transport/src/lib.rs
@@ -70,7 +70,7 @@ pub mod error;
 /// Resilient peer connection management.
 pub mod peer;
 
-/// FDB-compatible wire format with CRC32C checksums.
+/// Wire format with CRC32C checksums.
 pub mod wire;
 
 /// RPC layer with typed request/response patterns.

--- a/moonpool-transport/src/peer/core.rs
+++ b/moonpool-transport/src/peer/core.rs
@@ -1,6 +1,6 @@
 //! Core peer implementation with automatic reconnection and message queuing.
 //!
-//! Provides FDB-compatible wire format with UID-based endpoint addressing.
+//! Provides wire format with UID-based endpoint addressing.
 
 use std::cell::RefCell;
 use std::collections::VecDeque;
@@ -62,7 +62,7 @@ impl ReconnectState {
 /// Provides automatic reconnection and message queuing while abstracting
 /// over provider implementations via the [`Providers`] trait bundle.
 ///
-/// Uses FDB-compatible wire format: `[length:4][checksum:4][token:16][payload]`
+/// Uses wire format: `[length:4][checksum:4][token:16][payload]`
 ///
 /// Follows FoundationDB's architecture: synchronous API with background actors.
 pub struct Peer<P: Providers> {

--- a/moonpool-transport/src/rpc/endpoint_map.rs
+++ b/moonpool-transport/src/rpc/endpoint_map.rs
@@ -34,7 +34,7 @@ pub trait MessageReceiver {
     }
 }
 
-/// Maps endpoint tokens to message receivers (FDB-compatible pattern).
+/// Maps endpoint tokens to message receivers.
 ///
 /// # Design
 ///

--- a/moonpool-transport/src/wire/mod.rs
+++ b/moonpool-transport/src/wire/mod.rs
@@ -1,4 +1,4 @@
-//! Wire format for FDB-compatible packet serialization.
+//! Wire format for packet serialization.
 //!
 //! Packet format: `[length:4][checksum:4][token:16][payload:N]`
 //!
@@ -6,8 +6,6 @@
 //! - **checksum**: CRC32C of (token + payload) for integrity verification
 //! - **token**: Destination endpoint UID (two little-endian u64)
 //! - **payload**: Application data (custom serialization)
-//!
-//! This matches FDB's wire format for compatibility.
 
 use crate::UID;
 
@@ -112,7 +110,7 @@ impl PacketHeader {
     }
 }
 
-/// Compute CRC32C checksum over token + payload (FDB-compatible).
+/// Compute CRC32C checksum over token + payload.
 fn compute_checksum(token: UID, payload: &[u8]) -> u32 {
     let mut data = Vec::with_capacity(16 + payload.len());
     data.extend_from_slice(&token.first.to_le_bytes());


### PR DESCRIPTION
The wire format is inspired by FoundationDB but not actually compatible
with FDB's protocol. Removes misleading "FDB-compatible" claims from
documentation and comments throughout the codebase.