### PR TITLE
feat(sim): add CoveragePlateau iteration control

### DIFF
--- a/book/src/part3-building/04-simulation-builder.md
+++ b/book/src/part3-building/04-simulation-builder.md
@@ -49,6 +49,12 @@ One iteration is not enough. Different seeds produce different scheduling orders
 .set_time_limit(Duration::from_secs(60))
 ```
 
+**Coverage plateau** stops once `assert_sometimes!` and `assert_reachable!` coverage has not grown for a configurable number of consecutive seeds. Useful when you want chaos to run as long as it keeps finding new behaviour and stop automatically once it does not:
+
+```rust
+.until_coverage_plateau(50, 5_000)  // 50 plateau seeds, 5_000 safety cap
+```
+
 Each iteration gets a different seed, producing a different execution. The seeds are deterministic and derived from the iteration manager, so the same configuration always explores the same seeds.
 
 ## Seed Control

--- a/book/src/part3-building/05-running.md
+++ b/book/src/part3-building/05-running.md
@@ -140,6 +140,27 @@ The debugging workflow:
 5. **Fix** the root cause in the Process code
 6. **Verify** by running the full iteration suite again
 
+## Stop Conditions
+
+How long should a chaos run last? Moonpool exposes four answers via `IterationControl`, each suited to a different question.
+
+**`FixedCount(n)`** is the workhorse for CI. You commit to running exactly `n` seeds, the duration is bounded, and the report is reproducible across machines. Reach for this when budgets are predictable.
+
+**`TimeLimit(d)`** is the answer when "as much chaos as we have time for" is the right framing. Long-running soak runs and overnight loops use this. The seed count is unbounded but the wall clock is.
+
+**`UntilConverged { max_iterations }`** stops when every `assert_sometimes!` has fired at least once **and** the explorer's coverage bitmap stopped growing on the latest seed. It requires `.enable_exploration()` because it reads the fork-aware coverage map. Use it when you have configured exploration and want the run to end as soon as it has nothing left to discover.
+
+**`CoveragePlateau { plateau_seeds, require_all_sometimes, max_iterations }`** is the more general plateau detector. It tracks the set of `assert_sometimes!` / `assert_reachable!` messages that have ever fired and stops once that set has not grown for `plateau_seeds` consecutive seeds. The signal lives in moonpool-sim, so this works **with or without** fork-based exploration. Set `require_all_sometimes=true` if you want to refuse to stop until every observed sometimes assertion has fired at least once.
+
+```rust
+SimulationBuilder::new()
+    .workload(KvWorkload::new(200, keys))
+    .until_coverage_plateau(50, 5_000)
+    .run();
+```
+
+Both `UntilConverged` and `CoveragePlateau` set `report.convergence_timeout = true` when the safety cap is hit before the run converges, so CI can fail loudly instead of silently treating "we ran out of seeds" as success.
+
 ## cargo nextest vs cargo xtask sim
 
 Moonpool has two ways to run tests:

--- a/moonpool-sim/src/runner/builder.rs
+++ b/moonpool-sim/src/runner/builder.rs
@@ -53,6 +53,19 @@ pub enum IterationControl {
         /// Maximum number of seeds before stopping regardless.
         max_iterations: usize,
     },
+    /// Stop after `plateau_seeds` consecutive seeds have added no new
+    /// `assert_sometimes!` / `assert_reachable!` coverage. Works with or
+    /// without [`SimulationBuilder::enable_exploration`]: the underlying
+    /// assertion table is initialised unconditionally.
+    CoveragePlateau {
+        /// Number of consecutive seeds without coverage growth required to stop.
+        plateau_seeds: usize,
+        /// If true, additionally require every observed sometimes/reachable
+        /// assertion to have fired at least once before stopping.
+        require_all_sometimes: bool,
+        /// Maximum number of seeds before stopping regardless (safety cap).
+        max_iterations: usize,
+    },
 }
 
 /// How many instances of a workload to spawn per iteration.
@@ -485,6 +498,38 @@ impl SimulationBuilder {
         self
     }
 
+    /// Run until `assert_sometimes!` / `assert_reachable!` coverage has not
+    /// grown for `plateau_seeds` consecutive seeds.
+    ///
+    /// Works with or without [`SimulationBuilder::enable_exploration`].
+    /// `max_iterations` is a safety cap to prevent infinite loops when the
+    /// plateau is never reached.
+    pub fn until_coverage_plateau(mut self, plateau_seeds: usize, max_iterations: usize) -> Self {
+        self.iteration_control = IterationControl::CoveragePlateau {
+            plateau_seeds,
+            require_all_sometimes: false,
+            max_iterations,
+        };
+        self
+    }
+
+    /// Like [`Self::until_coverage_plateau`] but also lets the caller require
+    /// every observed sometimes/reachable assertion to have fired before the
+    /// plateau is allowed to terminate the run.
+    pub fn until_coverage_plateau_with(
+        mut self,
+        plateau_seeds: usize,
+        require_all_sometimes: bool,
+        max_iterations: usize,
+    ) -> Self {
+        self.iteration_control = IterationControl::CoveragePlateau {
+            plateau_seeds,
+            require_all_sometimes,
+            max_iterations,
+        };
+        self
+    }
+
     /// Register a callback invoked at the start of each simulation iteration.
     ///
     /// Use this to reset shared state (directories, membership, stores) that
@@ -625,11 +670,15 @@ impl SimulationBuilder {
         let mut bug_recipes: Vec<super::report::BugRecipe> = Vec::new();
         let mut per_seed_timelines: Vec<u64> = Vec::new();
 
-        // Convergence tracking (used only with UntilConverged)
+        // Convergence tracking (used by UntilConverged and CoveragePlateau)
         let mut reached_sometimes: std::collections::HashSet<String> =
             std::collections::HashSet::new();
         let mut prev_coverage_bits: u32 = 0;
         let mut converged = false;
+
+        // Plateau tracking (used only with CoveragePlateau)
+        let mut plateau_count: usize = 0;
+        let mut prev_reached_count: usize = 0;
 
         // Install the observability layer once for the entire run. The guard
         // is dropped when run() returns, restoring the previous subscriber.
@@ -902,11 +951,13 @@ impl SimulationBuilder {
             }
 
             // Accumulate which Sometimes/Reachable assertions have been reached
-            // (must read before next prepare_next_seed resets pass_count)
-            if matches!(
+            // (must read before next prepare_next_seed resets pass_count).
+            // Used by both UntilConverged and CoveragePlateau stop conditions.
+            let needs_assertion_scan = matches!(
                 self.iteration_control,
-                IterationControl::UntilConverged { .. }
-            ) {
+                IterationControl::UntilConverged { .. } | IterationControl::CoveragePlateau { .. }
+            );
+            if needs_assertion_scan {
                 let slots = moonpool_explorer::assertion_read_all();
                 for slot in &slots {
                     if let Some(kind) = moonpool_explorer::AssertKind::from_u8(slot.kind)
@@ -930,47 +981,88 @@ impl SimulationBuilder {
                     }
                 }
 
-                // Check convergence from seed 2 onward (need baseline for coverage delta)
-                if iteration_count >= 2 {
-                    // Count unique message strings (not raw slots) to handle
-                    // any residual duplicate slots from the fork allocation race.
-                    let all_sometimes_count = slots
-                        .iter()
-                        .filter(|s| {
-                            moonpool_explorer::AssertKind::from_u8(s.kind)
-                                .map(|k| {
-                                    matches!(
-                                        k,
-                                        moonpool_explorer::AssertKind::Sometimes
-                                            | moonpool_explorer::AssertKind::Reachable
-                                    )
-                                })
-                                .unwrap_or(false)
-                        })
-                        .map(|s| s.msg.clone())
-                        .collect::<std::collections::HashSet<_>>()
-                        .len();
-                    let all_reached =
-                        all_sometimes_count > 0 && reached_sometimes.len() >= all_sometimes_count;
+                // Count unique message strings (not raw slots) to handle
+                // any residual duplicate slots from the fork allocation race.
+                let all_sometimes_count = slots
+                    .iter()
+                    .filter(|s| {
+                        moonpool_explorer::AssertKind::from_u8(s.kind)
+                            .map(|k| {
+                                matches!(
+                                    k,
+                                    moonpool_explorer::AssertKind::Sometimes
+                                        | moonpool_explorer::AssertKind::Reachable
+                                )
+                            })
+                            .unwrap_or(false)
+                    })
+                    .map(|s| s.msg.clone())
+                    .collect::<std::collections::HashSet<_>>()
+                    .len();
 
-                    let current_bits = moonpool_explorer::explored_map_bits_set().unwrap_or(0);
-                    let no_new_coverage = current_bits == prev_coverage_bits;
+                if let IterationControl::UntilConverged { .. } = self.iteration_control {
+                    // Check convergence from seed 2 onward (need baseline for coverage delta)
+                    if iteration_count >= 2 {
+                        let all_reached = all_sometimes_count > 0
+                            && reached_sometimes.len() >= all_sometimes_count;
+
+                        let current_bits = moonpool_explorer::explored_map_bits_set().unwrap_or(0);
+                        let no_new_coverage = current_bits == prev_coverage_bits;
+
+                        tracing::warn!(
+                            "convergence: seed={} reached={}/{} coverage={}->{} delta={}",
+                            iteration_count,
+                            reached_sometimes.len(),
+                            all_sometimes_count,
+                            prev_coverage_bits,
+                            current_bits,
+                            current_bits.saturating_sub(prev_coverage_bits),
+                        );
+
+                        if all_reached && no_new_coverage {
+                            tracing::info!(
+                                "Converged after {} seeds: all {} sometimes reached, no new coverage",
+                                iteration_count,
+                                all_sometimes_count
+                            );
+                            converged = true;
+                        }
+                    }
+                } else if let IterationControl::CoveragePlateau {
+                    plateau_seeds,
+                    require_all_sometimes,
+                    ..
+                } = self.iteration_control
+                {
+                    let current_count = reached_sometimes.len();
+                    if iteration_count == 1 {
+                        prev_reached_count = current_count;
+                    } else if current_count == prev_reached_count {
+                        plateau_count += 1;
+                    } else {
+                        plateau_count = 0;
+                        prev_reached_count = current_count;
+                    }
+
+                    let all_reached = !require_all_sometimes
+                        || (all_sometimes_count > 0
+                            && reached_sometimes.len() >= all_sometimes_count);
 
                     tracing::warn!(
-                        "convergence: seed={} reached={}/{} coverage={}->{} delta={}",
+                        "plateau: seed={} reached={}/{} consecutive_no_growth={}/{}",
                         iteration_count,
-                        reached_sometimes.len(),
+                        current_count,
                         all_sometimes_count,
-                        prev_coverage_bits,
-                        current_bits,
-                        current_bits.saturating_sub(prev_coverage_bits),
+                        plateau_count,
+                        plateau_seeds,
                     );
 
-                    if all_reached && no_new_coverage {
+                    if plateau_count >= plateau_seeds && all_reached {
                         tracing::info!(
-                            "Converged after {} seeds: all {} sometimes reached, no new coverage",
+                            "Coverage plateau after {} seeds: {} consecutive without growth, {} sometimes reached",
                             iteration_count,
-                            all_sometimes_count
+                            plateau_count,
+                            current_count
                         );
                         converged = true;
                     }
@@ -1047,10 +1139,11 @@ impl SimulationBuilder {
 
         let iteration_count = iteration_manager.current_iteration();
 
-        // Detect convergence timeout: UntilConverged was used but we didn't converge
+        // Detect convergence timeout: a convergence-style stop condition was
+        // used but the safety cap was hit before we converged / plateaued.
         let convergence_timeout = matches!(
             self.iteration_control,
-            IterationControl::UntilConverged { .. }
+            IterationControl::UntilConverged { .. } | IterationControl::CoveragePlateau { .. }
         ) && !converged;
 
         // Final buggify reset to ensure no impact on subsequent code

--- a/moonpool-sim/src/runner/orchestrator.rs
+++ b/moonpool-sim/src/runner/orchestrator.rs
@@ -929,6 +929,9 @@ impl IterationManager {
             super::builder::IterationControl::UntilConverged { max_iterations } => {
                 self.iteration_count < *max_iterations
             }
+            super::builder::IterationControl::CoveragePlateau { max_iterations, .. } => {
+                self.iteration_count < *max_iterations
+            }
         }
     }
 
@@ -960,6 +963,8 @@ impl IterationManager {
                 super::builder::IterationControl::UntilConverged { max_iterations } => {
                     *max_iterations
                 }
+                super::builder::IterationControl::CoveragePlateau { max_iterations, .. } =>
+                    *max_iterations,
             }
         );
 
@@ -977,6 +982,9 @@ impl IterationManager {
             super::builder::IterationControl::FixedCount(count) => Some(*count),
             super::builder::IterationControl::TimeLimit(_) => None,
             super::builder::IterationControl::UntilConverged { max_iterations } => {
+                Some(*max_iterations)
+            }
+            super::builder::IterationControl::CoveragePlateau { max_iterations, .. } => {
                 Some(*max_iterations)
             }
         }

--- a/moonpool-sim/tests/coverage_plateau.rs
+++ b/moonpool-sim/tests/coverage_plateau.rs
@@ -1,0 +1,133 @@
+//! Integration tests for the `IterationControl::CoveragePlateau` stop condition.
+//!
+//! These exercise the runner's ability to terminate early when
+//! `assert_sometimes!` / `assert_reachable!` coverage stops growing,
+//! both with and without fork-based exploration enabled.
+
+use async_trait::async_trait;
+use moonpool_sim::{
+    ExplorationConfig, SimContext, SimulationBuilder, SimulationReport, SimulationResult, Workload,
+};
+
+fn run_simulation(builder: SimulationBuilder) -> SimulationReport {
+    builder.run()
+}
+
+/// Workload firing three sometimes assertions deterministically. The full
+/// coverage surface is exhausted after the first seed.
+struct ThreeAlwaysHitWorkload;
+
+#[async_trait(?Send)]
+impl Workload for ThreeAlwaysHitWorkload {
+    fn name(&self) -> &str {
+        "client"
+    }
+
+    async fn run(&mut self, _ctx: &SimContext) -> SimulationResult<()> {
+        moonpool_sim::assert_sometimes!(true, "gate 1");
+        moonpool_sim::assert_sometimes!(true, "gate 2");
+        moonpool_sim::assert_sometimes!(true, "gate 3");
+        Ok(())
+    }
+}
+
+/// Workload whose third assertion only fires in roughly 1-in-5 seeds.
+/// `require_all_sometimes=true` should refuse to stop until it has hit.
+struct RareGateWorkload;
+
+#[async_trait(?Send)]
+impl Workload for RareGateWorkload {
+    fn name(&self) -> &str {
+        "client"
+    }
+
+    async fn run(&mut self, _ctx: &SimContext) -> SimulationResult<()> {
+        moonpool_sim::assert_sometimes!(true, "gate 1");
+        moonpool_sim::assert_sometimes!(true, "gate 2");
+        let rare = moonpool_sim::sim_random_range(0u32..5) == 0;
+        moonpool_sim::assert_sometimes!(rare, "rare gate");
+        Ok(())
+    }
+}
+
+/// With no exploration enabled, plateau detection should still fire because
+/// the assertion table is initialised unconditionally.
+#[test]
+fn test_plateau_no_exploration() {
+    let report = run_simulation(
+        SimulationBuilder::new()
+            .until_coverage_plateau(3, 100)
+            .workload(ThreeAlwaysHitWorkload),
+    );
+
+    assert!(
+        report.iterations < 100,
+        "plateau should stop early; ran {} iterations",
+        report.iterations
+    );
+    assert!(
+        report.iterations >= 4,
+        "need at least seed 1 + 3 plateau seeds; got {}",
+        report.iterations
+    );
+    assert!(
+        !report.convergence_timeout,
+        "should not be marked as a convergence timeout"
+    );
+    assert_eq!(report.failed_runs, 0);
+}
+
+/// Same condition with exploration enabled — children write into the shared
+/// assertion table, so the plateau accumulator sees the full coverage too.
+#[test]
+fn test_plateau_with_exploration() {
+    let report = run_simulation(
+        SimulationBuilder::new()
+            .enable_exploration(ExplorationConfig {
+                max_depth: 1,
+                timelines_per_split: 2,
+                global_energy: 20,
+                adaptive: None,
+                parallelism: None,
+            })
+            .until_coverage_plateau(3, 100)
+            .workload(ThreeAlwaysHitWorkload),
+    );
+
+    assert!(
+        report.iterations < 100,
+        "plateau should stop early; ran {} iterations",
+        report.iterations
+    );
+    assert!(
+        !report.convergence_timeout,
+        "should not be marked as a convergence timeout"
+    );
+    assert_eq!(report.failed_runs, 0);
+}
+
+/// With `require_all_sometimes=true`, the runner must keep going until the
+/// rare gate has fired even if the other two assertions plateaued early.
+#[test]
+fn test_plateau_requires_all_sometimes() {
+    let report = run_simulation(
+        SimulationBuilder::new()
+            .until_coverage_plateau_with(2, true, 200)
+            .workload(RareGateWorkload),
+    );
+
+    assert!(
+        !report.convergence_timeout,
+        "rare gate should fire within 200 seeds; got convergence_timeout={}",
+        report.convergence_timeout
+    );
+
+    let rare_hit = report
+        .assertion_details
+        .iter()
+        .any(|d| d.msg == "rare gate" && d.pass_count > 0);
+    assert!(
+        rare_hit,
+        "expected the rare gate to have fired before stopping"
+    );
+}


### PR DESCRIPTION
Add a new `IterationControl::CoveragePlateau` variant that stops the runner
once `assert_sometimes!` / `assert_reachable!` coverage has not grown for a
configurable number of consecutive seeds. Unlike `UntilConverged`, it does
not require `enable_exploration()`: the assertion table is initialised
unconditionally, so the same plateau signal works with or without forks.

The trigger is configurable via `until_coverage_plateau_with` so callers can
optionally require every observed sometimes assertion to have fired before
stopping.

https://claude.ai/code/session_013HNbLbAqZ4uZK6Ryp5Xmc2