### PR TITLE
feat(moonpool-sim): add ClientId strategy for workload identity

### DIFF
--- a/moonpool-sim/src/lib.rs
+++ b/moonpool-sim/src/lib.rs
@@ -178,9 +178,9 @@ pub use sim::{
 
 // Runner module re-exports
 pub use runner::{
-    FaultContext, FaultInjector, IterationControl, PhaseConfig, SimContext, SimulationBuilder,
-    SimulationMetrics, SimulationReport, TokioReport, TokioRunner, Workload, WorkloadCount,
-    WorkloadTopology,
+    ClientId, FaultContext, FaultInjector, IterationControl, PhaseConfig, SimContext,
+    SimulationBuilder, SimulationMetrics, SimulationReport, TokioReport, TokioRunner, Workload,
+    WorkloadCount, WorkloadTopology,
 };
 
 // Chaos module re-exports

--- a/moonpool-sim/src/runner/context.rs
+++ b/moonpool-sim/src/runner/context.rs
@@ -80,6 +80,22 @@ impl SimContext {
         &self.topology.my_ip
     }
 
+    /// Get this workload's client ID.
+    ///
+    /// Assigned by the builder's [`ClientId`](crate::ClientId) strategy.
+    /// Defaults to sequential IDs starting from 0 (FDB-style).
+    pub fn client_id(&self) -> usize {
+        self.topology.client_id
+    }
+
+    /// Get the total number of workload instances sharing this entry.
+    ///
+    /// For single `.workload()` entries this is 1.
+    /// For `.workloads(count, factory)` entries this is the resolved count.
+    pub fn client_count(&self) -> usize {
+        self.topology.client_count
+    }
+
     /// Find a peer's IP address by workload name.
     pub fn peer(&self, name: &str) -> Option<String> {
         self.topology.get_peer_by_name(name)

--- a/moonpool-sim/src/runner/mod.rs
+++ b/moonpool-sim/src/runner/mod.rs
@@ -21,7 +21,7 @@ pub mod topology;
 pub mod workload;
 
 // Re-export main types at module level
-pub use builder::WorkloadCount;
+pub use builder::{ClientId, WorkloadCount};
 pub use builder::{IterationControl, SimulationBuilder};
 pub use context::SimContext;
 pub use fault_injector::{FaultContext, FaultInjector, PhaseConfig};

--- a/moonpool-sim/src/runner/tokio.rs
+++ b/moonpool-sim/src/runner/tokio.rs
@@ -179,6 +179,8 @@ impl TokioRunner {
                 .collect();
             let topology = WorkloadTopology {
                 my_ip,
+                client_id: 0,
+                client_count: 1,
                 peer_ips,
                 peer_names,
                 shutdown_signal: shutdown_signal.clone(),
@@ -216,6 +218,8 @@ impl TokioRunner {
                     .collect();
                 let topology = WorkloadTopology {
                     my_ip,
+                    client_id: 0,
+                    client_count: 1,
                     peer_ips,
                     peer_names,
                     shutdown_signal: shutdown_signal.clone(),

--- a/moonpool-sim/src/runner/topology.rs
+++ b/moonpool-sim/src/runner/topology.rs
@@ -8,6 +8,10 @@
 pub struct WorkloadTopology {
     /// The IP address assigned to this workload
     pub my_ip: String,
+    /// This workload's client ID (assigned by the builder's [`ClientId`] strategy)
+    pub client_id: usize,
+    /// Total number of workload instances sharing this entry (factory count or 1)
+    pub client_count: usize,
     /// The IP addresses of all other peers in the simulation
     pub peer_ips: Vec<String>,
     /// The names of all other peers in the simulation (parallel to peer_ips)
@@ -45,6 +49,8 @@ impl TopologyFactory {
     /// `all_workloads` is a list of `(name, ip)` pairs for all workloads.
     pub(crate) fn create_topology(
         workload_ip: &str,
+        client_id: usize,
+        client_count: usize,
         all_workloads: &[(String, String)],
         shutdown_signal: tokio_util::sync::CancellationToken,
     ) -> WorkloadTopology {
@@ -62,6 +68,8 @@ impl TopologyFactory {
 
         WorkloadTopology {
             my_ip: workload_ip.to_string(),
+            client_id,
+            client_count,
             peer_ips,
             peer_names,
             shutdown_signal,


### PR DESCRIPTION
## Summary

- Adds `ClientId` enum (`Fixed`, `RandomRange`) inspired by FDB's `WorkloadContext.clientId`, exposing resolved IDs via `SimContext::client_id()` and `SimContext::client_count()`
- Adds `workload_with_client_id()` and `workloads_with_client_id()` builder methods; existing `workload()` / `workloads()` default to sequential IDs from 0
- Extracts `WorkloadClientInfo` and `ResolvedEntries` structs to replace opaque tuples and remove `#[allow(clippy::type_complexity)]`

## Test plan

- [x] `cargo clippy` passes with zero warnings
- [x] `cargo fmt` clean
- [x] `cargo nextest run --profile fast` — 508 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)