### PR TITLE
refactor(core): switch NetworkProvider IO bounds to futures::io

### DIFF
--- a/book/src/part4-integration/01-standalone-sim.md
+++ b/book/src/part4-integration/01-standalone-sim.md
@@ -41,8 +41,9 @@ impl Process for HyperServer {
             _ = ctx.shutdown().cancelled() => return Ok(()),
         };
 
-        // TokioIo bridges SimTcpStream into hyper's type system
-        let io = TokioIo::new(stream);
+        // SimTcpStream implements futures::io traits; .compat() bridges them
+        // back to tokio's IO traits, which is what TokioIo (and hyper) expects.
+        let io = TokioIo::new(stream.compat());
 
         hyper::server::conn::http1::Builder::new()
             .serve_connection(io, service_fn(handle_request))
@@ -53,9 +54,9 @@ impl Process for HyperServer {
 }
 ```
 
-The `TokioIo` adapter bridges any `AsyncRead + AsyncWrite` into hyper's internal I/O type. Because `SimTcpStream` satisfies those bounds, hyper never knows it's running over simulated networking. The HTTP parser, chunked encoding, keep-alive logic, content-length validation: all exercised for real.
+`SimTcpStream` implements `futures::io::AsyncRead + AsyncWrite` (the runtime-agnostic IO traits). Hyper expects `tokio::io` traits, so we route the stream through `tokio_util::compat::Compat` via `.compat()` (from `FuturesAsyncReadCompatExt`), then hand the result to `TokioIo`. From hyper's perspective nothing has changed: HTTP parser, chunked encoding, keep-alive logic, content-length validation — all exercised for real over simulated networking.
 
-The client side follows the same pattern. Connect via `ctx.network().connect()`, wrap in `TokioIo`, hand to `hyper::client::conn::http1::handshake`. Real HTTP/1.1 request-response cycles over a network that drops packets, injects latency, and kills connections.
+The client side follows the same pattern. Connect via `ctx.network().connect()`, `.compat()` the stream, wrap in `TokioIo`, hand to `hyper::client::conn::http1::handshake`. Real HTTP/1.1 request-response cycles over a network that drops packets, injects latency, and kills connections.
 
 ## The Send Constraint
 

--- a/book/src/part4-integration/03-wiring-a-web-service.md
+++ b/book/src/part4-integration/03-wiring-a-web-service.md
@@ -95,7 +95,9 @@ impl Process for WebProcess {
                 _ = ctx.shutdown().cancelled() => return Ok(()),
             };
 
-            let io = TokioIo::new(stream);
+            // SimTcpStream implements futures::io traits; .compat() bridges them
+            // back to tokio::io so TokioIo (and therefore hyper) accepts the stream.
+            let io = TokioIo::new(stream.compat());
             // TowerToHyperService bridges axum's tower::Service to hyper's Service
             let service = TowerToHyperService::new(app.clone());
 
@@ -115,7 +117,7 @@ impl Process for WebProcess {
 }
 ```
 
-Two things to note. First, we use `hyper::server::conn::http1::serve_connection`, **not** `axum::serve()`. `axum::serve` takes `tokio::net::TcpListener` directly, so it can't accept our simulated listener. `serve_connection` takes any `AsyncRead + AsyncWrite`, which `SimTcpStream` satisfies through the `TokioIo` adapter.
+Two things to note. First, we use `hyper::server::conn::http1::serve_connection`, **not** `axum::serve()`. `axum::serve` takes `tokio::net::TcpListener` directly, so it can't accept our simulated listener. `serve_connection` takes any tokio `AsyncRead + AsyncWrite`. `SimTcpStream` implements `futures::io::AsyncRead + AsyncWrite` (the runtime-agnostic traits), so we route it through `tokio_util::compat::Compat` via `.compat()` before handing it to `TokioIo`.
 
 Second, `spawn_local` instead of `spawn`. The future holds a `SimTcpStream` which is `!Send`. Axum handlers remain `Send` (axum enforces this at compile time). The two coexist because hyper polls handlers inline within the connection future. The handler never escapes to another thread. This is architecturally correct, not a workaround.
 

