### PR TITLE
fix(orchestrator): deterministic run-phase virtual-time budget to catch self-perpetuating timers

### DIFF
--- a/moonpool-sim/src/runner/builder.rs
+++ b/moonpool-sim/src/runner/builder.rs
@@ -41,6 +41,7 @@ struct RunOrchestratorInputs<'a> {
     fault_injectors: Vec<Box<dyn FaultInjector>>,
     chaos_duration: Option<Duration>,
     obs_handle: SimulationLayerHandle,
+    run_time_budget: Duration,
 }
 
 /// Outcome of an orchestration attempt.
@@ -326,6 +327,7 @@ pub struct SimulationBuilder {
     exploration_config: Option<moonpool_explorer::ExplorationConfig>,
     before_iteration_hooks: Vec<Box<dyn FnMut()>>,
     seed_warning_timeout: Option<Duration>,
+    run_time_budget: Duration,
 }
 
 impl Default for SimulationBuilder {
@@ -351,6 +353,7 @@ impl SimulationBuilder {
             exploration_config: None,
             before_iteration_hooks: Vec::new(),
             seed_warning_timeout: None,
+            run_time_budget: super::orchestrator::DEFAULT_RUN_TIME_BUDGET,
         }
     }
 
@@ -539,6 +542,30 @@ impl SimulationBuilder {
         self
     }
 
+    /// Set the virtual-time budget for a single run phase.
+    ///
+    /// If simulated time advances past this bound while one or more workloads
+    /// are still running, the orchestrator first triggers a graceful shutdown
+    /// and — if simulated time keeps climbing by another full budget while
+    /// workloads remain — declares the run deadlocked.
+    ///
+    /// This is a deterministic safety net for a *self-perpetuating timer*: a
+    /// detached task (e.g. a reconnect / keepalive loop) that re-arms a
+    /// [`crate::TimeProvider::sleep`] every tick keeps the event queue
+    /// non-empty forever, so the no-progress deadlock detector never fires
+    /// even though no workload-relevant progress is being made. The budget
+    /// turns that silent hang into an actionable deadlock failure.
+    ///
+    /// The decision is a pure function of the simulated event schedule (no
+    /// wall clock, no RNG), so it never perturbs replay determinism. The
+    /// default (one simulated hour) is deliberately generous; raise it for
+    /// legitimately long simulations.
+    #[must_use]
+    pub fn run_time_budget(mut self, budget: Duration) -> Self {
+        self.run_time_budget = budget;
+        self
+    }
+
     /// Run until exploration has converged: all `assert_sometimes!` assertions
     /// have been reached and no new coverage was found on the last seed.
     ///
@@ -691,6 +718,7 @@ impl SimulationBuilder {
             fault_injectors,
             chaos_duration,
             obs_handle,
+            run_time_budget,
         } = inputs;
         let local_runtime = Self::build_local_runtime_for_seed(seed);
         local_runtime.block_on(async move {
@@ -705,6 +733,7 @@ impl SimulationBuilder {
                 sim,
                 chaos_duration,
                 iteration_count,
+                run_time_budget,
             })
             .await
         })
@@ -1236,6 +1265,7 @@ impl SimulationBuilder {
             fault_injectors,
             chaos_duration: self.chaos_duration,
             obs_handle: obs_handle.clone(),
+            run_time_budget: self.run_time_budget,
         });
         (outcome, start_time)
     }

