### PR TITLE
Rename fork-based concepts to timeline/split terminology

### DIFF
--- a/moonpool-explorer/README.md
+++ b/moonpool-explorer/README.md
@@ -41,7 +41,7 @@ This crate has zero knowledge of moonpool internals. Communication with the simu
 ## Key Concepts
 
 - **Coverage bitmap** — 8192-bit vector tracking which code paths have been exercised
-- **Virgin map** — Tracks frontier of new coverage across all timelines
+- **Explored map** — Tracks frontier of new coverage across all timelines
 - **Assertion slots** — 128 shared-memory slots for Antithesis-style assertion tracking (boolean, numeric, compound)
 - **Energy budgets** — Three-level system (global, per-mark, realloc pool) prevents runaway forking
 - **Adaptive forking** — Batch-based: fork N children, check coverage yield, return energy from barren marks
@@ -52,7 +52,7 @@ This crate has zero knowledge of moonpool internals. Communication with the simu
 ```rust
 ExplorationConfig {
     max_depth: 30,           // Maximum fork depth
-    children_per_fork: 4,    // Children per discovery (fixed-count mode)
+    timelines_per_split: 4,    // Timelines per split point (fixed-count mode)
     global_energy: 50_000,   // Total fork budget
     adaptive: Some(AdaptiveConfig {
         batch_size: 20,       // Children per adaptive batch

--- a/moonpool-explorer/src/coverage.rs
+++ b/moonpool-explorer/src/coverage.rs
@@ -1,17 +1,17 @@
 //! Coverage tracking for exploration novelty detection.
 //!
-//! Tracks which assertion-triggered code paths have been explored across
-//! forked processes. The [`VirginMap`] lives in shared memory and accumulates
-//! coverage from all children. Each child gets a fresh [`CoverageBitmap`]
-//! that is merged into the virgin map after the child exits.
+//! Tracks which assertion paths have been explored across all timelines.
+//! The [`ExploredMap`] lives in shared memory and accumulates coverage
+//! from every timeline. Each timeline gets a fresh [`CoverageBitmap`]
+//! that is merged into the explored map after the timeline finishes.
 
 /// Size of coverage bitmaps in bytes (8192 bit positions).
 pub const COVERAGE_MAP_SIZE: usize = 1024;
 
-/// Per-child coverage bitmap, cleared before each fork.
+/// Per-timeline coverage bitmap, cleared before each split.
 ///
-/// Tracks which assertion slots were hit during this child's execution.
-/// After the child exits, the parent merges this into the [`VirginMap`].
+/// Tracks which assertion paths were hit during this timeline's execution.
+/// After the timeline finishes, the parent merges this into the [`ExploredMap`].
 pub struct CoverageBitmap {
     ptr: *mut u8,
 }
@@ -52,16 +52,16 @@ impl CoverageBitmap {
     }
 }
 
-/// Cross-process coverage map, OR'd by all children.
+/// Cross-process coverage map, OR'd by all timelines.
 ///
-/// Lives in `MAP_SHARED` memory so all forked processes contribute.
+/// Lives in `MAP_SHARED` memory so all forked timelines contribute.
 /// A bit set to 1 means "this assertion path has been explored."
-pub struct VirginMap {
+pub struct ExploredMap {
     ptr: *mut u8,
 }
 
-impl VirginMap {
-    /// Wrap a shared-memory pointer as a virgin map.
+impl ExploredMap {
+    /// Wrap a shared-memory pointer as a explored map.
     ///
     /// # Safety
     ///
@@ -71,7 +71,7 @@ impl VirginMap {
         Self { ptr }
     }
 
-    /// Merge a child's coverage bitmap into this virgin map (bitwise OR).
+    /// Merge a timeline's coverage bitmap into this explored map (bitwise OR).
     pub fn merge_from(&self, other: &CoverageBitmap) {
         // Safety: both pointers are valid for COVERAGE_MAP_SIZE bytes
         unsafe {
@@ -81,15 +81,15 @@ impl VirginMap {
         }
     }
 
-    /// Check if a child's bitmap contains any bits not yet in the virgin map.
+    /// Check if a timeline's bitmap contains any bits not yet in the explored map.
     pub fn has_new_bits(&self, other: &CoverageBitmap) -> bool {
         // Safety: both pointers are valid for COVERAGE_MAP_SIZE bytes
         unsafe {
             for i in 0..COVERAGE_MAP_SIZE {
-                let virgin = *self.ptr.add(i);
+                let explored = *self.ptr.add(i);
                 let child = *other.as_ptr().add(i);
-                // Child has bits that virgin doesn't
-                if (child & !virgin) != 0 {
+                // Child has bits that explored map doesn't
+                if (child & !explored) != 0 {
                     return true;
                 }
             }
@@ -106,9 +106,9 @@ mod tests {
     #[test]
     fn test_set_bit_and_check() {
         let ptr = shared_mem::alloc_shared(COVERAGE_MAP_SIZE).expect("alloc failed");
-        let virgin_ptr = shared_mem::alloc_shared(COVERAGE_MAP_SIZE).expect("alloc failed");
+        let explored_ptr = shared_mem::alloc_shared(COVERAGE_MAP_SIZE).expect("alloc failed");
         let bm = unsafe { CoverageBitmap::new(ptr) };
-        let vm = unsafe { VirginMap::new(virgin_ptr) };
+        let vm = unsafe { ExploredMap::new(explored_ptr) };
 
         // Initially no new bits
         assert!(!vm.has_new_bits(&bm));
@@ -117,14 +117,14 @@ mod tests {
         bm.set_bit(42);
         assert!(vm.has_new_bits(&bm));
 
-        // Merge into virgin
+        // Merge into explored map
         vm.merge_from(&bm);
         // Now no new bits (already merged)
         assert!(!vm.has_new_bits(&bm));
 
         unsafe {
             shared_mem::free_shared(ptr, COVERAGE_MAP_SIZE);
-            shared_mem::free_shared(virgin_ptr, COVERAGE_MAP_SIZE);
+            shared_mem::free_shared(explored_ptr, COVERAGE_MAP_SIZE);
         }
     }
 
@@ -156,7 +156,7 @@ mod tests {
 
         let bm1 = unsafe { CoverageBitmap::new(bm1_ptr) };
         let bm2 = unsafe { CoverageBitmap::new(bm2_ptr) };
-        let vm = unsafe { VirginMap::new(vm_ptr) };
+        let vm = unsafe { ExploredMap::new(vm_ptr) };
 
         bm1.set_bit(10);
         bm2.set_bit(20);

--- a/moonpool-explorer/src/split_loop.rs
+++ b/moonpool-explorer/src/split_loop.rs
@@ -1,18 +1,18 @@
-//! Fork-based exploration loop.
+//! Timeline splitting loop.
 //!
-//! When a new assertion success is discovered, [`branch_on_discovery`] forks
+//! When a new assertion success is discovered, [`split_on_discovery`] forks
 //! child processes with different seeds to explore alternate timelines from
-//! that point forward.
+//! that splitpoint forward.
 //!
 //! # Process Model
 //!
 //! ```text
