### PR TITLE
Replace misused assert_sometimes!(true) with correct assertion macros

### DIFF
--- a/moonpool-sim/src/runner/fault_injector.rs
+++ b/moonpool-sim/src/runner/fault_injector.rs
@@ -44,6 +44,7 @@ use crate::providers::{SimRandomProvider, SimTimeProvider};
 use crate::runner::process::RebootKind;
 use crate::runner::tags::TagRegistry;
 use crate::sim::SimWorld;
+use crate::{assert_reachable, assert_sometimes_each};
 
 /// Process-related state for fault injection targeting.
 pub struct ProcessInfo {
@@ -192,6 +193,7 @@ impl FaultContext {
 
         match kind {
             RebootKind::Graceful => {
+                assert_reachable!("reboot: graceful path");
                 let grace_ms = crate::sim::sim_random_range(grace_period_range_ms.clone()) as u64;
                 let recovery_ms =
                     crate::sim::sim_random_range(recovery_delay_range_ms.clone()) as u64;
@@ -211,6 +213,7 @@ impl FaultContext {
                 );
             }
             RebootKind::Crash | RebootKind::CrashAndWipe => {
+                assert_reachable!("reboot: crash path");
                 self.sim.abort_all_connections_for_ip(ip_addr);
                 self.process_info
                     .dead_count
@@ -340,12 +343,14 @@ impl FaultInjector for AttritionInjector {
 
             // Respect max_dead: skip this cycle if already at the limit
             if ctx.dead_count() >= self.config.max_dead {
+                assert_reachable!("attrition: max_dead limit enforced");
                 continue;
             }
 
             // Choose reboot kind by weighted probability
             let rand_val = crate::sim::sim_random_range(0..10000) as f64 / 10000.0;
             let kind = self.config.choose_kind(rand_val);
+            assert_sometimes_each!("attrition_reboot_kind", [("kind", kind as i64)]);
 
             // Use configured delay ranges (or defaults)
             let recovery_range = self.config.recovery_delay_ms.clone().unwrap_or(1000..10000);
@@ -356,6 +361,7 @@ impl FaultInjector for AttritionInjector {
             }
             let idx = crate::sim::sim_random_range(0..ctx.process_ips().len());
             let ip = ctx.process_ips()[idx].to_string();
+            assert_sometimes_each!("attrition_process_targeted", [("process_idx", idx as i64)]);
             ctx.reboot_with_delays(&ip, kind, &recovery_range, &grace_range)?;
         }
         Ok(())

--- a/moonpool-sim/src/runner/orchestrator.rs
+++ b/moonpool-sim/src/runner/orchestrator.rs
@@ -17,7 +17,9 @@ use crate::runner::process::Process;
 use crate::runner::tags::{ProcessTags, TagRegistry};
 use crate::runner::topology::TopologyFactory;
 use crate::runner::workload::Workload;
-use crate::{SimulationResult, chaos::AssertionStats};
+use crate::{
+    SimulationResult, assert_always_less_than_or_equal_to, assert_reachable, chaos::AssertionStats,
+};
 
 use super::report::SimulationMetrics;
 
@@ -155,6 +157,12 @@ impl<'a> ProcessManager<'a> {
         if let Some(token) = &self.process_tokens[idx] {
             token.cancel();
             self.dead_count.set(self.dead_count.get() + 1);
+            assert_always_less_than_or_equal_to!(
+                self.dead_count.get(),
+                self.ips.len(),
+                "dead_count <= process_count"
+            );
+            assert_reachable!("process_manager: graceful shutdown signaled");
             tracing::info!(
                 "Signaled graceful shutdown for process at {} (index {})",
                 ip,
@@ -230,6 +238,7 @@ impl<'a> ProcessManager<'a> {
         if current > 0 {
             self.dead_count.set(current - 1);
         }
+        assert_reachable!("process_manager: process restarted");
         tracing::info!("Process at {} restarted (index {})", ip_str, idx);
     }
 
@@ -561,6 +570,7 @@ impl WorkloadOrchestrator {
                         grace_period_ms,
                         recovery_delay_ms,
                     }) => {
+                        assert_reachable!("event: ProcessGracefulShutdown");
                         process_manager.signal_graceful_shutdown(ip);
                         sim.schedule_event(
                             crate::sim::Event::ProcessForceKill {
@@ -579,6 +589,7 @@ impl WorkloadOrchestrator {
                         sim.schedule_process_restart(ip, Duration::from_millis(recovery_delay_ms));
                     }
                     Some(crate::sim::Event::ProcessRestart { ip }) => {
+                        assert_reachable!("event: ProcessRestart");
                         process_manager.handle_restart(ip, providers, state, shutdown_signal);
                     }
                     _ => {}
@@ -771,6 +782,7 @@ impl WorkloadOrchestrator {
                 chaos_shutdown.cancel();
                 Self::heal_all_partitions(sim, &all_ips);
                 chaos_ended = true;
+                assert_reachable!("phase: chaos ended");
             }
 
             if !recovery_ended
@@ -781,6 +793,7 @@ impl WorkloadOrchestrator {
                 Self::trigger_shutdown(sim, shutdown_signal);
                 recovery_ended = true;
                 shutdown_triggered = true;
+                assert_reachable!("phase: recovery ended");
             }
 
             // Process one simulation event
@@ -797,6 +810,7 @@ impl WorkloadOrchestrator {
                         grace_period_ms,
                         recovery_delay_ms,
                     }) => {
+                        assert_reachable!("event: ProcessGracefulShutdown");
                         process_manager.signal_graceful_shutdown(ip);
                         sim.schedule_event(
                             crate::sim::Event::ProcessForceKill {
@@ -815,6 +829,7 @@ impl WorkloadOrchestrator {
                         sim.schedule_process_restart(ip, Duration::from_millis(recovery_delay_ms));
                     }
                     Some(crate::sim::Event::ProcessRestart { ip }) => {
+                        assert_reachable!("event: ProcessRestart");
                         process_manager.handle_restart(ip, providers, state, shutdown_signal);
                     }
                     _ => {}

--- a/moonpool-transport/src/peer/core.rs
+++ b/moonpool-transport/src/peer/core.rs
@@ -18,7 +18,10 @@ use crate::{
     HEADER_SIZE, NetworkProvider, Providers, TaskProvider, TimeProvider, UID, WireError,
     serialize_packet, try_deserialize_packet,
 };
-use moonpool_sim::{assert_sometimes, assert_sometimes_each};
+use moonpool_sim::{
+    assert_always_less_than_or_equal_to, assert_reachable, assert_sometimes, assert_sometimes_all,
+    assert_sometimes_each, assert_sometimes_greater_than,
+};
 
 // =============================================================================
 // Ping/Pong Protocol Constants
@@ -447,7 +450,7 @@ impl<P: Providers> Peer<P> {
             // Check queue capacity before adding
             assert_sometimes!(
                 state.reliable_queue.len() >= (self.config.max_queue_size as f64 * 0.8) as usize,
-                "Message queue should sometimes approach capacity limit"
+                "reliable_queue_near_capacity"
             );
 
             // Handle queue overflow
@@ -467,10 +470,7 @@ impl<P: Providers> Peer<P> {
             );
 
             // Check if queue is growing with multiple messages
-            assert_sometimes!(
-                state.reliable_queue.len() > 1,
-                "Message queue should sometimes contain multiple messages"
-            );
+            assert_sometimes!(state.reliable_queue.len() > 1, "reliable_queue_has_backlog");
 
             // Wake connection task if this is first message (FoundationDB pattern)
             if first_unsent {
@@ -783,7 +783,7 @@ async fn connection_task<P: Providers>(
                     // Buggify: Sometimes force write failures to test requeuing
                     if moonpool_sim::buggify_with_prob!(0.02) {
                         tracing::debug!("Buggify forcing write failure for requeue testing");
-                        assert_sometimes!(true, "buggified_write_failure");
+                        assert_reachable!("buggified_write_failure");
                         handle_connection_failure(
                             &shared_state,
                             &mut current_connection,
@@ -837,7 +837,7 @@ async fn connection_task<P: Providers>(
                 match read_result {
                     Ok((_buffer, 0)) => {
                         // Connection closed
-                        assert_sometimes!(true, "graceful_close_on_read");
+                        assert_reachable!("graceful_close_on_read");
                         handle_connection_failure(
                             &shared_state,
                             &mut current_connection,
@@ -913,7 +913,7 @@ async fn connection_task<P: Providers>(
                             // Buggify: occasionally skip sending ping to test timeout path
                             let skip_ping = moonpool_sim::buggify_with_prob!(0.05);
                             if skip_ping {
-                                assert_sometimes!(true, "buggified_ping_skip");
+                                assert_reachable!("buggified_ping_skip");
                                 tracing::debug!("connection_task: buggify skipped ping send");
                             } else if current_connection.is_some()
                                 && let Ok(ping_packet) = serialize_packet(PING_TOKEN, &[])
@@ -932,7 +932,7 @@ async fn connection_task<P: Providers>(
                             }
                         }
                         PingAction::Tolerate => {
-                            assert_sometimes!(true, "ping_timeout_tolerated");
+                            assert_reachable!("ping_timeout_tolerated");
                             shared_state
                                 .borrow_mut()
                                 .metrics
@@ -958,7 +958,7 @@ async fn connection_task<P: Providers>(
                             }
                         }
                         PingAction::TearDown => {
-                            assert_sometimes!(true, "ping_timeout_teardown");
+                            assert_reachable!("ping_timeout_teardown");
                             shared_state.borrow_mut().metrics.record_ping_timeout();
                             tracing::debug!(
                                 "connection_task: ping timeout, tearing down connection to {}",
@@ -1003,10 +1003,7 @@ fn handle_connection_failure<P: Providers>(
     // Handle the failed send if provided
     if let Some((data, is_reliable)) = failed_send {
         if is_reliable {
-            assert_sometimes!(
-                true,
-                "Peer should sometimes re-queue reliable messages after send failure"
-            );
+            assert_reachable!("reliable_message_requeued");
             state.reliable_queue.push_front(data);
         } else {
             state.metrics.record_message_dropped();
@@ -1090,7 +1087,9 @@ fn process_read_buffer<P: Providers>(
                         if let Some(rtt) = tracker.on_pong_received(now) {
                             shared_state.borrow_mut().metrics.record_pong_received(rtt);
                             tracing::debug!("connection_task: received pong, rtt={:?}", rtt);
-                            assert_sometimes!(true, "pong_received_with_rtt");
+                            let rtt_ms = rtt.as_millis() as i64;
+                            assert_reachable!("pong_received");
+                            assert_sometimes_greater_than!(rtt_ms, 0, "pong_rtt_positive");
                         }
                     }
                     continue; // Do NOT deliver to application
@@ -1115,10 +1114,7 @@ fn process_read_buffer<P: Providers>(
                             expected,
                             actual
                         );
-                        assert_sometimes!(
-                            true,
-                            "Checksum validation should sometimes catch corrupted packets"
-                        );
+                        assert_reachable!("checksum_mismatch_detected");
                     }
                     _ => {
                         tracing::warn!(
@@ -1128,10 +1124,7 @@ fn process_read_buffer<P: Providers>(
                     }
                 }
 
-                assert_sometimes!(
-                    true,
-                    "Connection should sometimes be torn down on wire format errors"
-                );
+                assert_reachable!("wire_error_teardown");
 
                 *current_connection = None;
                 read_buffer.clear();
@@ -1152,10 +1145,7 @@ fn process_read_buffer<P: Providers>(
                             "connection_task: discarding {} unreliable packets after wire error (FDB pattern)",
                             unreliable_count
                         );
-                        assert_sometimes!(
-                            true,
-                            "Unreliable packets should sometimes be discarded on connection errors"
-                        );
+                        assert_reachable!("unreliable_packets_discarded");
                         for _ in 0..unreliable_count {
                             state.metrics.record_message_dropped();
                         }
@@ -1183,7 +1173,7 @@ async fn establish_connection<P: Providers>(
             if let Some(max_failures) = config.max_connection_failures
                 && state.reconnect_state.failure_count >= max_failures
             {
-                assert_sometimes!(true, "max_failures_reached");
+                assert_reachable!("max_failures_reached");
                 return Err(PeerError::ConnectionFailed);
             }
 
@@ -1232,12 +1222,21 @@ async fn establish_connection<P: Providers>(
                 {
                     let mut state = shared_state.borrow_mut();
 
-                    if state.reconnect_state.failure_count > 0 {
-                        assert_sometimes!(
-                            true,
-                            "Peer should sometimes successfully connect after previous failures"
-                        );
+                    let reliable_empty = state.reliable_queue.is_empty();
+                    let failure_count = state.reconnect_state.failure_count;
+
+                    if failure_count > 0 {
+                        assert_reachable!("reconnect_after_previous_failures");
                     }
+
+                    assert_sometimes_all!(
+                        "healthy_peer",
+                        [
+                            ("connected", true),
+                            ("queue_empty", reliable_empty),
+                            ("no_prior_failures", failure_count == 0)
+                        ]
+                    );
 
                     let now = state.time.now();
                     state.connection = Some(()); // Mark as connected
@@ -1254,7 +1253,7 @@ async fn establish_connection<P: Providers>(
             }
             Err(_) => {
                 // Connection attempt timed out
-                assert_sometimes!(true, "connection_timed_out");
+                assert_reachable!("connection_attempt_timed_out");
                 record_connection_failure(shared_state, config);
                 // Continue loop to retry
             }
@@ -1278,6 +1277,11 @@ fn record_connection_failure<P: Providers>(
         config.max_reconnect_delay,
     );
     state.reconnect_state.current_delay = next_delay;
+    assert_always_less_than_or_equal_to!(
+        next_delay.as_millis() as i64,
+        config.max_reconnect_delay.as_millis() as i64,
+        "backoff_within_max"
+    );
     let now = state.time.now();
     state.metrics.record_connection_failure_at(now, next_delay);
 }

--- a/moonpool-transport/src/rpc/endpoint_map.rs
+++ b/moonpool-transport/src/rpc/endpoint_map.rs
@@ -10,7 +10,7 @@ use std::collections::BTreeMap;
 use std::rc::Rc;
 
 use crate::{UID, WELL_KNOWN_RESERVED_COUNT, WellKnownToken};
-use moonpool_sim::assert_sometimes;
+use moonpool_sim::{assert_reachable, assert_sometimes};
 
 use crate::error::MessagingError;
 
@@ -105,7 +105,7 @@ impl EndpointMap {
         }
         self.well_known[index] = Some(receiver);
         self.registration_count += 1;
-        assert_sometimes!(true, "Well-known endpoint registered successfully");
+        assert_reachable!("endpoint_map: well_known registered");
         Ok(())
     }
 
@@ -144,7 +144,7 @@ impl EndpointMap {
 
         // Fall back to dynamic lookup
         let result = self.dynamic.get(token).cloned();
-        assert_sometimes!(result.is_some(), "Dynamic endpoint lookup succeeds");
+        assert_sometimes!(result.is_some(), "endpoint_map: dynamic lookup found");
         result
     }
 
@@ -158,14 +158,14 @@ impl EndpointMap {
     pub fn remove(&mut self, token: &UID) -> Option<Rc<dyn MessageReceiver>> {
         if token.is_well_known() {
             // Well-known endpoints cannot be removed
-            assert_sometimes!(true, "Well-known endpoint removal correctly rejected");
+            assert_reachable!("endpoint_map: well_known removal rejected");
             return None;
         }
 
         let result = self.dynamic.remove(token);
         if result.is_some() {
             self.deregistration_count += 1;
-            assert_sometimes!(true, "Dynamic endpoint deregistered successfully");
+            assert_reachable!("endpoint_map: dynamic deregistered");
         }
         result
     }

--- a/moonpool-transport/src/rpc/net_notified_queue.rs
+++ b/moonpool-transport/src/rpc/net_notified_queue.rs
@@ -32,7 +32,7 @@ use std::task::{Context, Poll, Waker};
 use serde::de::DeserializeOwned;
 
 use crate::{Endpoint, MessageCodec, NetworkAddress, UID};
-use moonpool_sim::assert_sometimes;
+use moonpool_sim::assert_reachable;
 
 use super::endpoint_map::MessageReceiver;
 
@@ -190,7 +190,7 @@ impl<T: DeserializeOwned + 'static, C: MessageCodec> MessageReceiver for NetNoti
         // Deserialize the message using the codec
         match self.codec.decode::<T>(payload) {
             Ok(message) => {
-                assert_sometimes!(true, "Message deserialized successfully");
+                assert_reachable!("queue: message deserialized");
                 let mut inner = self.inner.borrow_mut();
                 inner.queue.push_back(message);
                 inner.messages_received += 1;
@@ -201,11 +201,11 @@ impl<T: DeserializeOwned + 'static, C: MessageCodec> MessageReceiver for NetNoti
                     waker.wake();
                 }
                 if had_waiters {
-                    assert_sometimes!(true, "Wakers notified on new message");
+                    assert_reachable!("queue: wakers notified");
                 }
             }
             Err(e) => {
-                assert_sometimes!(true, "Message deserialization failed");
+                assert_reachable!("queue: deserialization failed");
                 // Log error and drop the message
                 tracing::warn!(
                     endpoint = %self.endpoint.token,
@@ -231,18 +231,18 @@ impl<T, C: MessageCodec> Future for RecvFuture<'_, T, C> {
 
         // Try to get a message
         if let Some(message) = inner.queue.pop_front() {
-            assert_sometimes!(true, "Message available immediately");
+            assert_reachable!("queue: immediate message");
             return Poll::Ready(Some(message));
         }
 
         // If closed and empty, return None
         if inner.closed {
-            assert_sometimes!(true, "Queue closed and empty");
+            assert_reachable!("queue: closed and empty");
             return Poll::Ready(None);
         }
 
         // Register waker and wait
-        assert_sometimes!(true, "Recv waiting for message");
+        assert_reachable!("queue: recv waiting");
         inner.wakers.push(cx.waker().clone());
         Poll::Pending
     }

--- a/moonpool-transport/src/rpc/net_transport.rs
+++ b/moonpool-transport/src/rpc/net_transport.rs
@@ -34,7 +34,7 @@ use crate::{
     Endpoint, NetworkAddress, NetworkProvider, Peer, PeerConfig, Providers, TaskProvider,
     TcpListenerTrait, UID, WellKnownToken,
 };
-use moonpool_sim::assert_sometimes;
+use moonpool_sim::assert_reachable;
 use tokio::sync::watch;
 
 use super::endpoint_map::{EndpointMap, MessageReceiver};
@@ -366,12 +366,12 @@ impl<P: Providers> NetTransport<P> {
     ) -> Result<(), MessagingError> {
         // Check for local delivery
         if self.is_local_address(&endpoint.address) {
-            assert_sometimes!(true, "Unreliable send uses local delivery path");
+            assert_reachable!("send_unreliable: local delivery");
             return self.deliver_local(&endpoint.token, payload);
         }
 
         // Get or create peer for remote address
-        assert_sometimes!(true, "Unreliable send uses remote peer path");
+        assert_reachable!("send_unreliable: remote peer");
         let peer = self.get_or_open_peer(&endpoint.address);
         peer.borrow_mut()
             .send_unreliable(endpoint.token, payload)
@@ -422,12 +422,12 @@ impl<P: Providers> NetTransport<P> {
             receiver.receive(payload);
             drop(data); // Release borrow before mutating stats
             self.data.borrow_mut().stats.packets_dispatched += 1;
-            assert_sometimes!(true, "Local delivery found registered endpoint");
+            assert_reachable!("local_delivery: endpoint found");
             Ok(())
         } else {
             drop(data); // Release borrow before mutating stats
             self.data.borrow_mut().stats.packets_undelivered += 1;
-            assert_sometimes!(true, "Local delivery to unregistered endpoint");
+            assert_reachable!("local_delivery: endpoint not found");
             Err(MessagingError::EndpointNotFound { token: *token })
         }
     }
@@ -450,14 +450,14 @@ impl<P: Providers> NetTransport<P> {
 
         // Check if outgoing peer already exists
         if let Some(peer) = self.data.borrow().peers.get(&addr_str) {
-            assert_sometimes!(true, "Existing peer reused for address");
+            assert_reachable!("peer: outgoing reused");
             return Rc::clone(peer);
         }
 
         // Check incoming peers — reuse accepted connection for responses
         // (FDB pattern: responses flow back on the same connection)
         if let Some(peer) = self.data.borrow().incoming_peers.get(&addr_str) {
-            assert_sometimes!(true, "Incoming peer reused for response");
+            assert_reachable!("peer: incoming reused for response");
             return Rc::clone(peer);
         }
 
@@ -480,7 +480,7 @@ impl<P: Providers> NetTransport<P> {
         // This handles responses for outgoing requests
         self.spawn_connection_reader(Rc::clone(&peer), addr_str);
 
-        assert_sometimes!(true, "New peer created for address");
+        assert_reachable!("peer: new created");
         peer
     }
 
@@ -497,12 +497,12 @@ impl<P: Providers> NetTransport<P> {
             receiver.receive(payload);
             drop(data); // Release borrow before mutating stats
             self.data.borrow_mut().stats.packets_dispatched += 1;
-            assert_sometimes!(true, "Message dispatched to endpoint");
+            assert_reachable!("dispatch: endpoint found");
             Ok(())
         } else {
             drop(data); // Release borrow before mutating stats
             self.data.borrow_mut().stats.packets_undelivered += 1;
-            assert_sometimes!(true, "Dispatch to unregistered endpoint");
+            assert_reachable!("dispatch: endpoint not found");
             Err(MessagingError::EndpointNotFound { token: *token })
         }
     }
@@ -812,7 +812,7 @@ async fn connection_reader<P: Providers>(
                     );
                 }
 
-                assert_sometimes!(true, "connectionReader dispatched incoming message");
+                assert_reachable!("connection_reader: dispatched message");
             }
             None => {
                 // Channel closed - peer disconnected or shutdown
@@ -890,7 +890,7 @@ async fn listen_task<P: Providers>(
                             &transport_rc,
                         );
 
-                        assert_sometimes!(true, "listen() accepted incoming connection");
+                        assert_reachable!("listen: accepted connection");
                     }
                     Err(e) => {
                         tracing::warn!("listen_task: accept error on {}: {:?}", listen_addr, e);

--- a/moonpool-transport/src/rpc/reply_promise.rs
+++ b/moonpool-transport/src/rpc/reply_promise.rs
@@ -29,7 +29,7 @@ use std::marker::PhantomData;
 use std::rc::Rc;
 
 use crate::{Endpoint, MessageCodec};
-use moonpool_sim::assert_sometimes;
+use moonpool_sim::assert_reachable;
 use serde::Serialize;
 
 use super::reply_error::ReplyError;
@@ -110,13 +110,13 @@ impl<T: Serialize, C: MessageCodec> ReplyPromise<T, C> {
             Ok(payload) => {
                 if let Some(sender) = inner.sender.take() {
                     sender(&inner.reply_endpoint, &payload);
-                    assert_sometimes!(true, "Reply successfully sent");
+                    assert_reachable!("reply_promise: sent");
                 }
             }
             Err(e) => {
                 // Serialization failed - send error instead
                 tracing::error!(error = %e, "failed to serialize reply");
-                assert_sometimes!(true, "reply_serialization_failed");
+                assert_reachable!("reply_promise: serialization failed");
                 let error_result: Result<T, ReplyError> = Err(ReplyError::Serialization {
                     message: e.to_string(),
                 });
@@ -140,7 +140,7 @@ impl<T: Serialize, C: MessageCodec> ReplyPromise<T, C> {
             return;
         }
 
-        assert_sometimes!(true, "error_reply_sent");
+        assert_reachable!("reply_promise: error sent");
         let result: Result<T, ReplyError> = Err(error);
         if let Ok(payload) = inner.codec.encode(&result)
             && let Some(sender) = inner.sender.take()
@@ -166,7 +166,7 @@ impl<T: Serialize, C: MessageCodec> Drop for ReplyPromise<T, C> {
     fn drop(&mut self) {
         let mut inner = self.inner.borrow_mut();
         if !inner.fulfilled {
-            assert_sometimes!(true, "Promise dropped without reply");
+            assert_reachable!("reply_promise: broken");
 
             // Send BrokenPromise error to client
             let result: Result<T, ReplyError> = Err(ReplyError::BrokenPromise);

--- a/moonpool-transport/src/simulations/e2e/workloads.rs
+++ b/moonpool-transport/src/simulations/e2e/workloads.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 use crate::{NetworkProvider, Peer, TcpListenerTrait, TimeProvider, try_deserialize_packet};
 use async_trait::async_trait;
-use moonpool_sim::{Process, SimContext, SimulationResult, Workload, assert_sometimes};
+use moonpool_sim::{Process, SimContext, SimulationResult, Workload, assert_reachable};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use super::TestMessage;
@@ -123,7 +123,7 @@ impl Workload for ClientWorkload {
                     );
                 }
                 OpResult::Failed { error } => {
-                    assert_sometimes!(true, "Client operation should sometimes fail");
+                    assert_reachable!("client: operation failed");
                     tracing::trace!("Client {}: operation failed: {}", my_id, error);
                 }
                 _ => {}
@@ -274,10 +274,7 @@ impl Process for WireServerWorkload {
                         match read_result {
                             Ok(Ok(0)) => {
                                 // Connection closed
-                                assert_sometimes!(
-                                    true,
-                                    "Wire server should sometimes see connections close"
-                                );
+                                assert_reachable!("wire_server: connection closed");
                                 break;
                             }
                             Ok(Ok(n)) => {
@@ -325,10 +322,7 @@ impl Process for WireServerWorkload {
                                         }
                                         Err(e) => {
                                             // Wire format error (checksum mismatch, etc.)
-                                            assert_sometimes!(
-                                                true,
-                                                "Wire server should sometimes see wire errors"
-                                            );
+                                            assert_reachable!("wire_server: wire error");
                                             tracing::trace!(
                                                 "Wire server {} wire error: {:?}",
                                                 my_addr,


### PR DESCRIPTION
## Summary

- Replace ~41 `assert_sometimes!(true, ...)` with `assert_reachable!(...)` across moonpool-transport (peer, rpc, simulations)
- Add 12 new assertions to moonpool-sim attrition/orchestrator (previously had zero)
- Add `assert_always_less_than_or_equal_to!` for invariants (dead_count, backoff bounds)
- Add `assert_sometimes_each!` for per-bucket coverage (reboot kinds, process targets)
- Add `assert_sometimes_all!` for multi-condition discovery (healthy peer)
- Add `assert_sometimes_greater_than!` for pong RTT positivity
- Shorten existing real-condition assertion messages for consistency

## Test plan

- [x] `cargo fmt` — clean
- [x] `cargo clippy` — clean
- [x] `cargo nextest run` — 582 tests pass
- [x] `cargo xtask sim run-all` — 6/6 simulations pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)