--- a/moonpool-sim/src/runner/orchestrator.rs
+++ b/moonpool-sim/src/runner/orchestrator.rs
@@ -26,6 +26,17 @@ use crate::{
 
 use super::report::SimulationMetrics;
 
+/// Default virtual-time budget for a single run phase.
+///
+/// If simulated time advances past this bound while workloads are still
+/// running, the run is declared deadlocked. The default is intentionally
+/// enormous (one simulated hour) so it never trips a legitimate long-running
+/// simulation; it exists only to convert a self-perpetuating-timer hang
+/// (a detached keepalive/reconnect loop re-arming a sleep every tick) into an
+/// actionable deadlock instead of an unbounded spin. Override per simulation
+/// with [`crate::SimulationBuilder::run_time_budget`].
+pub(crate) const DEFAULT_RUN_TIME_BUDGET: Duration = Duration::from_hours(1);
+
 /// Deadlock detection utility to identify stuck simulations.
 #[derive(Debug, Default)]
 pub(crate) struct DeadlockDetector {
@@ -323,6 +334,7 @@ struct RunPhaseInputs<'a, 'pm> {
     injector_handles: &'a mut InjectorHandleSlots,
     seed: u64,
     iteration_count: usize,
+    run_time_budget: Duration,
 }
 
 /// Aggregated borrows needed to build workload contexts.
@@ -364,6 +376,10 @@ pub(crate) struct OrchestrateInputs<'a> {
     pub(crate) chaos_duration: Option<Duration>,
     /// Iteration count (used for diagnostics on deadlock).
     pub(crate) iteration_count: usize,
+    /// Virtual-time budget for the run phase. If simulated time advances past
+    /// this bound while workloads are still running, the run is declared a
+    /// deadlock. See [`DEFAULT_RUN_TIME_BUDGET`].
+    pub(crate) run_time_budget: Duration,
 }
 
 /// Successful output of [`WorkloadOrchestrator::orchestrate_workloads`].
@@ -449,6 +465,7 @@ struct ChaosAndRunInputs<'a, 'pm> {
     shutdown_signal: &'a tokio_util::sync::CancellationToken,
     seed: u64,
     iteration_count: usize,
+    run_time_budget: Duration,
 }
 
 /// Output of [`WorkloadOrchestrator::do_chaos_and_run_phase`].
@@ -456,6 +473,91 @@ struct ChaosAndRunOutput {
     returned_workloads: Vec<Box<dyn Workload>>,
     returned_injectors: Vec<Box<dyn FaultInjector>>,
     results: Vec<SimulationResult<()>>,
+}
+
+/// Inputs to [`WorkloadOrchestrator::check_run_time_budget`].
+struct BudgetGuardInputs {
+    /// Workloads still running this iteration.
+    current_active: usize,
+    /// Current simulated time.
+    now: Duration,
+    /// Simulated time at which the run phase started.
+    run_start: Duration,
+    /// Configured virtual-time budget for the run phase.
+    run_time_budget: Duration,
+    /// Simulated time at which the budget was first breached, if any.
+    budget_breach_time: Option<Duration>,
+    /// Iteration seed (diagnostics).
+    seed: u64,
+    /// Iteration index (diagnostics).
+    iteration_count: usize,
+}
+
+/// Borrows + scalars needed by [`WorkloadOrchestrator::evaluate_stall_guards`]
+/// for one run-loop iteration.
+struct StallGuardInputs<'a> {
+    sim: &'a crate::sim::SimWorld,
+    deadlock_detector: &'a mut DeadlockDetector,
+    /// Simulated time at which the run phase started.
+    run_start: Duration,
+    /// Configured virtual-time budget for the run phase.
+    run_time_budget: Duration,
+    /// Simulated time at which the budget was first breached, if any.
+    budget_breach_time: &'a mut Option<Duration>,
+    /// Whether a shutdown has already been triggered this run.
+    shutdown_triggered: bool,
+    /// Workloads still running this iteration.
+    current_active: usize,
+    /// Workloads running at the start of this iteration.
+    initial_handle_count: usize,
+    /// Pending events at the start of this iteration.
+    initial_event_count: usize,
+    /// Iteration seed (diagnostics).
+    seed: u64,
+    /// Iteration index (diagnostics).
+    iteration_count: usize,
+}
+
+/// Inputs to [`WorkloadOrchestrator::check_no_progress`].
+struct NoProgressInputs {
+    /// Workloads still running this iteration.
+    current_active: usize,
+    /// Workloads running at the start of this iteration.
+    initial_handle_count: usize,
+    /// Pending events after this iteration's step.
+    event_count: usize,
+    /// Pending events at the start of this iteration.
+    initial_event_count: usize,
+    /// Iteration seed (diagnostics).
+    seed: u64,
+    /// Iteration index (diagnostics).
+    iteration_count: usize,
+}
+
+/// Outcome of a run-phase stall guard (no-progress counter or virtual-time
+/// budget). Both guards share the same two-phase escalation: first breach
+/// triggers a graceful shutdown; a persistent stall after shutdown is a
+/// deadlock.
+#[derive(Clone, Copy)]
+enum StallOutcome {
+    /// Making progress (or already shut down inside the grace window).
+    Ok,
+    /// Stall first detected: trigger a graceful shutdown to unblock workloads.
+    Breached,
+    /// Still stalled after shutdown: declare deadlock.
+    Deadlock,
+}
+
+impl StallOutcome {
+    /// Combine two stall verdicts, keeping the most severe
+    /// (`Deadlock` > `Breached` > `Ok`).
+    fn merge(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::Deadlock, _) | (_, Self::Deadlock) => Self::Deadlock,
+            (Self::Breached, _) | (_, Self::Breached) => Self::Breached,
+            _ => Self::Ok,
+        }
+    }
 }
 
 impl WorkloadOrchestrator {
@@ -482,6 +584,7 @@ impl WorkloadOrchestrator {
             mut sim,
             chaos_duration,
             iteration_count,
+            run_time_budget,
         } = inputs;
 
         tracing::debug!(
@@ -551,6 +654,7 @@ impl WorkloadOrchestrator {
             shutdown_signal: &shutdown_signal,
             seed,
             iteration_count,
+            run_time_budget,
         })
         .await?;
 
@@ -686,6 +790,7 @@ impl WorkloadOrchestrator {
             shutdown_signal,
             seed,
             iteration_count,
+            run_time_budget,
         } = inputs;
 
         let chaos_shutdown = tokio_util::sync::CancellationToken::new();
@@ -718,6 +823,7 @@ impl WorkloadOrchestrator {
             injector_handles: &mut injector_handles,
             seed,
             iteration_count,
+            run_time_budget,
         })
         .await?;
 