-//! Parent (seed S0, depth D)
-//!   |-- fork child 0 (seed S0', depth D+1) -> waitpid -> merge coverage
-//!   |-- fork child 1 (seed S1', depth D+1) -> waitpid -> merge coverage
+//! Parent timeline (seed S0, depth D)
+//!   |-- Timeline 0 (seed S0', depth D+1) -> waitpid -> merge coverage
+//!   |-- Timeline 1 (seed S1', depth D+1) -> waitpid -> merge coverage
 //!   |-- ...
-//!   `-- fork child N (seed SN', depth D+1) -> waitpid -> merge coverage
-//!   resume parent execution
+//!   `-- Timeline N (seed SN', depth D+1) -> waitpid -> merge coverage
+//!   resume parent timeline
 //! ```
 //!
 //! Each child returns from this function and continues the simulation with
@@ -21,9 +21,9 @@
 use std::sync::atomic::Ordering;
 
 use crate::context::{
-    self, COVERAGE_BITMAP_PTR, ENERGY_BUDGET_PTR, SHARED_RECIPE, SHARED_STATS, VIRGIN_MAP_PTR,
+    self, COVERAGE_BITMAP_PTR, ENERGY_BUDGET_PTR, EXPLORED_MAP_PTR, SHARED_RECIPE, SHARED_STATS,
 };
