### PR TITLE
chore(release): update release-plz config for new crates

### DIFF
--- a/moonpool-sim-examples/Cargo.toml
+++ b/moonpool-sim-examples/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "moonpool-sim-examples"
 version.workspace = true
+publish = false
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -32,6 +32,11 @@ changelog_path = "moonpool-core/CHANGELOG.md"
 version_group = "moonpool"
 
 [[package]]
+name = "moonpool-explorer"
+changelog_path = "moonpool-explorer/CHANGELOG.md"
+version_group = "moonpool"
+
+[[package]]
 name = "moonpool-sim"
 changelog_path = "moonpool-sim/CHANGELOG.md"
 version_group = "moonpool"
@@ -50,6 +55,16 @@ version_group = "moonpool"
 name = "moonpool"
 changelog_path = "moonpool/CHANGELOG.md"
 version_group = "moonpool"
+
+[[package]]
+name = "moonpool-sim-examples"
+release = false
+publish = false
+
+[[package]]
+name = "xtask"
+release = false
+publish = false
 
 # Changelog configuration
 [changelog]


### PR DESCRIPTION
Add moonpool-explorer to publishable packages in dependency order.
Exclude moonpool-sim-examples and xtask from release-plz.
Add publish = false to moonpool-sim-examples Cargo.toml.

https://claude.ai/code/session_013CPC3szyYJr8kyhcHhbjTu