### PR TITLE
refactor(moonpool-sim): remove workload_fn, add WorkloadCount, clean up TODOs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,4 +42,13 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Run cargo nextest
-        run: nix develop --command cargo nextest run
+        run: nix develop --command cargo nextest run --profile fast
+
+  sim:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - name: Run simulation tests
+        run: nix develop --command cargo nextest run --profile sim


### PR DESCRIPTION
Remove closure-based `workload_fn` in favor of struct-based `Workload` trait
implementations everywhere. Add `WorkloadCount` enum (Fixed/Random) and
`.workloads(count, factory)` builder method for spawning N instances.

- Delete FnWorkload, BoxedRunFn, workload_fn from workload.rs
- Add WorkloadEntry (Instance/Factory) internal enum to builder
- Add resolve_entries/return_entries for per-iteration workload management
- Port all 11 workload_fn call sites to struct-based Workload impls
- Port hyper_http example to HyperServer/HyperClient structs
- Delete stale tests/chaos/assertions.rs, port 2 builder tests
- Remove all TODO CLAUDE AI markers

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>