--- a/moonpool-core/Cargo.toml
+++ b/moonpool-core/Cargo.toml
@@ -15,11 +15,13 @@ rustc-args = ["--cfg", "tokio_unstable"]
 
 [dependencies]
 async-trait = "0.1"
+futures = "0.3"
 rand = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2.0"
 tokio = { version = "1", features = ["fs", "io-util", "net", "rt", "time", "tracing"] }
+tokio-util = { version = "0.7", features = ["compat"] }
 tracing = "0.1"
 
 [dev-dependencies]

--- a/moonpool-core/src/network.rs
+++ b/moonpool-core/src/network.rs
@@ -4,8 +4,9 @@
 //! between real Tokio networking and simulated networking for testing.
 
 use async_trait::async_trait;
+use futures::io::{AsyncRead, AsyncWrite};
 use std::io;
-use tokio::io::{AsyncRead, AsyncWrite};
+use tokio_util::compat::{Compat, TokioAsyncReadCompatExt};
 
 /// Provider trait for creating network connections and listeners.
 ///
@@ -39,6 +40,10 @@ pub trait TcpListenerTrait {
 }
 
 /// Real Tokio networking implementation.
+///
+/// Wraps `tokio::net::TcpStream` with `tokio_util::compat::Compat` so it
+/// implements the runtime-agnostic `futures::io::AsyncRead + AsyncWrite` traits
+/// required by [`NetworkProvider`].
 #[derive(Debug, Clone)]
 pub struct TokioNetworkProvider;
 