@@ -923,12 +1029,22 @@ impl WorkloadOrchestrator {
             injector_handles,
             seed,
             iteration_count,
+            run_time_budget,
         } = inputs;
 
         let chaos_start = sim.current_time();
+        // Virtual-time origin for the run-phase budget. Both this and the
+        // running `sim.current_time()` are pure functions of the event
+        // schedule, so the budget trip point is bit-for-bit deterministic
+        // across replays (no wall clock, no RNG).
+        let run_start = sim.current_time();
         let mut chaos_ended = chaos_duration.is_none();
         let mut deadlock_detector = DeadlockDetector::new(3);
         let mut shutdown_triggered = false;
+        // Virtual time at which the run-phase budget was first breached, if any.
+        // Used to give workloads a virtual-time grace window to observe the
+        // shutdown and exit before the run is declared deadlocked.
+        let mut budget_breach_time: Option<Duration> = None;
         let mut loop_count: u64 = 0;
 
         loop {
@@ -985,31 +1101,29 @@ impl WorkloadOrchestrator {
 
             let current_active = workload_handles.iter().filter(|h| h.is_some()).count();
 
-            if deadlock_detector.check_deadlock(
+            // Evaluate both stall guards (virtual-time budget + classic
+            // no-progress detector) and act on the most severe verdict.
+            let stall = Self::evaluate_stall_guards(StallGuardInputs {
+                sim,
+                deadlock_detector: &mut deadlock_detector,
+                run_start,
+                run_time_budget,
+                budget_breach_time: &mut budget_breach_time,
+                shutdown_triggered,
                 current_active,
                 initial_handle_count,
-                sim.pending_event_count(),
                 initial_event_count,
-            ) {
-                if shutdown_triggered {
-                    tracing::error!(
-                        "DEADLOCK detected on iteration {} with seed {}: {} tasks remaining after {} no-progress iterations",
-                        iteration_count,
-                        seed,
-                        current_active,
-                        deadlock_detector.no_progress_count()
-                    );
-                    return Err((vec![seed], 1));
+                seed,
+                iteration_count,
+            });
+            match stall {
+                StallOutcome::Ok => {}
+                StallOutcome::Breached => {
+                    Self::trigger_shutdown(sim, shutdown_signal);
+                    shutdown_triggered = true;
+                    deadlock_detector.reset();
                 }
-                tracing::warn!(
-                    "No progress detected on iteration {} with seed {}: {} tasks remaining. Triggering shutdown to unblock workloads.",
-                    iteration_count,
-                    seed,
-                    current_active,
-                );
-                Self::trigger_shutdown(sim, shutdown_signal);
-                shutdown_triggered = true;
-                deadlock_detector.reset();
+                StallOutcome::Deadlock => return Err((vec![seed], 1)),
             }
 
             if current_active > 0 {
@@ -1017,6 +1131,164 @@ impl WorkloadOrchestrator {
             }
         }
         Ok(())
+    }
+
+    /// Run both run-loop stall guards and combine their verdicts.
+    ///
+    /// The virtual-time budget guard ([`Self::check_run_time_budget`]) catches
+    /// a self-perpetuating timer that the classic no-progress detector
+    /// ([`Self::check_no_progress`]) cannot; the most severe of the two
+    /// verdicts wins (`Deadlock` > `Breached` > `Ok`). Records the budget
+    /// breach time so the post-shutdown grace window can be measured.
+    fn evaluate_stall_guards(inputs: StallGuardInputs<'_>) -> StallOutcome {
+        let StallGuardInputs {
+            sim,
+            deadlock_detector,
+            run_start,
+            run_time_budget,
+            budget_breach_time,
+            shutdown_triggered,
+            current_active,
+            initial_handle_count,
+            initial_event_count,
+            seed,
+            iteration_count,
+        } = inputs;
+
+        let budget = Self::check_run_time_budget(&BudgetGuardInputs {
+            current_active,
+            now: sim.current_time(),
+            run_start,
+            run_time_budget,
+            budget_breach_time: *budget_breach_time,
+            seed,
+            iteration_count,
+        });
+        if let StallOutcome::Breached = budget {
+            *budget_breach_time = Some(sim.current_time());
+        }
+        let no_progress = Self::check_no_progress(
+            deadlock_detector,
+            shutdown_triggered,
+            &NoProgressInputs {
+                current_active,
+                initial_handle_count,
+                event_count: sim.pending_event_count(),
+                initial_event_count,
+                seed,
+                iteration_count,
+            },
+        );
+        budget.merge(no_progress)
+    }
+
+    /// Evaluate the no-progress deadlock detector for one loop iteration.
+    ///
+    /// This is the classic stall guard: it fires when the event queue is empty
+    /// and the handle count is unchanged for several consecutive iterations
+    /// (see [`DeadlockDetector::check_deadlock`]). It cannot catch a
+    /// self-perpetuating timer — that path keeps the queue non-empty forever;
+    /// [`Self::check_run_time_budget`] covers that case.
+    fn check_no_progress(
+        deadlock_detector: &mut DeadlockDetector,
+        shutdown_triggered: bool,
+        inputs: &NoProgressInputs,
+    ) -> StallOutcome {
+        let &NoProgressInputs {
+            current_active,
+            initial_handle_count,
+            event_count,
+            initial_event_count,
+            seed,
+            iteration_count,
+        } = inputs;
+        if !deadlock_detector.check_deadlock(
+            current_active,
+            initial_handle_count,
+            event_count,
+            initial_event_count,
+        ) {
+            return StallOutcome::Ok;
+        }
+        if shutdown_triggered {
+            tracing::error!(
+                "DEADLOCK detected on iteration {} with seed {}: {} tasks remaining after {} no-progress iterations",
+                iteration_count,
+                seed,
+                current_active,
+                deadlock_detector.no_progress_count()
+            );
+            return StallOutcome::Deadlock;
+        }
+        tracing::warn!(
+            "No progress detected on iteration {} with seed {}: {} tasks remaining. Triggering shutdown to unblock workloads.",
+            iteration_count,
+            seed,
+            current_active,
+        );
+        StallOutcome::Breached
+    }
+
+    /// Evaluate the run-phase virtual-time budget for one loop iteration.
+    ///
+    /// A *self-perpetuating timer* (e.g. a detached keepalive/reconnect loop
+    /// re-arming a sleep every tick) keeps the event queue non-empty forever,
+    /// so the no-progress [`DeadlockDetector`] never fires — yet simulated
+    /// time climbs without bound while a workload waits on it. This guard
+    /// catches that class:
+    ///
+    /// - The first breach (run-phase elapsed > budget while workloads remain)
+    ///   returns [`StallOutcome::Breached`]: the caller triggers a
+    ///   graceful shutdown so a cancellation-aware workload can drain and exit
+    ///   via the nanosecond-offset wake events (which barely advance virtual
+    ///   time, so it finishes inside the grace window).
+    /// - If simulated time then climbs by *another* full budget after the
+    ///   breach while workloads are still running, the self-perpetuating timer
+    ///   is confirmed and this returns [`StallOutcome::Deadlock`].
+    ///
+    /// The decision is a pure function of the simulated event schedule (no
+    /// wall clock, no RNG), so the trip point replays bit-for-bit.
+    fn check_run_time_budget(inputs: &BudgetGuardInputs) -> StallOutcome {
+        let &BudgetGuardInputs {
+            current_active,
+            now,
+            run_start,
+            run_time_budget,
+            budget_breach_time,
+            seed,
+            iteration_count,
+        } = inputs;
+
+        if current_active == 0 {
+            return StallOutcome::Ok;
+        }
+        let run_elapsed = now.saturating_sub(run_start);
+        match budget_breach_time {
+            None if run_elapsed > run_time_budget => {
+                tracing::warn!(
+                    "Run-phase virtual-time budget exceeded on iteration {} with seed {}: simulated time advanced {:?} (budget {:?}) with {} workload(s) still running. Triggering shutdown to unblock workloads.",
+                    iteration_count,
+                    seed,
+                    run_elapsed,
+                    run_time_budget,
+                    current_active,
+                );
+                StallOutcome::Breached
+            }
+            Some(breach) if now.saturating_sub(breach) > run_time_budget => {
+                tracing::error!(
+                    "DEADLOCK detected on iteration {} with seed {}: run-phase virtual time advanced {:?} (budget {:?}) and kept climbing for another {:?} after shutdown with {} workload(s) still running — self-perpetuating timer making no workload progress",
+                    iteration_count,
+                    seed,
+                    run_elapsed,
+                    run_time_budget,
+                    now.saturating_sub(breach),
+                    current_active,
+                );
+                StallOutcome::Deadlock
+            }
+            _ => StallOutcome::Ok,
+        }
     }
 
     /// Spawn the fault injectors for the chaos phase. When `chaos_duration`

--- a/moonpool-sim/tests/run_time_budget.rs
+++ b/moonpool-sim/tests/run_time_budget.rs
@@ -1,0 +1,126 @@
+//! Regression: a self-perpetuating timer must become an actionable deadlock.
+//!
+//! A downstream user (a Pulsar client driver) hit a non-termination where a
+//! **detached** engine task — spawned via the `TaskProvider`, *not* registered
+//! as a `Workload` handle — entered a reconnect/keepalive loop that re-armed a
+//! `TimeProvider::sleep` timer every tick, advancing virtual time without
+//! bound while the owning workload sat blocked on it.
+//!
+//! The orchestrator never flagged this:
+//!
+//! - The no-progress `DeadlockDetector` only counts a no-progress iteration
+//!   when `pending_event_count() == 0`. The keepalive timer keeps the queue
+//!   non-empty forever, so the counter resets every iteration and never trips.
+//! - The run-phase loop ends only when every registered workload handle has
+//!   finished. A detached task is never in that set, so a workload internally
+//!   stuck awaiting it keeps the run alive indefinitely.
+//!
+//! The fix is a configurable, generous-by-default **virtual-time budget** on
+//! the run phase: if simulated time climbs past the budget while workloads are
+//! still running, the orchestrator triggers a shutdown and — if time keeps
+//! climbing past another full budget — declares a deadlock. The decision is a
+//! pure function of the event schedule, so replays stay bit-for-bit identical.
+
+use std::future;
+use std::time::Duration;
+
+use async_trait::async_trait;
+
+use moonpool_sim::{
+    SimContext, SimulationBuilder, SimulationResult, TaskProvider, TimeProvider, Workload,
+};
+
+/// Workload that reproduces the busy-but-non-completing-peer hang.
+///
+/// `run()` spawns a **detached** keepalive task that re-arms a sleep every
+/// tick (the self-perpetuating timer), then blocks forever. It deliberately
+/// does *not* honour `ctx.shutdown()`, mirroring the downstream bug where the
+/// workload is internally wedged behind a detached task that ignores
+/// cancellation. Without the virtual-time budget this run never terminates.
+struct SelfPerpetuatingTimerWorkload;
+
+#[async_trait]
+impl Workload for SelfPerpetuatingTimerWorkload {
+    fn name(&self) -> &'static str {
+        "self_perpetuating_timer"
+    }
+
+    async fn run(&mut self, ctx: &SimContext) -> SimulationResult<()> {
+        let time = ctx.time().clone();
+        // Detached keepalive loop: re-arms a 30s sleep every tick, keeping the
+        // event queue non-empty forever and advancing virtual time without
+        // bound. Not a registered workload handle, so the orchestrator's
+        // "all workloads done" exit never sees it.
+        ctx.task().spawn_task("keepalive", async move {
+            loop {
+                let _ = time.sleep(Duration::from_secs(30)).await;
+            }
+        });
+
+        // Block forever, ignoring shutdown — the workload is wedged behind the
+        // detached task. The virtual-time budget must rescue us.
+        future::pending::<()>().await;
+        Ok(())
+    }
+}
+
+/// The detached keepalive timer must be caught by the run-phase virtual-time
+/// budget and reported as a failed (deadlocked) run instead of hanging.
+#[test]
+fn self_perpetuating_timer_is_caught_by_run_time_budget() {
+    let report = SimulationBuilder::new()
+        .workload(SelfPerpetuatingTimerWorkload)
+        // Small budget so the test trips fast. The keepalive advances virtual
+        // time +30s/tick, so a 1min budget is breached within a couple of ticks.
+        .run_time_budget(Duration::from_mins(1))
+        .set_iterations(1)
+        .set_debug_seeds(vec![42])
+        .run();
+
+    assert!(
+        report.failed_runs >= 1,
+        "self-perpetuating timer should be reported as a deadlocked (failed) run; got report: {report:?}"
+    );
+    assert!(
+        report.seeds_failing.contains(&42),
+        "the failing seed should be surfaced for replay; got report: {report:?}"
+    );
+}
+
+/// A normal workload that finishes well within the budget must still pass —
+/// the budget must not perturb a sim that terminates on its own.
+struct WellBehavedWorkload;
+
+#[async_trait]
+impl Workload for WellBehavedWorkload {
+    fn name(&self) -> &'static str {
+        "well_behaved"
+    }
+
+    async fn run(&mut self, ctx: &SimContext) -> SimulationResult<()> {
+        for _ in 0..3 {
+            ctx.time().sleep(Duration::from_millis(10)).await.ok();
+        }
+        Ok(())
+    }
+}
+
+/// A tiny budget must not affect a workload whose own logic completes quickly:
+/// its virtual time stays far below the budget, so the guard never fires.
+#[test]
+fn well_behaved_workload_is_unaffected_by_budget() {
+    let report = SimulationBuilder::new()
+        .workload(WellBehavedWorkload)
+        // Even a deliberately tiny budget must not trip a sim that finishes
+        // inside it (3 x 10ms = 30ms of virtual time, well under 1s).
+        .run_time_budget(Duration::from_secs(1))
+        .set_iterations(3)
+        .set_debug_seeds(vec![1, 2, 3])
+        .run();
+
+    assert_eq!(
+        report.failed_runs, 0,
+        "a workload that finishes inside the budget must not be flagged; got report: {report:?}"
+    );
+    assert_eq!(report.successful_runs, 3);
+}


### PR DESCRIPTION
## Problem

A detached `TaskProvider` task — one that is *not* a registered `Workload` handle — that re-arms a `TimeProvider::sleep` on every tick (a keepalive/heartbeat loop) advances virtual time without bound.
The no-progress detector never fires, because `pending_event_count` stays `> 0` forever (there is always the next scheduled sleep), and `drive_run_phase` only terminates when `active_workloads == 0`.
A workload blocked waiting on such a task therefore hangs forever, and the run never ends.

This is a genuine blind spot: the simulation makes "progress" (events fire, virtual time advances) yet makes no *useful* progress, so neither the no-progress detector nor the active-workload count can break out.

## Root cause

The orchestrator's run phase has two exit conditions:

1. `active_workloads == 0` (all registered workloads finished), or
2. the no-progress detector trips (no events left to fire).

A self-perpetuating timer in a detached task satisfies neither: it keeps the event queue non-empty indefinitely while never unblocking the stuck workload.
There was no bound on *how much simulated time* a single run may consume, so an unbounded-but-event-producing loop is indistinguishable from healthy work.

## Fix

Add a configurable per-run **virtual-time budget** (`SimulationBuilder::run_time_budget`, default **1 simulated hour**):

- When simulated time elapsed in the run phase exceeds the budget while workloads are still active, the orchestrator triggers a **graceful shutdown**.
- If, after shutdown has been declared, virtual time climbs by a further full budget without the run completing, that is declared a **deadlock** and surfaced with the seed (so the exact run is replayable).
- Sims that terminate normally are completely unaffected — the budget is only consulted while workloads remain active, and 1 simulated hour is far above any healthy run's footprint.

### Determinism

The budget check is **pure `Duration` arithmetic over the event schedule's virtual clock** — a comparison against `now_instant()`, not a newly scheduled timer.
No wall-clock reads, no RNG draws, no new events injected into the schedule.
Replays therefore stay **bit-for-bit reproducible**: the same `(commit, seed)` pair produces the same decision at the same virtual instant.
This was a hard requirement — introducing a real timer to detect the hang would itself perturb the deterministic schedule.

## Tests

- Full workspace suite green (543 tests pass, 0 failures) on the rebased branch.
- New regression test `moonpool-sim/tests/run_time_budget.rs`:
  - `self_perpetuating_timer_is_caught_by_run_time_budget` — a detached keepalive that re-arms `sleep` forever is now caught (deadlock surfaced) instead of hanging.
  - `well_behaved_workload_is_unaffected_by_budget` — a normal workload completes well within budget and sees no behavioral change.

## Context

Found while debugging a hang in the [magnetar](https://github.com/FlorentinDUBOIS/magnetar) Pulsar client (a downstream consumer of moonpool's deterministic-simulation engine): a connect-retry keepalive in the client-under-test was exactly this shape — a detached task advancing virtual time unbounded — and the sim would hang on certain seeds rather than report a determinism/liveness failure.
Cross-repo validation of that specific hang is tracked as a follow-up downstream; this PR is the framework-level fix and stands on its own.
