### PR TITLE
refactor(core): replace SimulationResult with TimeError in TimeProvider

### DIFF
--- a/moonpool-core/src/lib.rs
+++ b/moonpool-core/src/lib.rs
@@ -80,7 +80,7 @@ pub use storage::{
     OpenOptions, StorageFile, StorageProvider, TokioStorageFile, TokioStorageProvider,
 };
 pub use task::{TaskProvider, TokioTaskProvider};
-pub use time::{TimeProvider, TokioTimeProvider};
+pub use time::{TimeError, TimeProvider, TokioTimeProvider};
 
 // Core type exports
 pub use types::{Endpoint, NetworkAddress, NetworkAddressParseError, UID, flags};

--- a/moonpool-sim/src/lib.rs
+++ b/moonpool-sim/src/lib.rs
@@ -74,8 +74,8 @@
 pub use moonpool_core::{
     CodecError, Endpoint, JsonCodec, MessageCodec, NetworkAddress, NetworkAddressParseError,
     NetworkProvider, Providers, RandomProvider, SimulationError, SimulationResult, TaskProvider,
-    TcpListenerTrait, TimeProvider, TokioNetworkProvider, TokioProviders, TokioTaskProvider,
-    TokioTimeProvider, UID, WELL_KNOWN_RESERVED_COUNT, WellKnownToken,
+    TcpListenerTrait, TimeError, TimeProvider, TokioNetworkProvider, TokioProviders,
+    TokioTaskProvider, TokioTimeProvider, UID, WELL_KNOWN_RESERVED_COUNT, WellKnownToken,
 };
 
 // =============================================================================

--- a/moonpool-transport/examples/calculator.rs
+++ b/moonpool-transport/examples/calculator.rs
@@ -219,7 +219,7 @@ async fn run_client() -> Result<(), Box<dyn std::error::Error>> {
         println!("Sending: {}", desc);
 
         // NEW: Clean trait method calls with .await?
-        // Note: timeout returns SimulationResult<Result<T, ()>> so we have 3 levels
+        // Note: timeout returns Result<T, TimeError>, inner T is Result<Response, RpcError>
         let result = match op {
             Op::Add(a, b) => {
                 match time
@@ -229,7 +229,7 @@ async fn run_client() -> Result<(), Box<dyn std::error::Error>> {
                     )
                     .await
                 {
-                    Ok(Ok(Ok(resp))) => Some(format!("{}", resp.result)),
+                    Ok(Ok(resp)) => Some(format!("{}", resp.result)),
                     _ => None,
                 }
             }
@@ -241,7 +241,7 @@ async fn run_client() -> Result<(), Box<dyn std::error::Error>> {
                     )
                     .await
                 {
-                    Ok(Ok(Ok(resp))) => Some(format!("{}", resp.result)),
+                    Ok(Ok(resp)) => Some(format!("{}", resp.result)),
                     _ => None,
                 }
             }
@@ -253,7 +253,7 @@ async fn run_client() -> Result<(), Box<dyn std::error::Error>> {
                     )
                     .await
                 {
-                    Ok(Ok(Ok(resp))) => Some(format!("{}", resp.result)),
+                    Ok(Ok(resp)) => Some(format!("{}", resp.result)),
                     _ => None,
                 }
             }
