### PR TITLE
feat(sim): add FDB-aligned chaos features and comprehensive documenta…

### DIFF
--- a/moonpool-sim/src/network/mod.rs
+++ b/moonpool-sim/src/network/mod.rs
@@ -10,7 +10,10 @@ pub mod config;
 pub mod sim;
 
 // Re-export configuration
-pub use config::{ChaosConfiguration, ConnectFailureMode, NetworkConfiguration, sample_duration};
+pub use config::{
+    ChaosConfiguration, ConnectFailureMode, LatencyDistribution, NetworkConfiguration,
+    PartitionStrategy, sample_duration, sample_duration_bimodal, sample_handshake_delay,
+};
 
 // Re-export simulation network provider
 pub use sim::SimNetworkProvider;

--- a/moonpool-sim/src/sim/state.rs
+++ b/moonpool-sim/src/sim/state.rs
@@ -139,6 +139,21 @@ pub struct ConnectionState {
     /// Before this time: writes succeed (data dropped), reads block.
     /// After this time: both read and write return ECONNRESET.
     pub half_open_error_at: Option<Duration>,
+
+    /// Whether this connection is stable (exempt from chaos).
+    ///
+    /// FDB ref: sim2.actor.cpp:357-362, 427, 440, 581-582 (stableConnection flag)
+    ///
+    /// Stable connections are exempt from:
+    /// - Random close (`roll_random_close`)
+    /// - Write clogging
+    /// - Read clogging
+    /// - Bit flip corruption
+    /// - Partial write truncation
+    ///
+    /// This is used for parent-child process connections or supervision channels
+    /// that should remain reliable even during chaos testing.
+    pub is_stable: bool,
 }
 
 /// Internal listener state for simulation


### PR DESCRIPTION
…tion

Add missing network simulation features from FoundationDB:
- Bimodal latency distribution (99.9% fast / 0.1% slow tail)
- Handshake delays for connection establishment
- Stable connections exempt from chaos (parent-child, supervision)
- Partition strategies (Random, UniformSize, IsolateSingle)

Remove packet_loss_probability - FDB only uses this for UDP simulation (sim2.actor.cpp:2726), not TCP. Per CLAUDE.md, Moonpool focuses on TCP-level simulation.

Add comprehensive rustdoc to config.rs with tables documenting all failure modes, their configuration, defaults, and real-world scenarios.