### PR TITLE
refactor(xtask): elide lifetime and remove redundant arg allocations

### DIFF
--- a/moonpool-core/src/network.rs
+++ b/moonpool-core/src/network.rs
@@ -55,7 +55,7 @@ pub trait TcpListenerTrait: Send + Sync + 'static {
 /// implements the runtime-agnostic `futures::io::AsyncRead + AsyncWrite` traits
 /// required by [`NetworkProvider`].
 #[cfg(feature = "tokio-providers")]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct TokioNetworkProvider;
 
 #[cfg(feature = "tokio-providers")]
@@ -64,13 +64,6 @@ impl TokioNetworkProvider {
     #[must_use]
     pub fn new() -> Self {
         Self
-    }
-}
-
-#[cfg(feature = "tokio-providers")]
-impl Default for TokioNetworkProvider {
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/moonpool-core/src/providers.rs
+++ b/moonpool-core/src/providers.rs
@@ -40,6 +40,56 @@ use crate::{
     TokioTimeProvider,
 };
 
+/// Implement [`Providers`] for a struct whose fields are named
+/// `network`, `time`, `task`, `random`, `storage` — the five canonical
+/// provider slots.
+///
+/// Expands to the trait impl plus the five trivial getter forwards. The
+/// type of each slot is specified once in the macro invocation, so the
+/// implementing struct does not have to repeat the field-to-type mapping
+/// in the trait body.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! impl_providers_bundle {
+    (
+        $struct:ty {
+            network: $network_ty:ty,
+            time: $time_ty:ty,
+            task: $task_ty:ty,
+            random: $random_ty:ty,
+            storage: $storage_ty:ty $(,)?
+        }
+    ) => {
+        impl $crate::Providers for $struct {
+            type Network = $network_ty;
+            type Time = $time_ty;
+            type Task = $task_ty;
+            type Random = $random_ty;
+            type Storage = $storage_ty;
+
+            fn network(&self) -> &Self::Network {
+                &self.network
+            }
+
+            fn time(&self) -> &Self::Time {
+                &self.time
+            }
+
+            fn task(&self) -> &Self::Task {
+                &self.task
+            }
+
+            fn random(&self) -> &Self::Random {
+                &self.random
+            }
+
+            fn storage(&self) -> &Self::Storage {
+                &self.storage
+            }
+        }
+    };
+}
+
 /// Bundle of all provider types for a runtime environment.
 ///
 /// This trait consolidates the five provider types ([`NetworkProvider`],
@@ -143,30 +193,10 @@ impl Default for TokioProviders {
 }
 
 #[cfg(feature = "tokio-providers")]
-impl Providers for TokioProviders {
-    type Network = TokioNetworkProvider;
-    type Time = TokioTimeProvider;
-    type Task = TokioTaskProvider;
-    type Random = TokioRandomProvider;
-    type Storage = TokioStorageProvider;
-
-    fn network(&self) -> &Self::Network {
-        &self.network
-    }
-
-    fn time(&self) -> &Self::Time {
-        &self.time
-    }
-
-    fn task(&self) -> &Self::Task {
-        &self.task
-    }
-
-    fn random(&self) -> &Self::Random {
-        &self.random
-    }
-
-    fn storage(&self) -> &Self::Storage {
-        &self.storage
-    }
-}
+impl_providers_bundle!(TokioProviders {
+    network: TokioNetworkProvider,
+    time: TokioTimeProvider,
+    task: TokioTaskProvider,
+    random: TokioRandomProvider,
+    storage: TokioStorageProvider,
+});

--- a/moonpool-core/src/storage.rs
+++ b/moonpool-core/src/storage.rs
@@ -47,42 +47,38 @@ impl OpenOptions {
         }
         self
     }
+}
 