@@ -57,7 +62,7 @@ impl Default for TokioNetworkProvider {
 
 #[async_trait(?Send)]
 impl NetworkProvider for TokioNetworkProvider {
-    type TcpStream = tokio::net::TcpStream;
+    type TcpStream = Compat<tokio::net::TcpStream>;
     type TcpListener = TokioTcpListener;
 
     async fn bind(&self, addr: &str) -> io::Result<Self::TcpListener> {
@@ -66,7 +71,7 @@ impl NetworkProvider for TokioNetworkProvider {
     }
 
     async fn connect(&self, addr: &str) -> io::Result<Self::TcpStream> {
-        tokio::net::TcpStream::connect(addr).await
+        Ok(tokio::net::TcpStream::connect(addr).await?.compat())
     }
 }
 
@@ -78,11 +83,11 @@ pub struct TokioTcpListener {
 
 #[async_trait(?Send)]
 impl TcpListenerTrait for TokioTcpListener {
-    type TcpStream = tokio::net::TcpStream;
+    type TcpStream = Compat<tokio::net::TcpStream>;
 
     async fn accept(&self) -> io::Result<(Self::TcpStream, String)> {
         let (stream, addr) = self.inner.accept().await?;
-        Ok((stream, addr.to_string()))
+        Ok((stream.compat(), addr.to_string()))
     }
 
     fn local_addr(&self) -> io::Result<String> {

--- a/moonpool-sim-examples/Cargo.toml
+++ b/moonpool-sim-examples/Cargo.toml
@@ -26,6 +26,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2.0"
 tokio = { version = "1", features = ["full"] }
+tokio-util = { version = "0.7", features = ["compat"] }
 
 [[bin]]
 name = "sim-maze-explore"

--- a/moonpool-sim-examples/src/axum_web.rs
+++ b/moonpool-sim-examples/src/axum_web.rs
@@ -3,8 +3,9 @@
 //! Demonstrates how to test an existing axum/hyper web service inside
 //! moonpool-sim's deterministic simulation with chaos injection.
 //!
-//! The key insight: `SimTcpStream` implements `tokio::io::AsyncRead + AsyncWrite`,
-//! so hyper (and therefore axum) works **unchanged** over simulated TCP.
+//! The key insight: `SimTcpStream` implements `futures::io::AsyncRead + AsyncWrite`,
+//! and `tokio_util::compat::Compat` bridges those to tokio's IO traits so hyper
+//! (and therefore axum) works **unchanged** over simulated TCP.
 //!
 //! # Architecture
 //!
@@ -29,6 +30,7 @@ use hyper::Request;
 use hyper_util::rt::TokioIo;
 use hyper_util::service::TowerToHyperService;
 use serde::{Deserialize, Serialize};
+use tokio_util::compat::FuturesAsyncReadCompatExt;
 use tracing::instrument;
 
 use moonpool_sim::{
@@ -246,8 +248,9 @@ impl Process for WebProcess {
 
             tracing::info!(%addr, "accepted connection");
 
-            // TokioIo adapts SimTcpStream (AsyncRead+AsyncWrite) for hyper.
-            let io = TokioIo::new(stream);
+            // SimTcpStream implements futures::io traits; .compat() bridges them
+            // back to tokio::io so TokioIo (and therefore hyper) accepts the stream.
+            let io = TokioIo::new(stream.compat());
             // TowerToHyperService bridges axum's tower::Service to hyper's Service trait.
             let service = TowerToHyperService::new(app.clone());
 
@@ -334,7 +337,7 @@ impl WebWorkload {
         };
         tracing::info!(round, "connected, starting handshake");
 
-        let io = TokioIo::new(stream);
+        let io = TokioIo::new(stream.compat());
         let (mut sender, conn) = hyper::client::conn::http1::handshake(io)
             .await
             .map_err(|e| moonpool_sim::SimulationError::InvalidState(format!("handshake: {e}")))?;

--- a/moonpool-sim/Cargo.toml
+++ b/moonpool-sim/Cargo.toml
@@ -27,7 +27,7 @@ serde_json = "1.0"
 thiserror = "2.0"
 parking_lot = "0.12"
 tokio = { version = "1", features = ["full", "tracing"] }
-tokio-util = "0.7"
+tokio-util = { version = "0.7", features = ["compat"] }
 tracing = "0.1"
 
 tracing-subscriber = { version = "0.3", features = ["registry"] }

--- a/moonpool-sim/src/network/sim/stream.rs
+++ b/moonpool-sim/src/network/sim/stream.rs
@@ -3,13 +3,13 @@ use crate::TcpListenerTrait;
 use crate::sim::state::CloseReason;
 use crate::{Event, WeakSimWorld};
 use async_trait::async_trait;
+use futures::io::{AsyncRead, AsyncWrite};
 use std::{
     future::Future,
     io,
     pin::Pin,
     task::{Context, Poll},
 };
-use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tracing::instrument;
 
 /// Create an io::Error for simulation shutdown.
@@ -157,8 +157,8 @@ impl AsyncRead for SimTcpStream {
     fn poll_read(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-        buf: &mut ReadBuf<'_>,
-    ) -> Poll<io::Result<()>> {
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
         tracing::trace!(
             "SimTcpStream::poll_read called on connection_id={}",
             self.connection_id.0
@@ -180,7 +180,7 @@ impl AsyncRead for SimTcpStream {
                 "SimTcpStream::poll_read connection_id={} recv side closed, returning EOF",
                 self.connection_id.0
             );
-            return Poll::Ready(Ok(())); // EOF
+            return Poll::Ready(Ok(0)); // EOF
         }
 
         // Check for half-open connection (peer crashed)
@@ -211,7 +211,7 @@ impl AsyncRead for SimTcpStream {
 
         // Try to read from connection's receive buffer first
         // We should be able to read buffered data even if connection is currently cut
-        let mut temp_buf = vec![0u8; buf.remaining()];
+        let mut temp_buf = vec![0u8; buf.len()];
         let bytes_read = sim
             .read_from_connection(self.connection_id, &mut temp_buf)
             .map_err(|e| io::Error::other(format!("read error: {}", e)))?;
@@ -229,8 +229,8 @@ impl AsyncRead for SimTcpStream {
                 self.connection_id.0,
                 data_preview
             );
-            buf.put_slice(&temp_buf[..bytes_read]);
-            Poll::Ready(Ok(()))
+            buf[..bytes_read].copy_from_slice(&temp_buf[..bytes_read]);
+            Poll::Ready(Ok(bytes_read))
         } else {
             // No data available - check if connection has received FIN, is closed, or cut
 
@@ -240,7 +240,7 @@ impl AsyncRead for SimTcpStream {
                     "SimTcpStream::poll_read connection_id={} remote FIN received, returning EOF (0 bytes)",
                     self.connection_id.0
                 );
-                return Poll::Ready(Ok(()));
+                return Poll::Ready(Ok(0));
             }
 
             if sim.is_connection_closed(self.connection_id) {
@@ -258,7 +258,7 @@ impl AsyncRead for SimTcpStream {
                             "SimTcpStream::poll_read connection_id={} is closed gracefully (FIN), returning EOF (0 bytes)",
                             self.connection_id.0
                         );
-                        return Poll::Ready(Ok(()));
+                        return Poll::Ready(Ok(0));
                     }
                 }
             }
@@ -283,7 +283,7 @@ impl AsyncRead for SimTcpStream {
 
             // Double-check for data after registering waker to handle race conditions
             // This prevents deadlocks where DataDelivery arrives between initial check and waker registration
-            let mut temp_buf_recheck = vec![0u8; buf.remaining()];
+            let mut temp_buf_recheck = vec![0u8; buf.len()];
             let bytes_read_recheck = sim
                 .read_from_connection(self.connection_id, &mut temp_buf_recheck)
                 .map_err(|e| io::Error::other(format!("recheck read error: {}", e)))?;
@@ -297,8 +297,8 @@ impl AsyncRead for SimTcpStream {
                     self.connection_id.0,
                     data_preview
                 );
-                buf.put_slice(&temp_buf_recheck[..bytes_read_recheck]);
-                Poll::Ready(Ok(()))
+                buf[..bytes_read_recheck].copy_from_slice(&temp_buf_recheck[..bytes_read_recheck]);
+                Poll::Ready(Ok(bytes_read_recheck))
             } else {
                 // Final check - if connection has received FIN, is closed, or cut and no data available
 
@@ -308,7 +308,7 @@ impl AsyncRead for SimTcpStream {
                         "SimTcpStream::poll_read connection_id={} remote FIN received on recheck, returning EOF (0 bytes)",
                         self.connection_id.0
                     );
-                    return Poll::Ready(Ok(()));
+                    return Poll::Ready(Ok(0));
                 }
 
                 if sim.is_connection_closed(self.connection_id) {
@@ -325,7 +325,7 @@ impl AsyncRead for SimTcpStream {
                                 "SimTcpStream::poll_read connection_id={} is closed on recheck (FIN), returning EOF (0 bytes)",
                                 self.connection_id.0
                             );
-                            Poll::Ready(Ok(()))
+                            Poll::Ready(Ok(0))
                         }
                     }
                 } else if sim.is_connection_cut(self.connection_id) {
@@ -454,12 +454,12 @@ impl AsyncWrite for SimTcpStream {
         Poll::Ready(Ok(()))
     }
 
-    fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+    fn poll_close(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
         let sim = self.sim.upgrade().map_err(|_| sim_shutdown_error())?;
 
-        // Close the connection in the simulation when shutdown is called
+        // Close the connection in the simulation when close is called
         tracing::debug!(
-            "SimTcpStream::poll_shutdown closing connection {}",
+            "SimTcpStream::poll_close closing connection {}",
             self.connection_id.0
         );
         sim.close_connection(self.connection_id);

--- a/moonpool-sim/tests/chaos/bit_flip.rs
+++ b/moonpool-sim/tests/chaos/bit_flip.rs
@@ -7,11 +7,11 @@
 //! - Respects cooldown periods
 //! - Can be disabled via configuration
 
+use futures::io::{AsyncReadExt, AsyncWriteExt};
 use moonpool_sim::{
     NetworkConfiguration, NetworkProvider, SimWorld, TcpListenerTrait, buggify_init,
 };
 use std::time::Duration;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 /// Test that bit flipping is disabled when probability is 0.0
 #[test]

--- a/moonpool-sim/tests/chaos/connect_failure.rs
+++ b/moonpool-sim/tests/chaos/connect_failure.rs
@@ -271,7 +271,7 @@ fn test_connect_failure_deterministic() {
 /// Test connection failure doesn't affect already established connections
 #[test]
 fn test_connect_failure_existing_connections() {
-    use tokio::io::AsyncWriteExt;
+    use futures::io::AsyncWriteExt;
 
     let local_runtime = tokio::runtime::Builder::new_current_thread()
         .enable_io()

--- a/moonpool-sim/tests/chaos/random_close.rs
+++ b/moonpool-sim/tests/chaos/random_close.rs
@@ -8,11 +8,11 @@
 //! - Can be disabled via configuration
 //! - Are handled gracefully by the peer layer with reconnection
 
+use futures::io::{AsyncReadExt, AsyncWriteExt};
 use moonpool_sim::{
     NetworkConfiguration, NetworkProvider, SimWorld, TcpListenerTrait, buggify_init,
 };
 use std::time::Duration;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 /// Test that random close is disabled when probability is 0.0
 #[test]

--- a/moonpool-sim/tests/hyper_http.rs
+++ b/moonpool-sim/tests/hyper_http.rs
@@ -11,6 +11,7 @@ use hyper::body::Incoming;
 use hyper::service::service_fn;
 use hyper::{Request, Response, StatusCode};
 use hyper_util::rt::TokioIo;
+use tokio_util::compat::FuturesAsyncReadCompatExt;
 
 use moonpool_sim::{
     NetworkProvider, Process, SimContext, SimulationBuilder, SimulationReport, SimulationResult,
@@ -91,7 +92,7 @@ impl Process for HyperServer {
             _ = ctx.shutdown().cancelled() => return Ok(()),
         };
 
-        let io = TokioIo::new(stream);
+        let io = TokioIo::new(stream.compat());
 
         tokio::select! {
             result = hyper::server::conn::http1::Builder::new()
@@ -131,7 +132,7 @@ impl Workload for HyperClient {
             _ = ctx.shutdown().cancelled() => return Ok(()),
         };
 
-        let io = TokioIo::new(stream);
+        let io = TokioIo::new(stream.compat());
 
         let (mut sender, conn) = hyper::client::conn::http1::handshake(io)
             .await

--- a/moonpool-sim/tests/network/latency.rs
+++ b/moonpool-sim/tests/network/latency.rs
@@ -1,8 +1,8 @@
+use futures::io::AsyncWriteExt;
 use moonpool_sim::{
     ChaosConfiguration, NetworkConfiguration, NetworkProvider, SimWorld, TcpListenerTrait,
 };
 use std::time::Duration;
-use tokio::io::AsyncWriteExt;
 
 // Simple networking test that measures bind + connect + accept latency
 async fn simple_network_test<P>(provider: P, addr: &str) -> std::io::Result<()>

--- a/moonpool-sim/tests/network/traits.rs
+++ b/moonpool-sim/tests/network/traits.rs
@@ -1,5 +1,5 @@
+use futures::io::{AsyncReadExt, AsyncWriteExt};
 use moonpool_sim::{NetworkProvider, TcpListenerTrait, TokioNetworkProvider};
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 // Generic echo client that works with any NetworkProvider
 async fn echo_client<P>(provider: P, server_addr: &str, message: &str) -> std::io::Result<String>

--- a/moonpool-sim/tests/reboot.rs
+++ b/moonpool-sim/tests/reboot.rs
@@ -39,7 +39,7 @@ impl Process for EchoProcess {
             match result {
                 Ok((mut stream, _)) => {
                     // Simple echo: read and write back
-                    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+                    use futures::io::{AsyncReadExt, AsyncWriteExt};
                     let mut buf = [0u8; 64];
                     match stream.read(&mut buf).await {
                         Ok(n) if n > 0 => {
@@ -338,7 +338,7 @@ impl Process for GracefulProcess {
             tokio::select! {
                 result = listener.accept() => {
                     if let Ok((mut stream, _)) = result {
-                        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+                        use futures::io::{AsyncReadExt, AsyncWriteExt};
                         let mut buf = [0u8; 64];
                         if let Ok(n) = stream.read(&mut buf).await
                             && n > 0 {

--- a/moonpool-sim/tests/sim/integration.rs
+++ b/moonpool-sim/tests/sim/integration.rs
@@ -1,5 +1,5 @@
+use futures::io::AsyncWriteExt;
 use moonpool_sim::{NetworkConfiguration, NetworkProvider, SimWorld, TcpListenerTrait};
-use tokio::io::AsyncWriteExt;
 
 #[test]
 fn test_basic_simulation_bind() {

--- a/moonpool-transport/src/peer/core.rs
+++ b/moonpool-transport/src/peer/core.rs
@@ -3,11 +3,11 @@
 //!
 //! Provides wire format with UID-based endpoint addressing.
 
+use futures::io::{AsyncReadExt, AsyncWriteExt};
 use std::cell::RefCell;
 use std::collections::VecDeque;
 use std::rc::Rc;
 use std::time::Duration;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::{Notify, mpsc};
 use tokio::task::JoinHandle;
 

--- a/moonpool-transport/src/rpc/net_transport.rs
+++ b/moonpool-transport/src/rpc/net_transport.rs
@@ -1200,17 +1200,17 @@ mod tests {
     // Dummy stream type for the mock
     struct DummyStream;
 
-    impl tokio::io::AsyncRead for DummyStream {
+    impl futures::io::AsyncRead for DummyStream {
         fn poll_read(
             self: std::pin::Pin<&mut Self>,
             _cx: &mut std::task::Context<'_>,
-            _buf: &mut tokio::io::ReadBuf<'_>,
-        ) -> std::task::Poll<std::io::Result<()>> {
+            _buf: &mut [u8],
+        ) -> std::task::Poll<std::io::Result<usize>> {
             std::task::Poll::Ready(Err(std::io::Error::other("dummy stream")))
         }
     }
 
-    impl tokio::io::AsyncWrite for DummyStream {
+    impl futures::io::AsyncWrite for DummyStream {
         fn poll_write(
             self: std::pin::Pin<&mut Self>,
             _cx: &mut std::task::Context<'_>,
@@ -1226,7 +1226,7 @@ mod tests {
             std::task::Poll::Ready(Err(std::io::Error::other("dummy stream")))
         }
 
-        fn poll_shutdown(
+        fn poll_close(
             self: std::pin::Pin<&mut Self>,
             _cx: &mut std::task::Context<'_>,
         ) -> std::task::Poll<std::io::Result<()>> {

--- a/moonpool-transport/src/rpc/test_support.rs
+++ b/moonpool-transport/src/rpc/test_support.rs
@@ -29,17 +29,17 @@ pub struct MockNetworkProvider;
 
 pub struct DummyStream;
 
-impl tokio::io::AsyncRead for DummyStream {
+impl futures::io::AsyncRead for DummyStream {
     fn poll_read(
         self: std::pin::Pin<&mut Self>,
         _cx: &mut std::task::Context<'_>,
-        _buf: &mut tokio::io::ReadBuf<'_>,
-    ) -> std::task::Poll<std::io::Result<()>> {
+        _buf: &mut [u8],
+    ) -> std::task::Poll<std::io::Result<usize>> {
         std::task::Poll::Ready(Err(std::io::Error::other("dummy")))
     }
 }
 
-impl tokio::io::AsyncWrite for DummyStream {
+impl futures::io::AsyncWrite for DummyStream {
     fn poll_write(
         self: std::pin::Pin<&mut Self>,
         _cx: &mut std::task::Context<'_>,
@@ -53,7 +53,7 @@ impl tokio::io::AsyncWrite for DummyStream {
     ) -> std::task::Poll<std::io::Result<()>> {
         std::task::Poll::Ready(Err(std::io::Error::other("dummy")))
     }
-    fn poll_shutdown(
+    fn poll_close(
         self: std::pin::Pin<&mut Self>,
         _cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<std::io::Result<()>> {

--- a/moonpool-transport/tests/rpc_integration.rs
+++ b/moonpool-transport/tests/rpc_integration.rs
@@ -23,17 +23,17 @@ struct MockNetworkProvider;
 
 struct DummyStream;
 
-impl tokio::io::AsyncRead for DummyStream {
+impl futures::io::AsyncRead for DummyStream {
     fn poll_read(
         self: std::pin::Pin<&mut Self>,
         _cx: &mut std::task::Context<'_>,
-        _buf: &mut tokio::io::ReadBuf<'_>,
-    ) -> std::task::Poll<std::io::Result<()>> {
+        _buf: &mut [u8],
+    ) -> std::task::Poll<std::io::Result<usize>> {
         std::task::Poll::Ready(Err(std::io::Error::other("dummy")))
     }
 }
 
-impl tokio::io::AsyncWrite for DummyStream {
+impl futures::io::AsyncWrite for DummyStream {
     fn poll_write(
         self: std::pin::Pin<&mut Self>,
         _cx: &mut std::task::Context<'_>,
@@ -49,7 +49,7 @@ impl tokio::io::AsyncWrite for DummyStream {
         std::task::Poll::Ready(Err(std::io::Error::other("dummy")))
     }
 
-    fn poll_shutdown(
+    fn poll_close(
         self: std::pin::Pin<&mut Self>,
         _cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<std::io::Result<()>> {


### PR DESCRIPTION
NetworkProvider::TcpStream and TcpListenerTrait::TcpStream now require
futures::io::AsyncRead + AsyncWrite instead of tokio::io's variants. This
removes a tokio dependency from the abstraction so future non-tokio
providers (e.g., a WebSocket-tunneled stream for browser wasm) can
implement the trait without going through tokio.

Tokio compatibility is preserved by wrapping tokio::net::TcpStream with
tokio_util::compat::Compat in TokioNetworkProvider and TokioTcpListener.
The sim's SimTcpStream switches its AsyncRead/AsyncWrite impls to
futures::io: poll_read takes &mut [u8] -> Poll<Result<usize>> instead of
ReadBuf, and poll_shutdown is renamed to poll_close. The internal byte
plumbing (VecDeque<u8> backing, sim.read_from_connection) is unchanged.

Call sites that use IO extension methods on network streams swap from
tokio::io::{AsyncReadExt, AsyncWriteExt} to futures::io's equivalents
(method signatures are identical for read/write_all). The hyper-based
example (axum_web) and the hyper_http test bridge back to tokio::io via
.compat() before TokioIo::new(...), since hyper_util only accepts tokio's
IO traits. Three DummyStream test mocks switch their trait impls
accordingly.

StorageFile is intentionally left on tokio::io for a follow-up PR.

https://claude.ai/code/session_01PJ8fgGurw491tLDT2muhvS