@@ -265,7 +265,7 @@ async fn run_client() -> Result<(), Box<dyn std::error::Error>> {
                     )
                     .await
                 {
-                    Ok(Ok(Ok(resp))) => Some(
+                    Ok(Ok(resp)) => Some(
                         resp.result
                             .map(|r| r.to_string())
                             .unwrap_or_else(|| "ERROR (division by zero)".to_string()),

--- a/moonpool-transport/examples/ping_pong.rs
+++ b/moonpool-transport/examples/ping_pong.rs
@@ -194,24 +194,21 @@ async fn run_client() -> Result<(), Box<dyn std::error::Error>> {
         // ====================================================================
         // NEW: Clean trait method call with .await
         // No more manual send_request or type annotations!
-        // Note: timeout returns SimulationResult<Result<T, ()>> so we have 3 levels
+        // Note: timeout returns Result<T, TimeError>, inner T is Result<Response, RpcError>
         // ====================================================================
         match time
             .timeout(Duration::from_secs(5), ping_client.ping(request))
             .await
         {
-            Ok(Ok(Ok(response))) => {
+            Ok(Ok(response)) => {
                 println!("Received pong seq={}: {:?}\n", response.seq, response.echo);
                 success_count += 1;
             }
-            Ok(Ok(Err(e))) => {
+            Ok(Err(e)) => {
                 println!("RPC error: {:?}\n", e);
             }
-            Ok(Err(())) => {
-                println!("Timeout waiting for response\n");
-            }
             Err(e) => {
-                println!("Simulation error: {:?}\n", e);
+                println!("Timeout or shutdown: {:?}\n", e);
             }
         }
 

--- a/moonpool-transport/src/lib.rs
+++ b/moonpool-transport/src/lib.rs
@@ -56,7 +56,7 @@
 pub use moonpool_core::{
     CodecError, Endpoint, JsonCodec, MessageCodec, NetworkAddress, NetworkAddressParseError,
     NetworkProvider, OpenOptions, Providers, RandomProvider, SimulationError, SimulationResult,
-    StorageFile, StorageProvider, TaskProvider, TcpListenerTrait, TimeProvider,
+    StorageFile, StorageProvider, TaskProvider, TcpListenerTrait, TimeError, TimeProvider,
     TokioNetworkProvider, TokioProviders, TokioRandomProvider, TokioStorageFile,
     TokioStorageProvider, TokioTaskProvider, TokioTimeProvider, UID, WELL_KNOWN_RESERVED_COUNT,
     WellKnownToken,

--- a/moonpool-transport/src/peer/core.rs
+++ b/moonpool-transport/src/peer/core.rs
@@ -891,7 +891,7 @@ async fn establish_connection<P: Providers>(
             .timeout(config.connection_timeout, network.connect(&destination))
             .await
         {
-            Ok(Ok(Ok(stream))) => {
+            Ok(Ok(stream)) => {
                 // Success - check if this was a recovery after failures
                 {
                     let mut state = shared_state.borrow_mut();
@@ -912,7 +912,7 @@ async fn establish_connection<P: Providers>(
                 }
                 return Ok(stream);
             }
-            Ok(Ok(Err(_))) | Ok(Err(())) | Err(_) => {
+            Ok(Err(_)) | Err(_) => {
                 // Connection failed - update state and retry
                 {
                     let mut state = shared_state.borrow_mut();

--- a/moonpool-transport/tests/e2e/operations.rs
+++ b/moonpool-transport/tests/e2e/operations.rs
@@ -271,20 +271,20 @@ where
                 .timeout(std::time::Duration::from_millis(100), peer.receive())
                 .await
             {
-                Ok(Ok(Ok((_token, payload)))) => match TestMessage::from_bytes(&payload) {
+                Ok(Ok((_token, payload))) => match TestMessage::from_bytes(&payload) {
                     Ok(message) => OpResult::Received { message },
                     Err(e) => OpResult::Failed {
                         error: format!("deserialization failed: {:?}", e),
                     },
                 },
-                Ok(Ok(Err(PeerError::Disconnected))) => OpResult::Failed {
+                Ok(Err(PeerError::Disconnected)) => OpResult::Failed {
                     error: "peer disconnected".to_string(),
                 },
-                Ok(Ok(Err(e))) => OpResult::Failed {
+                Ok(Err(e)) => OpResult::Failed {
                     error: format!("receive error: {:?}", e),
                 },
-                Ok(Err(())) | Err(_) => {
-                    // Timeout - no message available
+                Err(_) => {
+                    // Timeout or shutdown - no message available
                     OpResult::NoMessage
                 }
             }

--- a/moonpool-transport/tests/e2e/workloads.rs
+++ b/moonpool-transport/tests/e2e/workloads.rs
@@ -337,7 +337,7 @@ pub async fn server_workload_with_config(
             .await;
 
         match accept_result {
-            Ok(Ok(Ok((mut stream, peer_addr)))) => {
+            Ok(Ok((mut stream, peer_addr))) => {
                 tracing::debug!("Server {} accepted connection from {}", my_addr, peer_addr);
 
                 // Read messages from this connection
@@ -350,7 +350,7 @@ pub async fn server_workload_with_config(
                         .await;
 
                     match read_result {
-                        Ok(Ok(Ok(0))) => {
+                        Ok(Ok(0)) => {
                             // Connection closed
                             sometimes_assert!(
                                 server_connection_closed,
@@ -359,7 +359,7 @@ pub async fn server_workload_with_config(
                             );
                             break;
                         }
-                        Ok(Ok(Ok(n))) => {
+                        Ok(Ok(n)) => {
                             read_buffer.extend_from_slice(&buffer[..n]);
 
                             // Try to parse messages from buffer
@@ -400,10 +400,10 @@ pub async fn server_workload_with_config(
                     }
                 }
             }
-            Ok(Ok(Err(e))) => {
+            Ok(Err(e)) => {
                 tracing::trace!("Server {} accept error: {:?}", my_addr, e);
             }
-            Ok(Err(_)) | Err(_) => {
+            Err(_) => {
                 // Accept timeout - continue loop
             }
         }
@@ -462,7 +462,7 @@ pub async fn echo_server_workload(
             .timeout(Duration::from_millis(100), listener.accept())
             .await;
 
-        if let Ok(Ok(Ok((mut stream, peer_addr)))) = accept_result {
+        if let Ok(Ok((mut stream, peer_addr))) = accept_result {
             tracing::debug!("Echo server accepted connection from {}", peer_addr);
 
             // Echo data back
@@ -473,8 +473,8 @@ pub async fn echo_server_workload(
                     .await;
 
                 match read_result {
-                    Ok(Ok(Ok(0))) => break, // Connection closed
-                    Ok(Ok(Ok(n))) => {
+                    Ok(Ok(0)) => break, // Connection closed
+                    Ok(Ok(n)) => {
                         total_bytes += n as u64;
                         // Echo back
                         if stream.write_all(&buffer[..n]).await.is_err() {
@@ -578,7 +578,7 @@ pub async fn wire_server_workload_with_config(
             .await;
 
         match accept_result {
-            Ok(Ok(Ok((mut stream, peer_addr)))) => {
+            Ok(Ok((mut stream, peer_addr))) => {
                 tracing::debug!(
                     "Wire server {} accepted connection from {}",
                     my_addr,
@@ -596,7 +596,7 @@ pub async fn wire_server_workload_with_config(
                         .await;
 
                     match read_result {
-                        Ok(Ok(Ok(0))) => {
+                        Ok(Ok(0)) => {
                             // Connection closed
                             sometimes_assert!(
                                 wire_server_connection_closed,
@@ -605,7 +605,7 @@ pub async fn wire_server_workload_with_config(
                             );
                             break;
                         }
-                        Ok(Ok(Ok(n))) => {
+                        Ok(Ok(n)) => {
                             wire_buffer.extend_from_slice(&read_buffer[..n]);
 
                             // Try to parse complete packets from the buffer
@@ -681,7 +681,7 @@ pub async fn wire_server_workload_with_config(
                                 }
                             }
                         }
-                        Ok(Ok(Err(e))) => {
+                        Ok(Err(e)) => {
                             tracing::trace!("Wire server {} read error: {:?}", my_addr, e);
                             break;
                         }
@@ -692,10 +692,10 @@ pub async fn wire_server_workload_with_config(
                     }
                 }
             }
-            Ok(Ok(Err(e))) => {
+            Ok(Err(e)) => {
                 tracing::trace!("Wire server {} accept error: {:?}", my_addr, e);
             }
-            Ok(Err(_)) | Err(_) => {
+            Err(_) => {
                 // Accept timeout - continue loop
             }
         }


### PR DESCRIPTION
TimeProvider::timeout previously returned SimulationResult<Result<T, ()>>, leaking simulation semantics into a trait meant to be runtime-agnostic. This caused triple-nested Results (Ok(Ok(Ok(x)))) when combining timeout with RPC calls. Introduce a proper TimeError enum with Elapsed and Shutdown variants, flattening timeout to Result<T, TimeError>.