+macro_rules! flag_setters {
+    ($($(#[$attr:meta])* $name:ident => $flag:ident),* $(,)?) => {
+        impl OpenOptions {
+            $(
+                $(#[$attr])*
+                #[must_use]
+                pub fn $name(self, value: bool) -> Self {
+                    self.set_flag(Self::$flag, value)
+                }
+            )*
+        }
+    };
+}
+
+flag_setters! {
     /// Set the read flag.
-    #[must_use]
-    pub fn read(self, read: bool) -> Self {
-        self.set_flag(Self::FLAG_READ, read)
-    }
-
+    read => FLAG_READ,
     /// Set the write flag.
-    #[must_use]
-    pub fn write(self, write: bool) -> Self {
-        self.set_flag(Self::FLAG_WRITE, write)
-    }
-
+    write => FLAG_WRITE,
     /// Set the create flag.
-    #[must_use]
-    pub fn create(self, create: bool) -> Self {
-        self.set_flag(Self::FLAG_CREATE, create)
-    }
-
+    create => FLAG_CREATE,
     /// Set the `create_new` flag.
-    #[must_use]
-    pub fn create_new(self, create_new: bool) -> Self {
-        self.set_flag(Self::FLAG_CREATE_NEW, create_new)
-    }
-
+    create_new => FLAG_CREATE_NEW,
     /// Set the truncate flag.
-    #[must_use]
-    pub fn truncate(self, truncate: bool) -> Self {
-        self.set_flag(Self::FLAG_TRUNCATE, truncate)
-    }
-
+    truncate => FLAG_TRUNCATE,
     /// Set the append flag.
-    #[must_use]
-    pub fn append(self, append: bool) -> Self {
-        self.set_flag(Self::FLAG_APPEND, append)
-    }
+    append => FLAG_APPEND,
+}
+
+impl OpenOptions {
 
     /// Returns true if the file will be opened for reading.
     #[must_use]

--- a/moonpool-core/src/storage.rs
+++ b/moonpool-core/src/storage.rs
@@ -180,7 +180,7 @@ pub trait StorageFile: AsyncRead + AsyncWrite + AsyncSeek + Unpin + Send + Sync 
 
 /// Real Tokio storage implementation.
 #[cfg(feature = "tokio-providers")]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct TokioStorageProvider;
 
 #[cfg(feature = "tokio-providers")]
@@ -189,13 +189,6 @@ impl TokioStorageProvider {
     #[must_use]
     pub fn new() -> Self {
         Self
-    }
-}
-
-#[cfg(feature = "tokio-providers")]
-impl Default for TokioStorageProvider {
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/moonpool-core/src/storage.rs
+++ b/moonpool-core/src/storage.rs
@@ -79,7 +79,6 @@ flag_setters! {
 }
 
 impl OpenOptions {
-
     /// Returns true if the file will be opened for reading.
     #[must_use]
     pub fn is_read(&self) -> bool {

--- a/moonpool-sim-examples/src/bin/sim/axum_web.rs
+++ b/moonpool-sim-examples/src/bin/sim/axum_web.rs
@@ -8,12 +8,11 @@ use std::process;
 fn main() {
     moonpool_sim::init_sim_tracing(tracing::Level::WARN);
 
-    let report = moonpool_sim::simulations::run_simulation(
-        moonpool_sim::SimulationBuilder::new()
-            .processes(1, || Box::new(moonpool_sim_examples::axum_web::WebProcess))
-            .workload(moonpool_sim_examples::axum_web::WebWorkload)
-            .set_iterations(50),
-    );
+    let report = moonpool_sim::SimulationBuilder::new()
+        .processes(1, || Box::new(moonpool_sim_examples::axum_web::WebProcess))
+        .workload(moonpool_sim_examples::axum_web::WebWorkload)
+        .set_iterations(50)
+        .run();
 
     report.eprint();
 

--- a/moonpool-sim-examples/src/bin/sim/axum_web.rs
+++ b/moonpool-sim-examples/src/bin/sim/axum_web.rs
@@ -6,9 +6,7 @@
 use std::process;
 
 fn main() {
-    let _ = tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::WARN)
-        .try_init();
+    moonpool_sim::init_sim_tracing(tracing::Level::WARN);
 
     let report = moonpool_sim::simulations::run_simulation(
         moonpool_sim::SimulationBuilder::new()

--- a/moonpool-sim-examples/src/bin/sim/dungeon_explore.rs
+++ b/moonpool-sim-examples/src/bin/sim/dungeon_explore.rs
@@ -6,9 +6,7 @@
 use std::process;
 
 fn main() {
-    let _ = tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::WARN)
-        .try_init();
+    moonpool_sim::init_sim_tracing(tracing::Level::WARN);
 
     let report = moonpool_sim::simulations::run_simulation(
         moonpool_sim::SimulationBuilder::new()

--- a/moonpool-sim-examples/src/bin/sim/dungeon_explore.rs
+++ b/moonpool-sim-examples/src/bin/sim/dungeon_explore.rs
@@ -8,24 +8,23 @@ use std::process;
 fn main() {
     moonpool_sim::init_sim_tracing(tracing::Level::WARN);
 
-    let report = moonpool_sim::simulations::run_simulation(
-        moonpool_sim::SimulationBuilder::new()
-            .workload(moonpool_sim_examples::dungeon::DungeonWorkload::default())
-            .enable_exploration(moonpool_sim::ExplorationConfig {
-                max_depth: 120,
-                timelines_per_split: 4,
-                global_energy: 400_000,
-                adaptive: Some(moonpool_sim::AdaptiveConfig {
-                    batch_size: 30,
-                    min_timelines: 400,
-                    max_timelines: 1000,
-                    per_mark_energy: 10_000,
-                    warm_min_timelines: Some(30),
-                }),
-                parallelism: Some(moonpool_sim::Parallelism::HalfCores),
-            })
-            .set_iterations(3),
-    );
+    let report = moonpool_sim::SimulationBuilder::new()
+        .workload(moonpool_sim_examples::dungeon::DungeonWorkload::default())
+        .enable_exploration(moonpool_sim::ExplorationConfig {
+            max_depth: 120,
+            timelines_per_split: 4,
+            global_energy: 400_000,
+            adaptive: Some(moonpool_sim::AdaptiveConfig {
+                batch_size: 30,
+                min_timelines: 400,
+                max_timelines: 1000,
+                per_mark_energy: 10_000,
+                warm_min_timelines: Some(30),
+            }),
+            parallelism: Some(moonpool_sim::Parallelism::HalfCores),
+        })
+        .set_iterations(3)
+        .run();
 
     report.eprint();
 

--- a/moonpool-sim-examples/src/bin/sim/maze_explore.rs
+++ b/moonpool-sim-examples/src/bin/sim/maze_explore.rs
@@ -8,24 +8,23 @@ use std::process;
 fn main() {
     moonpool_sim::init_sim_tracing(tracing::Level::WARN);
 
-    let report = moonpool_sim::simulations::run_simulation(
-        moonpool_sim::SimulationBuilder::new()
-            .workload(moonpool_sim_examples::maze::MazeWorkload::default())
-            .enable_exploration(moonpool_sim::ExplorationConfig {
-                max_depth: 30,
-                timelines_per_split: 4,
-                global_energy: 20_000,
-                adaptive: Some(moonpool_sim::AdaptiveConfig {
-                    batch_size: 20,
-                    min_timelines: 60,
-                    max_timelines: 150,
-                    per_mark_energy: 600,
-                    warm_min_timelines: Some(20),
-                }),
-                parallelism: None,
-            })
-            .set_iterations(2),
-    );
+    let report = moonpool_sim::SimulationBuilder::new()
+        .workload(moonpool_sim_examples::maze::MazeWorkload::default())
+        .enable_exploration(moonpool_sim::ExplorationConfig {
+            max_depth: 30,
+            timelines_per_split: 4,
+            global_energy: 20_000,
+            adaptive: Some(moonpool_sim::AdaptiveConfig {
+                batch_size: 20,
+                min_timelines: 60,
+                max_timelines: 150,
+                per_mark_energy: 600,
+                warm_min_timelines: Some(20),
+            }),
+            parallelism: None,
+        })
+        .set_iterations(2)
+        .run();
 
     report.eprint();
 

--- a/moonpool-sim-examples/src/bin/sim/maze_explore.rs
+++ b/moonpool-sim-examples/src/bin/sim/maze_explore.rs
@@ -6,9 +6,7 @@
 use std::process;
 
 fn main() {
-    let _ = tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::WARN)
-        .try_init();
+    moonpool_sim::init_sim_tracing(tracing::Level::WARN);
 
     let report = moonpool_sim::simulations::run_simulation(
         moonpool_sim::SimulationBuilder::new()

--- a/moonpool-sim/src/lib.rs
+++ b/moonpool-sim/src/lib.rs
@@ -168,7 +168,7 @@ pub use chaos::{
 // Observability module re-exports (new system replacing legacy Timeline + Invariant)
 pub use observability::{
     CapturedEvent, Clock, InstallGuard, Invariant, SimTime, SimulationLayer, SimulationLayerHandle,
-    TimelineQuery, TimelineQueryExt, TypedEntry, invariant_fn,
+    TimelineQuery, TimelineQueryExt, TypedEntry, init_sim_tracing, invariant_fn,
 };
 
 // Network exports

--- a/moonpool-sim/src/observability/init.rs
+++ b/moonpool-sim/src/observability/init.rs
@@ -1,0 +1,16 @@
+//! Convenience initializer for example/sim binaries.
+
+use tracing::Level;
+
+/// Install a basic stdout `tracing_subscriber::fmt` subscriber at `max_level`.
+///
+/// Each sim binary's `main` previously inlined the same
+/// `tracing_subscriber::fmt().with_max_level(level).try_init()` boilerplate.
+/// Calling this helper centralizes that pattern. `try_init` is used so
+/// repeat calls (e.g. from re-entrant test harnesses) do not panic; the
+/// result is intentionally discarded.
+pub fn init_sim_tracing(max_level: Level) {
+    let _ = tracing_subscriber::fmt()
+        .with_max_level(max_level)
+        .try_init();
+}

--- a/moonpool-sim/src/observability/mod.rs
+++ b/moonpool-sim/src/observability/mod.rs
@@ -26,12 +26,14 @@
 pub mod emit;
 pub mod event;
 pub mod fmt;
+pub mod init;
 pub mod invariant;
 pub mod layer;
 pub mod query;
 
 pub use event::{CapturedEvent, TypedEntry};
 pub use fmt::{Clock, SimTime};
+pub use init::init_sim_tracing;
 pub use invariant::{Invariant, invariant_fn};
 pub use layer::{InstallGuard, SimulationLayer, SimulationLayerHandle};
 pub use query::{TimelineQuery, TimelineQueryExt};

--- a/moonpool-sim/src/providers/sim_providers.rs
+++ b/moonpool-sim/src/providers/sim_providers.rs
@@ -2,7 +2,7 @@
 
 use std::net::IpAddr;
 
-use moonpool_core::{Providers, TokioTaskProvider};
+use moonpool_core::{TokioTaskProvider, impl_providers_bundle};
 
 use crate::network::SimNetworkProvider;
 use crate::sim::WeakSimWorld;
@@ -66,31 +66,10 @@ impl SimProviders {
     }
 }
 
-impl Providers for SimProviders {
-    type Network = SimNetworkProvider;
-    type Time = SimTimeProvider;
-    type Task = TokioTaskProvider;
-    type Random = SimRandomProvider;
-
-    fn network(&self) -> &Self::Network {
-        &self.network
-    }
-
-    fn time(&self) -> &Self::Time {
-        &self.time
-    }
-
-    fn task(&self) -> &Self::Task {
-        &self.task
-    }
-
-    fn random(&self) -> &Self::Random {
-        &self.random
-    }
-
-    type Storage = SimStorageProvider;
-
-    fn storage(&self) -> &Self::Storage {
-        &self.storage
-    }
-}
+impl_providers_bundle!(SimProviders {
+    network: SimNetworkProvider,
+    time: SimTimeProvider,
+    task: TokioTaskProvider,
+    random: SimRandomProvider,
+    storage: SimStorageProvider,
+});

--- a/moonpool-sim/src/simulations/mod.rs
+++ b/moonpool-sim/src/simulations/mod.rs
@@ -3,11 +3,3 @@
 //! Contains workload definitions that can be used both in `#[test]` integration
 //! tests and in standalone binary targets (where sancov instrumentation is
 //! visible).
-
-use crate::SimulationReport;
-
-/// Run a `SimulationBuilder` and return the report.
-#[must_use]
-pub fn run_simulation(builder: crate::SimulationBuilder) -> SimulationReport {
-    builder.run()
-}

--- a/moonpool-transport-sim/src/bin/sim/transport.rs
+++ b/moonpool-transport-sim/src/bin/sim/transport.rs
@@ -14,9 +14,7 @@ use moonpool_transport_sim::process::TransportServerProcess;
 use moonpool_transport_sim::workload::TransportClientWorkload;
 
 fn main() {
-    let _ = tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::INFO)
-        .try_init();
+    moonpool_sim::init_sim_tracing(tracing::Level::INFO);
 
     let report = moonpool_sim::simulations::run_simulation(
         SimulationBuilder::new()

--- a/moonpool-transport-sim/src/bin/sim/transport.rs
+++ b/moonpool-transport-sim/src/bin/sim/transport.rs
@@ -16,18 +16,17 @@ use moonpool_transport_sim::workload::TransportClientWorkload;
 fn main() {
     moonpool_sim::init_sim_tracing(tracing::Level::INFO);
 
-    let report = moonpool_sim::simulations::run_simulation(
-        SimulationBuilder::new()
-            .processes(ProcessCount::Fixed(1), || Box::new(TransportServerProcess))
-            .workloads(WorkloadCount::Fixed(1), |i| {
-                Box::new(TransportClientWorkload::new(i))
-            })
-            .invariant(TransportIntegrityInvariant::new())
-            .chaos_duration(Duration::from_secs(10))
-            .random_network()
-            .set_iterations(20)
-            .seed_warning_timeout(Duration::from_secs(15)),
-    );
+    let report = SimulationBuilder::new()
+        .processes(ProcessCount::Fixed(1), || Box::new(TransportServerProcess))
+        .workloads(WorkloadCount::Fixed(1), |i| {
+            Box::new(TransportClientWorkload::new(i))
+        })
+        .invariant(TransportIntegrityInvariant::new())
+        .chaos_duration(Duration::from_secs(10))
+        .random_network()
+        .set_iterations(20)
+        .seed_warning_timeout(Duration::from_secs(15))
+        .run();
 
     report.eprint();
 

--- a/moonpool-transport/src/rpc/delivery.rs
+++ b/moonpool-transport/src/rpc/delivery.rs
@@ -13,12 +13,13 @@
 //! `RequestStream::send`, `tryGetReply`, `getReply`, `getReplyUnlessFailedFor`
 //! from `fdbrpc.h:727-895`
 
+use std::future::Future;
 use std::time::Duration;
 
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 
-use super::failure_monitor::FailureStatus;
+use super::failure_monitor::{FailureMonitor, FailureStatus};
 use super::reply_error::ReplyError;
 use super::reply_future::ReplyFuture;
 use super::request::{send_request, send_request_unreliable};
@@ -26,6 +27,37 @@ use super::request_stream::RequestEnvelope;
 use super::transport_handle::{DecodeFn, EncodeFn, TransportHandle};
 use crate::error::MessagingError;
 use crate::{Endpoint, UID};
+
+/// Race a `ReplyFuture` against a signal future (disconnect, failure-window
+/// timeout, etc.) and translate the outcome into a `ReplyError`.
+///
+/// Shared by [`try_get_reply`] and [`get_reply_unless_failed_for`]: both want
+/// "give me the reply, but if the signal fires first treat the request as
+/// `MaybeDelivered`", and both map `BrokenPromise` from the server into a
+/// `MaybeDelivered` after notifying the failure monitor.
+async fn race_reply_or_signal<Resp, S>(
+    reply_future: ReplyFuture<Resp>,
+    signal: S,
+    fm: &FailureMonitor,
+    destination: &Endpoint,
+) -> Result<Resp, ReplyError>
+where
+    Resp: DeserializeOwned + Send + Sync + 'static,
+    S: Future<Output = ()>,
+{
+    tokio::pin!(signal);
+    tokio::select! {
+        result = reply_future => match result {
+            Ok(resp) => Ok(resp),
+            Err(ReplyError::BrokenPromise) => {
+                fm.endpoint_not_found(destination);
+                Err(ReplyError::MaybeDelivered)
+            }
+            Err(e) => Err(e),
+        },
+        () = &mut signal => Err(ReplyError::MaybeDelivered),
+    }
+}
 
 /// Fire-and-forget delivery: send request unreliably with no reply.
 ///
@@ -108,19 +140,7 @@ where
     })?;
 
     let disconnect = fm.on_disconnect_or_failure(destination);
-    tokio::pin!(disconnect);
-
-    tokio::select! {
-        result = reply_future => match result {
-            Ok(resp) => Ok(resp),
-            Err(ReplyError::BrokenPromise) => {
-                fm.endpoint_not_found(destination);
-                Err(ReplyError::MaybeDelivered)
-            }
-            Err(e) => Err(e),
-        },
-        () = &mut disconnect => Err(ReplyError::MaybeDelivered),
-    }
+    race_reply_or_signal(reply_future, disconnect, &fm, destination).await
 }
 
 /// At-least-once delivery: send reliably, retransmit on reconnect.
@@ -194,21 +214,7 @@ where
     })?;
 
     let failed_for = fm.on_failed_for(destination, sustained_failure_duration);
-    tokio::pin!(failed_for);
-
-    tokio::select! {
-        result = reply_future => match result {
-            Ok(resp) => Ok(resp),
-            Err(ReplyError::BrokenPromise) => {
-                fm.endpoint_not_found(destination);
-                Err(ReplyError::MaybeDelivered)
-            }
-            Err(e) => Err(e),
-        },
-        () = &mut failed_for => {
-            Err(ReplyError::MaybeDelivered)
-        }
-    }
+    race_reply_or_signal(reply_future, failed_for, &fm, destination).await
 }
 
 #[cfg(test)]

--- a/moonpool-transport/src/rpc/delivery.rs
+++ b/moonpool-transport/src/rpc/delivery.rs
@@ -213,7 +213,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::net::{IpAddr, Ipv4Addr};
     use std::sync::Arc;
 
     use serde::{Deserialize, Serialize};
@@ -222,13 +221,9 @@ mod tests {
     use crate::rpc::failure_monitor::FailureStatus;
     use crate::rpc::net_notified_queue::NetNotifiedQueue;
     use crate::rpc::request_stream::RequestEnvelope;
-    use crate::rpc::test_support::make_transport;
+    use crate::rpc::test_support::{make_transport, test_address};
     use crate::rpc::transport_handle::{make_decode_fn, make_encode_fn};
-    use crate::{JsonCodec, NetworkAddress, UID};
-
-    fn test_address() -> NetworkAddress {
-        NetworkAddress::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 4500)
-    }
+    use crate::{JsonCodec, UID};
 
     #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
     struct TestRequest {

--- a/moonpool-transport/src/rpc/reply_promise.rs
+++ b/moonpool-transport/src/rpc/reply_promise.rs
@@ -106,6 +106,12 @@ impl<T: Serialize> ReplyPromise<T> {
         }
     }
 
+    fn write_inner(&self) -> std::sync::RwLockWriteGuard<'_, ReplyPromiseInner<T>> {
+        self.inner
+            .write()
+            .expect("RwLock poisoned: prior task panicked")
+    }
+
     /// Send a successful response.
     ///
     /// Consumes the promise, preventing double-send.
@@ -115,10 +121,7 @@ impl<T: Serialize> ReplyPromise<T> {
     /// Panics if the internal `RwLock` is poisoned (only possible if a prior
     /// task panicked while holding the lock).
     pub fn send(self, value: T) {
-        let mut inner = self
-            .inner
-            .write()
-            .expect("RwLock poisoned: prior task panicked");
+        let mut inner = self.write_inner();
         if inner.fulfilled {
             // Already fulfilled (shouldn't happen due to move semantics)
             return;
@@ -158,10 +161,7 @@ impl<T: Serialize> ReplyPromise<T> {
     /// Panics if the internal `RwLock` is poisoned (only possible if a prior
     /// task panicked while holding the lock).
     pub fn send_error(self, error: ReplyError) {
-        let mut inner = self
-            .inner
-            .write()
-            .expect("RwLock poisoned: prior task panicked");
+        let mut inner = self.write_inner();
         if inner.fulfilled {
             return;
         }
@@ -179,10 +179,7 @@ impl<T: Serialize> ReplyPromise<T> {
 
 impl<T: Serialize> Drop for ReplyPromise<T> {
     fn drop(&mut self) {
-        let mut inner = self
-            .inner
-            .write()
-            .expect("RwLock poisoned: prior task panicked");
+        let mut inner = self.write_inner();
         if !inner.fulfilled {
             // Send BrokenPromise error to client
             let result: Result<T, ReplyError> = Err(ReplyError::BrokenPromise);

--- a/moonpool-transport/src/rpc/request.rs
+++ b/moonpool-transport/src/rpc/request.rs
@@ -162,19 +162,14 @@ where
 #[cfg(test)]
 mod tests {
 
-    use std::net::{IpAddr, Ipv4Addr};
     use std::sync::Arc;
 
-    use crate::rpc::test_support::make_transport;
+    use crate::rpc::test_support::{make_transport, test_address};
     use crate::rpc::transport_handle::{make_decode_fn, make_encode_fn};
-    use crate::{JsonCodec, NetworkAddress, UID};
+    use crate::{JsonCodec, UID};
     use serde::{Deserialize, Serialize};
 
     use super::*;
-
-    fn test_address() -> NetworkAddress {
-        NetworkAddress::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 4500)
-    }
 
     #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
     struct PingRequest {

--- a/moonpool-transport/src/rpc/test_support.rs
+++ b/moonpool-transport/src/rpc/test_support.rs
@@ -141,10 +141,14 @@ impl Providers for MockProviders {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Echo(pub u32);
 
+/// Canonical server-side network address used by the rpc test suites.
+pub fn test_address() -> NetworkAddress {
+    NetworkAddress::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 4500)
+}
+
 pub fn make_transport() -> Arc<NetTransport<MockProviders>> {
-    let local = NetworkAddress::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 4500);
     crate::NetTransportBuilder::new(MockProviders::new())
-        .local_address(local)
+        .local_address(test_address())
         .build()
         .expect("build transport")
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -103,23 +103,22 @@ fn fmt_duration(d: std::time::Duration) -> String {
     }
 }
 
-fn filter_binaries<'a>(filters: &[&str]) -> Vec<&'a SimBinary> {
+fn filter_binaries(filters: &[String]) -> Vec<&'static SimBinary> {
     if filters.is_empty() {
         SIM_BINARIES.iter().collect()
     } else {
         SIM_BINARIES
             .iter()
-            .filter(|b| filters.iter().any(|f| b.name.contains(f)))
+            .filter(|b| filters.iter().any(|f| b.name.contains(f.as_str())))
             .collect()
     }
 }
 
 fn sim_list(args: &[String]) {
-    let filters: Vec<&str> = args.iter().map(std::string::String::as_str).collect();
-    let binaries = filter_binaries(&filters);
+    let binaries = filter_binaries(args);
 
     if binaries.is_empty() {
-        eprintln!("No binaries match filters: {filters:?}");
+        eprintln!("No binaries match filters: {args:?}");
         process::exit(1);
     }
 
@@ -135,12 +134,7 @@ fn sim_run(args: &[String]) {
         None => (args, [].as_slice()),
     };
 
-    let filters: Vec<&str> = filter_args
-        .iter()
-        .map(std::string::String::as_str)
-        .collect();
-
-    if filters.is_empty() {
+    if filter_args.is_empty() {
         eprintln!("error: 'run' requires at least one filter argument");
         eprintln!();
         eprintln!("Usage: cargo xtask sim run <filter...> [-- <binary-args...>]");
@@ -148,10 +142,10 @@ fn sim_run(args: &[String]) {
         process::exit(1);
     }
 
-    let binaries = filter_binaries(&filters);
+    let binaries = filter_binaries(filter_args);
 
     if binaries.is_empty() {
-        eprintln!("No binaries match filters: {filters:?}");
+        eprintln!("No binaries match filters: {filter_args:?}");
         process::exit(1);
     }
 


### PR DESCRIPTION
filter_binaries had a phantom 'a lifetime parameter unrelated to its
input slice — its result references &'static SIM_BINARIES, so the
lifetime is now stated explicitly. The two callers (sim_list, sim_run)
no longer build intermediate Vec<&str> copies of their &[String] args.