### PR TITLE
refactor(core): switch StorageFile IO bounds to futures::io

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,8 @@
 ## Environment & Commands
 **Nix shell required**: `nix develop --command <cargo-command>`
 
+**Remote environments** (`CLAUDE_CODE_REMOTE=true`): nix is not preinstalled. Install it first via `DeterminateSystems/nix-installer` (or equivalent) so the validation commands below run with the same toolchain as CI. Without nix, `cargo nextest`, the `cargo` toolchain pinned by the flake, and the simulation binaries are unavailable, and local results will not match CI.
+
 **Validation**: All must pass before completing work:
 - `nix develop --command cargo fmt`
 - `nix develop --command cargo clippy`

--- a/moonpool-core/src/storage.rs
+++ b/moonpool-core/src/storage.rs
@@ -4,11 +4,12 @@
 //! between real Tokio file I/O and simulated storage for testing.
 
 use async_trait::async_trait;
+use futures::io::{AsyncRead, AsyncSeek, AsyncWrite};
 use std::io;
 use std::io::SeekFrom;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use tokio::io::{AsyncRead, AsyncSeek, AsyncWrite, ReadBuf};
+use tokio_util::compat::{Compat, TokioAsyncReadCompatExt};
 
 /// Options for opening a file.
 ///
@@ -162,7 +163,9 @@ impl StorageProvider for TokioStorageProvider {
             .append(options.append)
             .open(path)
             .await?;
-        Ok(TokioStorageFile { inner: file })
+        Ok(TokioStorageFile {
+            inner: file.compat(),
+        })
     }
 
     async fn exists(&self, path: &str) -> io::Result<bool> {
@@ -183,28 +186,35 @@ impl StorageProvider for TokioStorageProvider {
 }
 
 /// Wrapper for Tokio File to implement our trait.
+///
+/// Holds the underlying `tokio::fs::File` inside `tokio_util::compat::Compat`
+/// so the futures::io trait impls come through automatically. The four custom
+/// methods on [`StorageFile`] reach the inner [`tokio::fs::File`] via
+/// [`Compat::get_ref`] / [`Compat::get_mut`] to call tokio-specific APIs
+/// (`sync_all`, `sync_data`, `metadata`, `set_len`) that `Compat` itself
+/// does not expose.
 #[derive(Debug)]
 pub struct TokioStorageFile {
-    inner: tokio::fs::File,
+    inner: Compat<tokio::fs::File>,
 }
 
 #[async_trait(?Send)]
 impl StorageFile for TokioStorageFile {
     async fn sync_all(&self) -> io::Result<()> {
-        self.inner.sync_all().await
+        self.inner.get_ref().sync_all().await
     }
 
     async fn sync_data(&self) -> io::Result<()> {
-        self.inner.sync_data().await
+        self.inner.get_ref().sync_data().await
     }
 
     async fn size(&self) -> io::Result<u64> {
-        let metadata = self.inner.metadata().await?;
+        let metadata = self.inner.get_ref().metadata().await?;
         Ok(metadata.len())
     }
 
     async fn set_len(&self, size: u64) -> io::Result<()> {
-        self.inner.set_len(size).await
+        self.inner.get_ref().set_len(size).await
     }
 }
 
@@ -212,8 +222,8 @@ impl AsyncRead for TokioStorageFile {
     fn poll_read(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-        buf: &mut ReadBuf<'_>,
-    ) -> Poll<io::Result<()>> {
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
         Pin::new(&mut self.inner).poll_read(cx, buf)
     }
 }
@@ -231,17 +241,17 @@ impl AsyncWrite for TokioStorageFile {
         Pin::new(&mut self.inner).poll_flush(cx)
     }
 
-    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        Pin::new(&mut self.inner).poll_shutdown(cx)
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_close(cx)
     }
 }
 
 impl AsyncSeek for TokioStorageFile {
-    fn start_seek(mut self: Pin<&mut Self>, position: SeekFrom) -> io::Result<()> {
-        Pin::new(&mut self.inner).start_seek(position)
-    }
-
-    fn poll_complete(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<u64>> {
-        Pin::new(&mut self.inner).poll_complete(cx)
+    fn poll_seek(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        pos: SeekFrom,
+    ) -> Poll<io::Result<u64>> {
+        Pin::new(&mut self.inner).poll_seek(cx, pos)
     }
 }

--- a/moonpool-sim/src/storage/file.rs
+++ b/moonpool-sim/src/storage/file.rs
@@ -3,24 +3,15 @@
 use crate::sim::WeakSimWorld;
 use crate::sim::state::FileId;
 use async_trait::async_trait;
+use futures::io::{AsyncRead, AsyncSeek, AsyncWrite};
 use moonpool_core::StorageFile;
 use std::cell::Cell;
 use std::io::{self, SeekFrom};
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use tokio::io::{AsyncRead, AsyncSeek, AsyncWrite, ReadBuf};
 
 use super::futures::{SetLenFuture, SyncFuture};
 use super::sim_shutdown_error;
-
-/// State for an in-progress seek operation.
-#[derive(Debug, Clone, Copy)]
-enum SeekState {
-    /// No seek in progress.
-    Idle,
-    /// Seek requested, waiting to complete.
-    Seeking(u64),
-}
 
 /// Simulated storage file for deterministic testing.
 ///
@@ -48,8 +39,6 @@ pub struct SimStorageFile {
     pending_read: Cell<Option<(u64, u64, usize)>>,
     /// Pending write operation: (op_seq, bytes_written)
     pending_write: Cell<Option<(u64, usize)>>,
-    /// Current seek state
-    seek_state: Cell<SeekState>,
 }
 
 impl SimStorageFile {
@@ -60,7 +49,6 @@ impl SimStorageFile {
             file_id,
             pending_read: Cell::new(None),
             pending_write: Cell::new(None),
-            seek_state: Cell::new(SeekState::Idle),
         }
     }
 
@@ -96,8 +84,8 @@ impl AsyncRead for SimStorageFile {
     fn poll_read(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-        buf: &mut ReadBuf<'_>,
-    ) -> Poll<io::Result<()>> {
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
         let sim = self.sim.upgrade().map_err(|_| sim_shutdown_error())?;
 
         // Check for pending read operation
@@ -108,22 +96,20 @@ impl AsyncRead for SimStorageFile {
                 self.pending_read.set(None);
 
                 // Calculate how many bytes to actually read
-                let bytes_to_read = buf.remaining().min(len);
+                let bytes_to_read = buf.len().min(len);
                 if bytes_to_read == 0 {
-                    return Poll::Ready(Ok(()));
+                    return Poll::Ready(Ok(0));
                 }
 
                 // Read from file at the stored offset
-                let mut temp_buf = vec![0u8; bytes_to_read];
-                let bytes_read = sim.read_from_file(self.file_id, offset, &mut temp_buf)?;
+                let bytes_read =
+                    sim.read_from_file(self.file_id, offset, &mut buf[..bytes_to_read])?;
 
                 // Update file position
                 let new_position = offset + bytes_read as u64;
                 sim.set_file_position(self.file_id, new_position)?;
 
-                // Copy to output buffer
-                buf.put_slice(&temp_buf[..bytes_read]);
-                return Poll::Ready(Ok(()));
+                return Poll::Ready(Ok(bytes_read));
             }
 
             // Operation not complete, register waker and wait
@@ -141,15 +127,15 @@ impl AsyncRead for SimStorageFile {
 
         // Check for EOF
         if position >= file_size {
-            return Poll::Ready(Ok(())); // EOF - 0 bytes read
+            return Poll::Ready(Ok(0)); // EOF - 0 bytes read
         }
 
         // Calculate bytes to read (don't read past EOF)
         let remaining_in_file = (file_size - position) as usize;
-        let len = buf.remaining().min(remaining_in_file);
+        let len = buf.len().min(remaining_in_file);
 
         if len == 0 {
-            return Poll::Ready(Ok(()));
+            return Poll::Ready(Ok(0));
         }
 
         // Schedule the read operation
@@ -219,23 +205,25 @@ impl AsyncWrite for SimStorageFile {
         Poll::Ready(Ok(()))
     }
 
-    fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        // Shutdown is a no-op - file cleanup handled via Drop if needed
+    fn poll_close(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        // Close is a no-op - file cleanup handled via Drop if needed
         Poll::Ready(Ok(()))
     }
 }
 
 impl AsyncSeek for SimStorageFile {
-    fn start_seek(self: Pin<&mut Self>, position: SeekFrom) -> io::Result<()> {
+    fn poll_seek(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        pos: SeekFrom,
+    ) -> Poll<io::Result<u64>> {
         let sim = self.sim.upgrade().map_err(|_| sim_shutdown_error())?;
 
-        // Calculate target position
         let current_position = sim.file_position(self.file_id)?;
-
         let file_size = sim.file_size(self.file_id)?;
 
-        let target = match position {
-            SeekFrom::Start(pos) => pos,
+        let target = match pos {
+            SeekFrom::Start(p) => p,
             SeekFrom::End(offset) => {
                 if offset >= 0 {
                     file_size.saturating_add(offset as u64)
@@ -252,26 +240,7 @@ impl AsyncSeek for SimStorageFile {
             }
         };
 
-        // Store the seek state
-        self.seek_state.set(SeekState::Seeking(target));
-        Ok(())
-    }
-
-    fn poll_complete(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<u64>> {
-        let sim = self.sim.upgrade().map_err(|_| sim_shutdown_error())?;
-
-        match self.seek_state.get() {
-            SeekState::Idle => {
-                // No seek in progress, return current position
-                let position = sim.file_position(self.file_id)?;
-                Poll::Ready(Ok(position))
-            }
-            SeekState::Seeking(target) => {
-                // Complete the seek by setting the position
-                sim.set_file_position(self.file_id, target)?;
-                self.seek_state.set(SeekState::Idle);
-                Poll::Ready(Ok(target))
-            }
-        }
+        sim.set_file_position(self.file_id, target)?;
+        Poll::Ready(Ok(target))
     }
 }

--- a/moonpool-sim/tests/storage/basic.rs
+++ b/moonpool-sim/tests/storage/basic.rs
@@ -3,11 +3,11 @@
 //! Tests fundamental storage operations: read, write, seek, size, truncate, sync,
 //! and file management (create, delete, rename).
 
+use futures::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 use moonpool_core::{OpenOptions, StorageFile, StorageProvider};
 use moonpool_sim::{SimWorld, StorageConfiguration};
 use std::io::SeekFrom;
 use std::net::IpAddr;
-use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 
 const TEST_IP_STR: &str = "127.0.0.1";
 

--- a/moonpool-sim/tests/storage/concurrent.rs
+++ b/moonpool-sim/tests/storage/concurrent.rs
@@ -4,10 +4,10 @@
 //! without interference, similar to how network tests verify multiple
 //! connections work independently.
 
+use futures::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 use moonpool_core::{OpenOptions, StorageFile, StorageProvider};
 use moonpool_sim::{SimWorld, StorageConfiguration};
 use std::net::IpAddr;
-use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 
 const TEST_IP_STR: &str = "127.0.0.1";
 

--- a/moonpool-sim/tests/storage/crash_api.rs
+++ b/moonpool-sim/tests/storage/crash_api.rs
@@ -4,10 +4,10 @@
 //! following the same pattern as `network/partition.rs` tests
 //! for `sim.partition_pair()`.
 
+use futures::io::{AsyncReadExt, AsyncWriteExt};
 use moonpool_core::{OpenOptions, StorageFile, StorageProvider};
 use moonpool_sim::{SimWorld, StorageConfiguration};
 use std::net::IpAddr;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 const TEST_IP_STR: &str = "127.0.0.1";
 

--- a/moonpool-sim/tests/storage/determinism.rs
+++ b/moonpool-sim/tests/storage/determinism.rs
@@ -3,11 +3,11 @@
 //! These tests verify that the storage simulation produces deterministic
 //! behavior when run with the same seed.
 
+use futures::io::{AsyncReadExt, AsyncWriteExt};
 use moonpool_core::{OpenOptions, StorageFile, StorageProvider};
 use moonpool_sim::{SimWorld, StorageConfiguration};
 use std::net::IpAddr;
 use std::time::Duration;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 const TEST_IP_STR: &str = "127.0.0.1";
 

--- a/moonpool-sim/tests/storage/faults.rs
+++ b/moonpool-sim/tests/storage/faults.rs
@@ -3,10 +3,10 @@
 //! These tests verify that the fault injection mechanisms work correctly
 //! for various failure modes.
 
+use futures::io::{AsyncReadExt, AsyncWriteExt};
 use moonpool_core::{OpenOptions, StorageFile, StorageProvider};
 use moonpool_sim::{SimWorld, StorageConfiguration};
 use std::net::IpAddr;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 const TEST_IP_STR: &str = "127.0.0.1";
 

--- a/moonpool-sim/tests/storage/latency.rs
+++ b/moonpool-sim/tests/storage/latency.rs
@@ -3,11 +3,11 @@
 //! These tests verify that storage operations respect configured latencies
 //! and follow the FDB latency formula: base_latency + 1/iops + size/bandwidth
 
+use futures::io::{AsyncReadExt, AsyncWriteExt};
 use moonpool_core::{OpenOptions, StorageFile, StorageProvider};
 use moonpool_sim::{SimWorld, StorageConfiguration};
 use std::net::IpAddr;
 use std::time::Duration;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 const TEST_IP_STR: &str = "127.0.0.1";
 

--- a/moonpool-sim/tests/storage/performance.rs
+++ b/moonpool-sim/tests/storage/performance.rs
@@ -4,11 +4,11 @@
 //! IOPS limits and bandwidth constraints following the latency formula:
 //! `total_latency = base_latency + 1/iops + size/bandwidth`
 
+use futures::io::{AsyncReadExt, AsyncWriteExt};
 use moonpool_core::{OpenOptions, StorageFile, StorageProvider};
 use moonpool_sim::{SimWorld, StorageConfiguration};
 use std::net::IpAddr;
 use std::time::Duration;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 const TEST_IP_STR: &str = "127.0.0.1";
 

--- a/moonpool-sim/tests/storage/recovery.rs
+++ b/moonpool-sim/tests/storage/recovery.rs
@@ -4,10 +4,10 @@
 //! across crash scenarios, following patterns from TigerBeetle and
 //! FoundationDB's crash consistency testing.
 
+use futures::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 use moonpool_core::{OpenOptions, StorageFile, StorageProvider};
 use moonpool_sim::{SimWorld, StorageConfiguration};
 use std::net::IpAddr;
-use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 
 const TEST_IP_STR: &str = "127.0.0.1";
 

--- a/moonpool-sim/tests/storage/tokio_provider.rs
+++ b/moonpool-sim/tests/storage/tokio_provider.rs
@@ -4,10 +4,10 @@
 //! actual filesystem operations, following the same pattern as network/traits.rs
 //! for TokioNetworkProvider.
 
+use futures::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 use moonpool_core::{OpenOptions, StorageFile, StorageProvider, TokioStorageProvider};
 use std::io::SeekFrom;
 use tempfile::TempDir;
-use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 
 /// Helper to create a local runtime for tests.
 fn local_runtime() -> tokio::runtime::LocalRuntime {


### PR DESCRIPTION
StorageFile and StorageProvider::File now require futures::io::AsyncRead
+ AsyncWrite + AsyncSeek instead of tokio::io's variants. This removes
a tokio dependency from the abstraction so future non-tokio storage
providers (e.g. wasm OPFS) can implement the trait without going through
tokio. The four custom methods on StorageFile (sync_all, sync_data,
size, set_len) are unchanged, as are StorageProvider's open / exists /
delete / rename signatures.

Tokio compatibility is preserved by wrapping tokio::fs::File in
tokio_util::compat::Compat inside TokioStorageFile. The tokio-specific
methods (sync_all, sync_data, metadata, set_len) reach the inner
tokio::fs::File via Compat::get_ref, since Compat does not expose them.

The sim's SimStorageFile switches its AsyncRead / AsyncWrite / AsyncSeek
impls to futures::io: poll_read takes &mut [u8] -> Poll<Result<usize>>
instead of ReadBuf, poll_shutdown is renamed to poll_close, and the
previous start_seek + poll_complete pair collapses into a single
poll_seek that completes synchronously (the sim's seek was already
zero-latency, so dropping the SeekState cell is safe). The internal
file-id, position, and pending-op plumbing is unchanged.

Storage integration tests swap their tokio::io::{AsyncReadExt,
AsyncWriteExt, AsyncSeekExt} imports for the futures::io equivalents.
Method signatures are identical so no call sites change.

NetworkProvider was migrated in the previous PR and is left alone.

https://claude.ai/code/session_01PJ8fgGurw491tLDT2muhvS