-use crate::coverage::{COVERAGE_MAP_SIZE, CoverageBitmap, VirginMap};
+use crate::coverage::{COVERAGE_MAP_SIZE, CoverageBitmap, ExploredMap};
 use crate::shared_stats::MAX_RECIPE_ENTRIES;
 
 /// Compute a child seed by mixing the parent seed, assertion name, and child index.
@@ -42,12 +42,12 @@ fn compute_child_seed(parent_seed: u64, mark_name: &str, child_idx: u32) -> u64 
     hash
 }
 
-/// Configuration for adaptive batch-based forking.
+/// Configuration for adaptive batch-based timeline splitting.
 ///
-/// Instead of forking a fixed number of children, the adaptive loop forks
-/// in batches and checks coverage yield between batches. Productive marks
-/// (that find new coverage) get more forks; barren marks stop early and
-/// return their energy to the reallocation pool.
+/// Instead of spawning a fixed number of timelines, the adaptive loop
+/// spawns in batches and checks coverage yield between batches. Productive
+/// marks (that find new coverage) get more timelines; barren marks stop
+/// early and return their energy to the reallocation pool.
 #[derive(Debug, Clone)]
 pub struct AdaptiveConfig {
     /// Number of children to fork per batch before checking coverage yield.
@@ -60,27 +60,27 @@ pub struct AdaptiveConfig {
     pub per_mark_energy: i64,
 }
 
-/// Dispatch to either adaptive or fixed-count forking based on config.
+/// Dispatch to either adaptive or fixed-count splitting based on config.
 ///
 /// If an energy budget is configured (adaptive mode), uses coverage-yield-driven
-/// batching. Otherwise falls back to the fixed `children_per_fork` behavior.
+/// batching. Otherwise falls back to the fixed `timelines_per_split` behavior.
 #[cfg(unix)]
-pub(crate) fn dispatch_branch(mark_name: &str, slot_idx: usize) {
+pub(crate) fn dispatch_split(mark_name: &str, slot_idx: usize) {
     let has_adaptive = ENERGY_BUDGET_PTR.with(|c| !c.get().is_null());
     if has_adaptive {
-        adaptive_branch_on_discovery(mark_name, slot_idx);
+        adaptive_split_on_discovery(mark_name, slot_idx);
     } else {
-        branch_on_discovery(mark_name);
+        split_on_discovery(mark_name);
     }
 }
 
 /// No-op on non-unix platforms.
 #[cfg(not(unix))]
-pub(crate) fn dispatch_branch(_mark_name: &str, _slot_idx: usize) {}
+pub(crate) fn dispatch_split(_mark_name: &str, _slot_idx: usize) {}
 
-/// Adaptive branch: fork in batches, check coverage yield, stop when barren.
+/// Adaptive split: spawn timelines in batches, check coverage yield, stop when barren.
 #[cfg(unix)]
-fn adaptive_branch_on_discovery(mark_name: &str, slot_idx: usize) {
+fn adaptive_split_on_discovery(mark_name: &str, slot_idx: usize) {
     // Read context for guard checks
     let (active, depth, max_depth, current_seed) =
         context::with_ctx(|ctx| (ctx.active, ctx.depth, ctx.max_depth, ctx.current_seed));
@@ -101,11 +101,11 @@ fn adaptive_branch_on_discovery(mark_name: &str, slot_idx: usize) {
     }
 
     // Record the current RNG call count for the recipe
-    let fork_call_count = context::rng_get_count();
+    let split_call_count = context::rng_get_count();
 
     // Get shared memory pointers
     let bm_ptr = COVERAGE_BITMAP_PTR.with(|c| c.get());
-    let vm_ptr = VIRGIN_MAP_PTR.with(|c| c.get());
+    let vm_ptr = EXPLORED_MAP_PTR.with(|c| c.get());
     let stats_ptr = SHARED_STATS.with(|c| c.get());
 
     // Read adaptive config from context
@@ -128,14 +128,14 @@ fn adaptive_branch_on_discovery(mark_name: &str, slot_idx: usize) {
         }
     }
 
-    let mut total_forked: u32 = 0;
+    let mut timelines_spawned: u32 = 0;
 
     // Batch loop
     loop {
         let mut batch_has_new = false;
 
         for _ in 0..batch_size {
-            if total_forked >= max_timelines {
+            if timelines_spawned >= max_timelines {
                 break;
             }
 
@@ -151,10 +151,10 @@ fn adaptive_branch_on_discovery(mark_name: &str, slot_idx: usize) {
                 bm.clear();
             }
 
-            let child_seed = compute_child_seed(current_seed, mark_name, total_forked);
-            total_forked += 1;
+            let child_seed = compute_child_seed(current_seed, mark_name, timelines_spawned);
+            timelines_spawned += 1;
 
-            // Safety: single-threaded, no real I/O. See branch_on_discovery.
+            // Safety: single-threaded, no real I/O. See split_on_discovery.
             let pid = unsafe { libc::fork() };
 
             match pid {
@@ -166,7 +166,7 @@ fn adaptive_branch_on_discovery(mark_name: &str, slot_idx: usize) {
                         ctx.is_child = true;
                         ctx.depth += 1;
                         ctx.current_seed = child_seed;
-                        ctx.recipe.push((fork_call_count, child_seed));
+                        ctx.recipe.push((split_call_count, child_seed));
                     });
                     if !stats_ptr.is_null() {
                         unsafe {
@@ -185,7 +185,7 @@ fn adaptive_branch_on_discovery(mark_name: &str, slot_idx: usize) {
                     // Check coverage yield BEFORE merging
                     if !bm_ptr.is_null() && !vm_ptr.is_null() {
                         let bm = unsafe { CoverageBitmap::new(bm_ptr) };
-                        let vm = unsafe { VirginMap::new(vm_ptr) };
+                        let vm = unsafe { ExploredMap::new(vm_ptr) };
                         if vm.has_new_bits(&bm) {
                             batch_has_new = true;
                         }
@@ -200,7 +200,7 @@ fn adaptive_branch_on_discovery(mark_name: &str, slot_idx: usize) {
                                 (*stats_ptr).bug_found.fetch_add(1, Ordering::Relaxed);
                             }
                         }
-                        save_bug_recipe(fork_call_count, child_seed);
+                        save_bug_recipe(split_call_count, child_seed);
                     }
 
                     if !stats_ptr.is_null() {
@@ -213,18 +213,18 @@ fn adaptive_branch_on_discovery(mark_name: &str, slot_idx: usize) {
         }
 
         // Batch complete — decide whether to continue
-        if total_forked >= max_timelines {
+        if timelines_spawned >= max_timelines {
             break;
         }
-        if !batch_has_new && total_forked >= min_timelines {
+        if !batch_has_new && timelines_spawned >= min_timelines {
             // Barren — return remaining energy to pool
             unsafe {
                 crate::energy::return_mark_energy_to_pool(budget_ptr, slot_idx);
             }
             break;
         }
-        // Check if we ran out of energy mid-batch (total_forked didn't reach batch_size)
-        if !total_forked.is_multiple_of(batch_size) && total_forked < max_timelines {
+        // Check if we ran out of energy mid-batch (timelines_spawned didn't reach batch_size)
+        if !timelines_spawned.is_multiple_of(batch_size) && timelines_spawned < max_timelines {
             break; // energy exhausted
         }
     }
@@ -237,11 +237,11 @@ fn adaptive_branch_on_discovery(mark_name: &str, slot_idx: usize) {
     }
 }
 
-/// Branch the simulation timeline at a discovery point.
+/// Split the simulation timeline at a discovery point.
 ///
 /// Called when an assertion detects a new success (e.g. via `assertion_bool`
-/// or `assertion_numeric`). Forks `children_per_fork` child processes, each with
-/// a different seed derived from the current seed and the assertion name.
+/// or `assertion_numeric`). Spawns `timelines_per_split` child timelines,
+/// each with a different seed derived from the current seed and the mark name.
 ///
 /// **In the child**: sets `is_child = true`, increments depth, reseeds the RNG,
 /// and returns (the simulation continues with new randomness).
@@ -249,14 +249,14 @@ fn adaptive_branch_on_discovery(mark_name: &str, slot_idx: usize) {
 /// **In the parent**: calls `waitpid()` for each child, merges coverage, checks
 /// exit codes, and continues after all children are done.
 #[cfg(unix)]
-pub fn branch_on_discovery(mark_name: &str) {
+pub fn split_on_discovery(mark_name: &str) {
     // Read context for guard checks
-    let (active, depth, max_depth, children_per_fork, current_seed) = context::with_ctx(|ctx| {
+    let (active, depth, max_depth, timelines_per_split, current_seed) = context::with_ctx(|ctx| {
         (
             ctx.active,
             ctx.depth,
             ctx.max_depth,
-            ctx.children_per_fork,
+            ctx.timelines_per_split,
             ctx.current_seed,
         )
     });
@@ -276,11 +276,11 @@ pub fn branch_on_discovery(mark_name: &str) {
     }
 
     // Record the current RNG call count for the recipe
-    let fork_call_count = context::rng_get_count();
+    let split_call_count = context::rng_get_count();
 
     // Get shared memory pointers
     let bm_ptr = COVERAGE_BITMAP_PTR.with(|c| c.get());
-    let vm_ptr = VIRGIN_MAP_PTR.with(|c| c.get());
+    let vm_ptr = EXPLORED_MAP_PTR.with(|c| c.get());
 
     // Save parent bitmap (copy to stack)
     let mut parent_bitmap_backup = [0u8; COVERAGE_MAP_SIZE];
@@ -296,7 +296,7 @@ pub fn branch_on_discovery(mark_name: &str) {
     }
 
     // Fork children
-    for child_idx in 0..children_per_fork {
+    for child_idx in 0..timelines_per_split {
         // Additional children beyond the first each consume energy
         if child_idx > 0 {
             // Safety: stats_ptr is valid
@@ -334,7 +334,7 @@ pub fn branch_on_discovery(mark_name: &str) {
                     ctx.is_child = true;
                     ctx.depth += 1;
                     ctx.current_seed = child_seed;
-                    ctx.recipe.push((fork_call_count, child_seed));
+                    ctx.recipe.push((split_call_count, child_seed));
                 });
 
                 // Increment total timelines counter
@@ -356,11 +356,11 @@ pub fn branch_on_discovery(mark_name: &str) {
                     libc::waitpid(child_pid, &mut status, 0);
                 }
 
-                // Merge child coverage into virgin map
+                // Merge child coverage into explored map
                 if !bm_ptr.is_null() && !vm_ptr.is_null() {
                     // Safety: both pointers are valid shared memory
                     let bm = unsafe { CoverageBitmap::new(bm_ptr) };
-                    let vm = unsafe { VirginMap::new(vm_ptr) };
+                    let vm = unsafe { ExploredMap::new(vm_ptr) };
                     vm.merge_from(&bm);
                 }
 
@@ -374,7 +374,7 @@ pub fn branch_on_discovery(mark_name: &str) {
                             (*stats_ptr).bug_found.fetch_add(1, Ordering::Relaxed);
                         }
                         // Save the bug recipe
-                        save_bug_recipe(fork_call_count, child_seed);
+                        save_bug_recipe(split_call_count, child_seed);
                     }
                 }
 
@@ -398,10 +398,10 @@ pub fn branch_on_discovery(mark_name: &str) {
 
 /// No-op on non-unix platforms.
 #[cfg(not(unix))]
-pub fn branch_on_discovery(_mark_name: &str) {}
+pub fn split_on_discovery(_mark_name: &str) {}
 
 /// Save a bug recipe to shared memory.
-fn save_bug_recipe(fork_call_count: u64, child_seed: u64) {
+fn save_bug_recipe(split_call_count: u64, child_seed: u64) {
     let recipe_ptr = SHARED_RECIPE.with(|c| c.get());
     if recipe_ptr.is_null() {
         return;
@@ -428,7 +428,7 @@ fn save_bug_recipe(fork_call_count: u64, child_seed: u64) {
                 }
                 // Add the current fork point
                 if len > 0 {
-                    recipe.entries[len - 1] = (fork_call_count, child_seed);
+                    recipe.entries[len - 1] = (split_call_count, child_seed);
                 }
                 recipe.len = len as u32;
             });

--- a/moonpool-explorer/tests/adaptive_scenarios.rs
+++ b/moonpool-explorer/tests/adaptive_scenarios.rs
@@ -1,7 +1,7 @@
 //! Integration tests for adaptive fork-based exploration.
 //!
-//! These tests exercise the adaptive code path (`dispatch_branch →
-//! `adaptive_branch_on_discovery`) with coverage-yield-driven batching
+//! These tests exercise the adaptive code path (`dispatch_split →
+//! `adaptive_split_on_discovery`) with coverage-yield-driven batching
 //! and 3-level energy budgets.
 //!
 //! Each test provides a minimal xorshift64 RNG via thread-local storage,
@@ -69,7 +69,7 @@ fn test_adaptive_maze_cascade() {
 
     moonpool_explorer::init(ExplorationConfig {
         max_depth: 8,
-        children_per_fork: 4,
+        timelines_per_split: 4,
         global_energy: 150,
         adaptive: Some(AdaptiveConfig {
             batch_size: 4,
@@ -196,7 +196,7 @@ fn test_adaptive_dungeon_floors() {
 
     moonpool_explorer::init(ExplorationConfig {
         max_depth: 7,
-        children_per_fork: 4,
+        timelines_per_split: 4,
         global_energy: 200,
         adaptive: Some(AdaptiveConfig {
             batch_size: 4,
@@ -282,7 +282,7 @@ fn test_adaptive_energy_budget() {
 
     moonpool_explorer::init(ExplorationConfig {
         max_depth: 3,
-        children_per_fork: 4,
+        timelines_per_split: 4,
         global_energy: 8,
         adaptive: Some(AdaptiveConfig {
             batch_size: 2,

--- a/moonpool-sim/tests/exploration/dungeon.rs
+++ b/moonpool-sim/tests/exploration/dungeon.rs
@@ -676,7 +676,7 @@ fn test_dungeon_slow_simulation() {
             .set_iterations(1)
             .enable_exploration(ExplorationConfig {
                 max_depth: 120,
-                children_per_fork: 4,
+                timelines_per_split: 4,
                 global_energy: 2_000_000,
                 adaptive: Some(moonpool_sim::AdaptiveConfig {
                     batch_size: 30,
@@ -722,7 +722,7 @@ fn test_dungeon_bug_replay_slow_simulation() {
             .set_debug_seeds(vec![54321])
             .enable_exploration(ExplorationConfig {
                 max_depth: 120,
-                children_per_fork: 4,
+                timelines_per_split: 4,
                 global_energy: 2_000_000,
                 adaptive: Some(moonpool_sim::AdaptiveConfig {
                     batch_size: 30,

--- a/moonpool-sim/tests/exploration/maze.rs
+++ b/moonpool-sim/tests/exploration/maze.rs
@@ -259,7 +259,7 @@ fn test_maze_slow_simulation() {
             .set_iterations(1)
             .enable_exploration(ExplorationConfig {
                 max_depth: 30,
-                children_per_fork: 4,
+                timelines_per_split: 4,
                 global_energy: 50_000,
                 adaptive: Some(moonpool_sim::AdaptiveConfig {
                     batch_size: 20,
@@ -306,7 +306,7 @@ fn test_maze_bug_replay_slow_simulation() {
             .set_debug_seeds(vec![12345])
             .enable_exploration(ExplorationConfig {
                 max_depth: 30,
-                children_per_fork: 4,
+                timelines_per_split: 4,
                 global_energy: 50_000,
                 adaptive: Some(moonpool_sim::AdaptiveConfig {
                     batch_size: 20,

--- a/moonpool-sim/tests/exploration/tests.rs
+++ b/moonpool-sim/tests/exploration/tests.rs
@@ -43,7 +43,7 @@ fn test_fork_basic() {
             .set_iterations(1)
             .enable_exploration(ExplorationConfig {
                 max_depth: 1,
-                children_per_fork: 2,
+                timelines_per_split: 2,
                 global_energy: 10,
                 adaptive: None,
             })
@@ -77,7 +77,7 @@ fn test_child_exit_code() {
             .set_iterations(1)
             .enable_exploration(ExplorationConfig {
                 max_depth: 1,
-                children_per_fork: 2,
+                timelines_per_split: 2,
                 global_energy: 10,
                 adaptive: None,
             })
@@ -117,7 +117,7 @@ fn test_depth_limit() {
             .set_iterations(1)
             .enable_exploration(ExplorationConfig {
                 max_depth: 1,
-                children_per_fork: 2,
+                timelines_per_split: 2,
                 global_energy: 100,
                 adaptive: None,
             })
@@ -135,7 +135,7 @@ fn test_depth_limit() {
 
     assert_eq!(report.successful_runs, 1);
 
-    // With max_depth=1 and children_per_fork=2:
+    // With max_depth=1 and timelines_per_split=2:
     // - Root forks 2 children at gate_1 (depth 0->1)
     // - Gate_2 in children: depth=1 == max_depth, no fork
     // So total_timelines should be exactly 2
@@ -155,7 +155,7 @@ fn test_energy_limit() {
             .set_iterations(1)
             .enable_exploration(ExplorationConfig {
                 max_depth: 3,
-                children_per_fork: 8,
+                timelines_per_split: 8,
                 global_energy: 2,
                 adaptive: None,
             })
@@ -171,7 +171,7 @@ fn test_energy_limit() {
 
     assert_eq!(report.successful_runs, 1);
 
-    // With energy=2 and children_per_fork=8, we can only fork 2 children total
+    // With energy=2 and timelines_per_split=8, we can only fork 2 children total
     let exp = report.exploration.expect("exploration report missing");
     assert!(
         exp.total_timelines <= 2,
@@ -208,7 +208,7 @@ fn test_planted_bug() {
             .set_iterations(1)
             .enable_exploration(ExplorationConfig {
                 max_depth: 3,
-                children_per_fork: 4,
+                timelines_per_split: 4,
                 global_energy: 50,
                 adaptive: None,
             })
@@ -254,7 +254,7 @@ fn test_sometimes_each_triggers_fork() {
             .set_iterations(1)
             .enable_exploration(ExplorationConfig {
                 max_depth: 2,
-                children_per_fork: 2,
+                timelines_per_split: 2,
                 global_energy: 20,
                 adaptive: None,
             })


### PR DESCRIPTION
## Summary

This PR refactors the moonpool-explorer crate to use clearer, more intuitive terminology for the multiverse exploration system. The core concepts remain unchanged, but the naming now better reflects what's actually happening: exploring alternate **timelines** by **splitting** at discovery points, rather than the previous fork-centric language.

## Key Changes

- **Terminology updates across all modules:**
  - `fork_loop.rs` → `split_loop.rs`
  - `branch_on_discovery()` → `split_on_discovery()`
  - `dispatch_branch()` → `dispatch_split()`
  - `adaptive_branch_on_discovery()` → `adaptive_split_on_discovery()`
  - `children_per_fork` → `timelines_per_split`
  - `fork_triggered` → `split_triggered`
  - `fork_watermark` → `split_watermark`
  - `VirginMap` → `ExploredMap`
  - `VIRGIN_MAP_PTR` → `EXPLORED_MAP_PTR`

- **Documentation expansion in `lib.rs`:**
  - Added comprehensive glossary explaining all key terms (Seed, Timeline, Splitpoint, Multiverse, Coverage bitmap, Explored map, Energy budget, Watermark, Frontier, Recipe, Mark)
  - Added "The big idea" section with ASCII diagrams showing how multiverse exploration works
  - Added detailed sections on RNG mechanics, splitpoint triggers, step-by-step splitpoint execution, coverage bitmap mechanics, energy budget (both fixed and adaptive modes), and a complete walkthrough example
  - Added explanation of how `fork()` and copy-on-write enable the system
  - Added module overview documenting the purpose of each source file

- **Updated all references in:**
  - `assertion_slots.rs` — assertion discovery and branching logic
  - `coverage.rs` — coverage tracking and merging
  - `context.rs` — thread-local state management
  - `each_buckets.rs` — per-value bucketed assertions
  - Test files in both `moonpool-explorer` and `moonpool-sim`
  - `README.md` — high-level documentation

## Implementation Details

The refactoring is purely a naming/documentation change with no functional modifications. All the underlying logic for:
- Process forking via `libc::fork()`
- Copy-on-write memory management
- Shared memory coordination
- Coverage-yield-driven adaptive batching
- 3-level energy budgeting

...remains identical. The new terminology is more intuitive because it emphasizes the exploration strategy (splitting timelines) rather than the implementation mechanism (forking processes).

https://claude.ai/code/session_01Y9Uej2yM8XPFeAx41cQUoa