### PR TITLE
refactor(moonpool-sim): cross-validate invariants with plain tracing events

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ xtask/                       - Cargo xtask automation (simulation runner)
 **Multi-seed testing**: Default `UntilAllSometimesReached(1000)` runs until all assert_sometimes! statements have triggered
 **Failing seeds**: Debug with `SimulationBuilder::set_seed(failing_seed)` → fix root cause → verify → re-enable chaos
 **Infrastructure events**: Tests terminate early when only ConnectionRestore events remain
-**Invariant checking**: Cross-workload properties validated after every simulation event
+**Invariant checking**: Cross-workload properties validated after every simulation step
 **Goal**: Find bugs, not regression testing
 **NEVER remove assertions that catch bugs** — if an assertion fails, fix the underlying bug. Assertions exist to find real issues; deleting a failing assertion hides the bug.
 **When an assertion catches a bug**: Stop, enter plan mode, and enable deep thinking. Read relevant reference code, trace the full data flow, and understand the root cause before attempting a fix. Do not rush.
@@ -181,28 +181,29 @@ Strategic placement: error handling, timeouts, retries, resource limits
 ## Invariant System
 **When to use invariants**: Cross-process properties, global system constraints, deterministic bug detection
 **When to use assertions**: Per-process validation (`assert_always!` in process code)
-**Performance**: Invariants run after every captured event - design accordingly
+**Performance**: Invariants run after every simulation step - design accordingly (cursor-based `since`, not `snapshot`)
 
-**Architecture**: Correctness facts emitted as plain `tracing` events with a marker field; `SimulationLayer` captures them and runs registered invariants.
+**Architecture**: Correctness facts are plain `tracing` events — the same instrumentation production observability consumes. `SimulationLayer` captures them into a timeline; the orchestrator runs registered invariants after each `sim.step()`.
 
 ```rust
-// Emit (in process / workload code)
-tracing::info!(
-    capture = true,
-    trail = "leader",
-    source = my_ip,
-    event = valuable(&LeaderElected { term, leader: my_ip.into() }),
-);
+// Emit (in process / workload code) — plain production-style tracing
+tracing::info!(target: "raft", term, leader = %my_ip, "leader_elected");
 
-// Observe (in the invariant)
-fn observe(&self, q: &dyn TrailQuery, _sim_time_ms: u64) {
-    for entry in q.since::<LeaderElected>("leader", &self.cursor) { ... }
+// Observe (in the invariant) — query by event name, extract fields by key
+fn observe(&self, q: &dyn TraceQuery, _sim_time_ms: u64) {
+    for e in q.since("leader_elected", &self.cursor) {
+        let term = e.u64("term");
+        let leader = e.str("leader");
+        ...
+    }
 }
 ```
 
-- **Required fields**: `capture = true`, `trail = "..."`, `event = valuable(&p)`. Optional: `source = "..."`.
-- **Payload types** must derive `Valuable + Serialize + Deserialize`. Use structs (or struct/tuple enum variants), not unit-variant enums (valuable-serde shape mismatch).
+- **Capture rule**: INFO+ level, non-empty constant message (= the event name), emitted inside a process/workload task. No special fields, no derives.
+- **Source attribution**: the orchestrator wraps each process/workload task in `info_span!("process"/"workload", ip = %ip)`; the layer resolves `TraceEvent::source` from the nearest enclosing span. Events outside actor spans are dropped.
+- **Field tips**: use `%` for strings (`?` on a `String` keeps Debug quotes); bytes go hex-encoded into a string field.
+- **Sim faults**: engine records `SimFaultEvent`s internally (`SimWorld::take_faults()`); the runner merges them into the timeline under `SIM_FAULT_EVENT_NAME` (`"sim_fault"`) with a `kind` field and `source = "sim"`.
 - **Sim time** is stamped by the layer from its internal clock (the orchestrator pushes `obs.set_sim_time_ms(...)` after each `sim.step()`). Do NOT include a `time_ms` field on the emit.
-- **Invariants emitting events** are silently dropped by tracing-core's dispatch reentrancy guard — treat `observe(...)` as read-only.
-- **Production**: any tracing subscriber (fmt, OpenTelemetry) sees the same emissions as structured events; install `SimulationLayer` to layer invariants on top.
-- **Canonical example**: `moonpool-sim/tests/leader_election.rs` (split-brain detection).
+- **Invariants** run from the runner loop (not tracing dispatch); use the assertion macros, not raw `panic!`, and treat `observe(...)` as read-only.
+- **Production**: any tracing subscriber (fmt, OpenTelemetry) sees the same emissions as structured events; cross-validation in sim uses the very same traces.
+- **Canonical example**: `moonpool-sim/tests/leader_election.rs` (split-brain detection). Deeper: `moonpool-transport-sim` (hash-chain replay from `append_block` events).

--- a/book/src/appendix/05-glossary.md
+++ b/book/src/appendix/05-glossary.md
@@ -24,7 +24,7 @@ Terms are listed alphabetically. Cross-references are shown in **bold**.
 
 **Determinism** -- The property that given the same **seed**, the simulation produces exactly the same execution. All randomness flows through the seeded RNG, and all I/O is simulated. This makes bugs reproducible: same seed, same bug, every time.
 
-**Trail** -- An append-only typed log captured by `SimulationLayer`. Producers emit events as ordinary `tracing::*!` calls with three structured fields: `capture = true` (the marker), `trail = "name"` (selects the stream), `event = valuable(&p)` (the typed payload). An optional `source = "..."` records the originating actor; sim time is stamped automatically. Invariants read via the `TrailQuery` trait: `q.since::<T>(name, &cursor)` for incremental scans, `q.snapshot::<T>(name)` for full re-scans. Each entry carries `time_ms`, `source`, and a global monotonic `seq`. Distinct from **Timeline** (a simulation run in the explorer); see also **Fault trail**.
+**Trace timeline** -- The append-only log of trace events captured by `SimulationLayer`. Producers emit plain `tracing::*!` events with a constant message (the event name) and structured fields; no markers or derives. The `source` is attributed from the process/workload span the orchestrator wraps around each actor task; sim time is stamped automatically. Invariants read via the `TraceQuery` trait: `q.since(name, &cursor)` for incremental scans, `q.snapshot(name)` for full re-scans, with per-field accessors (`e.u64("term")`, `e.str("leader")`). Each event carries `time_ms`, `source`, `target`, `level`, and a global monotonic `seq`. Distinct from **Timeline** (a simulation run in the explorer); see also **Fault timeline**.
 
 **Endpoint** -- A `(IpAddr, Token)` pair that uniquely identifies a connection endpoint in the simulated network. The IP address identifies the node; the **token** identifies the specific listener or connection on that node.
 
@@ -34,13 +34,13 @@ Terms are listed alphabetically. Cross-references are shown in **bold**.
 
 **Explorer** -- The multiverse exploration framework (`moonpool-explorer` crate). Uses `fork()` to create **timeline** branches at **splitpoints**, exploring alternate executions with different randomness. Has zero knowledge of Moonpool internals -- communicates only through RNG function pointers.
 
-**Fault trail** -- The well-known **trail** named `"sim:faults"` (`SIM_FAULT_TRAIL`). Automatically populated by the simulator with `SimFaultEvent` entries covering network, storage, and process lifecycle faults. Invariants use it to correlate application behavior with infrastructure events. Because the same fault events flow through `tracing`, production observability tools see them too.
+**Fault timeline** -- The well-known event name `"sim_fault"` (`SIM_FAULT_EVENT_NAME`) in the trace timeline. The engine records `SimFaultEvent`s internally and the runner merges them in with `source = "sim"` and a `kind` field (e.g. `"partition_created"`, `"process_force_kill"`) covering network, storage, and process lifecycle faults. Invariants use it to correlate application behavior with infrastructure events. Engine-level tests can drain records directly via `SimWorld::take_faults()`.
 
 **Fork** -- An OS-level `fork()` call that creates a child process sharing the parent's memory via copy-on-write. Each child continues the simulation with a new **seed**, creating an alternate **timeline**. Forks are triggered at **splitpoints**.
 
 **Frontier** -- For `assert_sometimes_all!`: the maximum number of named conditions that have been simultaneously true. When the frontier advances (more conditions true at once than ever before), a **splitpoint** is triggered. The frontier value is preserved across seeds in multi-seed exploration.
 
-**Invariant** -- A property that must hold across the entire simulated system, checked after every captured event. Invariants read from a **trail** via the `TrailQuery` trait and panic (typically via `assert_always!`) on violation. Registered on the builder with `.invariant(...)` or `.invariant_fn(...)`.
+**Invariant** -- A property that must hold across the entire simulated system, checked by the runner after every simulation step. Invariants read from the **trace timeline** via the `TraceQuery` trait and report violations via `assert_always!`. Registered on the builder with `.invariant(...)` or `.invariant_fn(...)`.
 
 **Mark** -- An assertion site that can trigger **splitpoints** in the **explorer**. Each mark has a name, a shared-memory slot index, and (in **adaptive** mode) its own **energy** allowance. Marks are the unit of exploration budget management.
 

--- a/book/src/index.md
+++ b/book/src/index.md
@@ -56,7 +56,7 @@ A sitemap of every chapter in the Moonpool book. Each entry links to a chapter w
 - [Always and Sometimes](./part3-building/14-always-sometimes.md) — `assert_always!` (must hold) vs `assert_sometimes!` (exploration guidance)
 - [Numeric Assertions](./part3-building/15-numeric-assertions.md) — `assert_always_less_than!`; watermark tracking; explorer optimizes bounds
 - [Compound Assertions](./part3-building/16-compound-assertions.md) — `assert_sometimes_all!` for simultaneous sub-goals; frontier tracking
-- [Events and Invariants](./part3-building/17-events-and-invariants.md) — `ctx.emit` typed event timelines, the `Invariant` trait runs after every event, the auto-emitted fault timeline, `SimTime` formatter for sim-time log prefixes
+- [Events and Invariants](./part3-building/17-events-and-invariants.md) — plain `tracing` events as the timeline, the `Invariant` trait runs after every step, the auto-recorded fault timeline, `SimTime` formatter for sim-time log prefixes
 - [Designing Workloads That Find Bugs](./part3-building/19-designing-workloads.md) — Targeted adversarial design vs white noise; strategy matters
 - [Debugging a Failing Seed](./part3-building/20-debugging.md) — Five-step workflow: reproduce, isolate, understand, fix, verify
 - [Reproducing with FixedCount](./part3-building/21-reproducing.md) — Pin seed with `set_debug_seeds()` + `set_iterations(1)`; exact replay

--- a/book/src/part3-building/03-writing-workload.md
+++ b/book/src/part3-building/03-writing-workload.md
@@ -169,7 +169,7 @@ The check phase is your last chance to validate. The system is quiet. No message
 
 ## Publishing State for Invariants
 
-Workloads can publish state that invariant functions read after every simulation event. This enables cross-workload validation:
+Workloads can publish state that invariant functions read after every simulation step. This enables cross-workload validation:
 
 ```rust
 // In run(), after each operation:
@@ -179,19 +179,19 @@ ctx.state().publish("kv_model", self.model.clone());
 An invariant function (registered on the builder) can then read this state:
 
 ```rust
-fn check_model_size(q: &dyn TrailQuery, _sim_time_ms: u64) {
+fn check_model_size(q: &dyn TraceQuery, _sim_time_ms: u64) {
     // Snapshot the latest size events; assert_always if any exceeds bounds.
-    let entries = q.snapshot::<usize>("kv_model_size");
+    let entries = q.snapshot("kv_model_size");
     if let Some(latest) = entries.last() {
         assert_always!(
-            latest.event <= 100,
+            latest.u64("size").is_some_and(|s| s <= 100),
             "model grew beyond expected bounds"
         );
     }
 }
 ```
 
-This is the publish-and-check pattern: the workload publishes its reference model, and invariants validate cross-workload properties after every event. The [events and invariants chapter](./17-events-and-invariants.md) covers this in depth.
+This is the publish-and-check pattern: the workload publishes its reference model, and invariants validate cross-workload properties after every step. The [events and invariants chapter](./17-events-and-invariants.md) covers this in depth.
 
 ## Patterns That Find Bugs
 

--- a/book/src/part3-building/17-events-and-invariants.md
+++ b/book/src/part3-building/17-events-and-invariants.md
@@ -6,70 +6,61 @@ Assertions live inside workloads. They validate local properties: this key shoul
 
 Other properties span time rather than space. Monotonicity says a term number never decreased. Causal ordering says the lock was acquired before the write. Conservation over time says total money stayed constant through a sequence of transfers. A snapshot of the latest state cannot tell us any of these. If a balance went 100, then 50, then 100 again, a snapshot-based check sees 100 and declares everything fine. The dip to 50 is invisible.
 
-Both kinds of properties need the same two ingredients: an append-only log of typed events, and a watcher that runs after every step.
+Both kinds of properties need the same two ingredients: an append-only timeline of events, and a watcher that runs as the simulation advances.
+
+How would you find a dual leader in production? You would query your traces: every `leader_elected` event, grouped by term, flagged when two nodes claim the same one. Moonpool's invariant system runs exactly that query, against exactly those traces, inside the simulation. The instrumentation you write for production observability **is** the test oracle.
 
 ## Emitting Events
 
-Correctness facts are ordinary `tracing` events with three structured fields. Anywhere you have a typed payload that derives `Valuable + Serialize + Deserialize`, fire a normal `tracing::info!`:
+Correctness facts are plain `tracing` events. No markers, no derives, no moonpool-specific API:
 
 ```rust
-use serde::{Deserialize, Serialize};
-use tracing::field::valuable;
-use valuable::Valuable;
-
-#[derive(Debug, Clone, Valuable, Serialize, Deserialize)]
-struct CommitEvent {
-    slot: u64,
-    value: u64,
-}
-
-// Inside a process or workload
-tracing::info!(
-    capture = true,
-    trail = "commits",
-    source = ctx.my_ip(),
-    event = valuable(&CommitEvent { slot: 7, value: 42 }),
-);
+// Inside a process or workload — exactly what you'd write for production
+// observability anyway.
+tracing::info!(target: "raft", term, leader = %my_ip, "leader_elected");
 ```
 
-Three rules. `capture = true` is the marker that tells `SimulationLayer` this event matters; without it, the layer ignores the event. `trail = "name"` selects the append-only stream that invariants read from. `event = valuable(&payload)` carries the typed payload through `tracing`'s structured field machinery. An optional `source = "..."` records the originating actor; sim time is stamped automatically by the layer, so do not include a `time_ms` field.
+Three rules:
 
-For convenience inside a `SimContext`, `ctx.emit(trail, payload)` expands to the same `tracing::info!` with `source = ctx.my_ip()` filled in.
+1. **The message is the event name.** Use a constant name like `"leader_elected"`, not an interpolated sentence. Events are grouped and queried by name, the same way you would query Loki or your OTel backend.
+2. **Use `%` for strings.** `%value` records the `Display` form without quotes. `?value` on a `String` keeps `Debug` quotes, which makes field matching annoying.
+3. **`INFO` or above.** `debug!` and `trace!` events are not captured.
 
-```rust
-ctx.emit("commits", CommitEvent { slot: 7, value: 42 });
-```
+That's the whole convention. Sim time is stamped automatically from the simulation clock, so do not include a `time_ms` field.
 
-**One emission, two audiences.** In simulation, `SimulationLayer` captures the typed payload and runs invariants. In production, where no `SimulationLayer` is registered, the same event flows to whatever subscriber is configured: `fmt`, OpenTelemetry, structured JSON. The `valuable` machinery keeps the payload's fields visible to every layer; nothing is hidden behind a `Debug` blob.
+**Where does the source come from?** The orchestrator wraps every process and workload task in a tracing span carrying its `ip` (`info_span!("process", ip = %ip)`). When an event fires inside that task, the capture layer walks the span scope and attributes the event to the nearest enclosing actor. In production the same role is played by host or pod attributes on your trace resource. Events emitted outside any actor span (runtime internals, the orchestrator itself) are not captured.
 
-**Use structs, not unit-variant enums.** `valuable-serde` emits enum unit variants as `{"VariantName": []}` while `serde`'s default external tagging deserializes from the bare string `"VariantName"`, so the round-trip silently fails. Add at least one field (e.g. a `reason: String` for catch-all variants) and the shape is unambiguous.
-
-Each captured entry is wrapped as a `TypedEntry<T>`:
+Each captured event is a `TraceEvent`:
 
 ```rust
-pub struct TypedEntry<T> {
-    pub event: T,        // your payload, deserialized on read
+pub struct TraceEvent {
+    pub seq: u64,        // global monotonic sequence number, reset per seed
     pub time_ms: u64,    // simulation time at capture
-    pub source: String,  // source field (or empty if omitted)
-    pub seq: u64,        // global monotonic sequence number
+    pub source: String,  // ip of the enclosing actor span, or "sim" for faults
+    pub target: String,  // tracing target, e.g. "raft"
+    pub level: tracing::Level,
+    pub name: String,    // the message, e.g. "leader_elected"
+    pub fields: BTreeMap<String, FieldValue>,
 }
 ```
 
-The `seq` field gives total ordering across all trails. If trail A gets seq 0 and trail B gets seq 1, A's event was emitted first, even at the same `time_ms`.
+The `seq` field gives total ordering across all event names. If `leader_elected` gets seq 0 and `client_ack` gets seq 1, the election was captured first, even at the same `time_ms`. Typed values come out per field: `e.u64("term")`, `e.str("leader")`, `e.bool("ok")`, `e.f64("ratio")` all return `Option`s.
+
+**One emission, two audiences.** In simulation, `SimulationLayer` captures the event into the timeline and invariants cross-validate it. In production, where no `SimulationLayer` is installed, the same event flows to whatever subscriber is configured: `fmt`, OpenTelemetry, structured JSON. Nothing in the emission is moonpool-specific.
 
 ## The Invariant Trait
 
-An invariant is a check that runs **after every captured event**. The simulation engine calls it automatically. If the invariant panics, the simulation stops and reports the failing seed.
+An invariant is a check the orchestrator runs **after every simulation step**. If the invariant records a failure, the simulation reports the failing seed.
 
 ```rust
 pub trait Invariant: 'static + Send {
     fn name(&self) -> &str;
-    fn observe(&self, q: &dyn TrailQuery, sim_time_ms: u64);
+    fn observe(&self, q: &dyn TraceQuery, sim_time_ms: u64);
     fn reset(&mut self) {}
 }
 ```
 
-The invariant gets a `TrailQuery` view of all captured events plus the current simulation time. The contract: if the invariant holds, return normally. If it does not, panic with a descriptive message. The `reset` hook is called between seeds to clear cursors and tracking sets. Treat `observe` as read-only: any captured event you try to emit from inside it is silently dropped by `tracing-core`'s dispatch reentrancy guard.
+The invariant gets a `TraceQuery` view of all captured events plus the current simulation time. The contract: if the property holds, return normally. If it does not, report with `assert_always!` so the failure is recorded with the seed. The `reset` hook is called between seeds to clear cursors and tracking sets. Because steps batch events, one `observe` call may see several new events.
 
 Register invariants on the builder:
 
@@ -84,29 +75,24 @@ SimulationBuilder::new()
 For quick one-off checks there is a closure shorthand:
 
 ```rust
-use moonpool_sim::TrailQueryExt;
-
 SimulationBuilder::new()
-    .invariant_fn("single_leader", |q, _t| {
-        let leaders = q.snapshot::<LeaderEvent>("leadership");
-        let active = leaders.iter().filter(|e| matches!(e.event, LeaderEvent::Elected { .. })).count()
-                   - leaders.iter().filter(|e| matches!(e.event, LeaderEvent::StepDown { .. })).count();
-        assert!(active <= 1, "multiple leaders elected at once");
+    .invariant_fn("commit_volume", |q, _t| {
+        assert_always!(q.len("commit") <= 10_000, "runaway commit volume");
     });
 ```
 
-## Reading Trails
+## Querying the Timeline
 
-`TrailQuery` is the dyn-safe core trait. `TrailQueryExt` is auto-implemented for any `TrailQuery` and adds two generic helpers. Use `since::<T>(name, &cursor)` when you only need new entries since the last call (cheap, advances the cursor). Use `snapshot::<T>(name)` when you need a full re-scan.
+`TraceQuery` has three methods. `since(name, &cursor)` returns only the events newer than the cursor and advances it — cheap, and the right default. `snapshot(name)` re-reads everything from the start of the seed. `len(name)` counts.
 
 A real consensus example. Multiple nodes must agree on committed values. The agreement invariant checks that no two nodes have committed different values for the same slot. This catches subtle bugs: a leader change that replays a proposal, a vote that arrives after a new ballot, a crash during the accept phase.
 
-Each node emits a `CommitEvent { slot, value }` whenever it commits. The invariant scans the trail and verifies no two commits for the same slot disagree.
+Each node emits `tracing::info!(slot, value, "commit")` whenever it commits. The invariant scans the timeline and verifies no two commits for the same slot disagree.
 
 ```rust
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
-use moonpool_sim::{Invariant, TrailQuery, TrailQueryExt, assert_always};
+use moonpool_sim::{Invariant, TraceQuery, assert_always};
 
 #[derive(Default)]
 pub struct AgreementInvariant {
@@ -117,16 +103,16 @@ pub struct AgreementInvariant {
 impl Invariant for AgreementInvariant {
     fn name(&self) -> &str { "agreement" }
 
-    fn observe(&self, q: &dyn TrailQuery, _t: u64) {
-        // Cursor-based: only new entries since the last call.
-        let new = q.since::<CommitEvent>("commits", &self.cursor);
+    fn observe(&self, q: &dyn TraceQuery, _t: u64) {
+        // Cursor-based: only new events since the last call.
         let mut committed = self.committed.borrow_mut();
-        for entry in new {
-            let CommitEvent { slot, value } = entry.event;
+        for e in q.since("commit", &self.cursor) {
+            let slot = e.u64("slot").expect("commit carries a slot");
+            let value = e.u64("value").expect("commit carries a value");
             if let Some(prev) = committed.get(&slot) {
                 assert_always!(
                     *prev == value,
-                    format!("agreement violated at slot {}: {} vs {}", slot, prev, value)
+                    format!("agreement violated at slot {slot}: {prev} vs {value}")
                 );
             } else {
                 committed.insert(slot, value);
@@ -141,27 +127,30 @@ impl Invariant for AgreementInvariant {
 }
 ```
 
-This runs after every simulation event. If a leader change causes two nodes to commit different values for the same slot, the invariant fires immediately on the second `Commit`. Reset between seeds is the invariant's responsibility. Clear the cursor in `reset()` and the simulation builder calls it for you between iterations.
+If a leader change causes two nodes to commit different values for the same slot, the invariant fires on the step that captured the second commit. Reset between seeds is the invariant's responsibility: clear the cursor in `reset()` and the simulation builder calls it for you between iterations.
+
+The canonical runnable example is [`moonpool-sim/tests/leader_election.rs`](https://github.com/PierreZ/moonpool/blob/main/moonpool-sim/tests/leader_election.rs): a workload emits `leader_elected` events, a `SplitBrainInvariant` detects two leaders claiming the same term. For a deeper one, [`moonpool-transport-sim`](https://github.com/PierreZ/moonpool/tree/main/moonpool-transport-sim) replays a hash chain from `append_block` events, with the block bytes hex-encoded into a string field.
 
 ## Reading from a Workload
 
-Inside `Workload::check()` or anywhere you have a `SimContext`, query the layer directly:
+Inside `Workload::check()` or anywhere you have a `SimContext`, the observability handle implements `TraceQuery` too:
 
 ```rust
-let entries = ctx.trail::<TransferEvent>("transfers");
-let total: u64 = entries.iter().map(|e| e.event.amount).sum();
+let q = ctx.observability();
+let transfers = q.snapshot("transfer");
+let total: u64 = transfers.iter().filter_map(|e| e.u64("amount")).sum();
 assert_always!(total <= max_funds, "spent more than reserves");
 ```
 
-`ctx.trail()` returns `Vec<TypedEntry<T>>`, empty if nothing emitted under that trail. No `Option` to unwrap.
+`snapshot` returns an empty `Vec` if nothing was emitted under that name. No `Option` to unwrap.
 
-## The Fault Trail
+## The Fault Timeline
 
-Every fault the simulator injects, from network partitions to storage corruption to process kills, is automatically emitted to a well-known trail called `"sim:faults"`. No workload code needed.
+Every fault the simulator injects, from network partitions to storage corruption to process kills, lands in the same timeline under the well-known name `"sim_fault"`, with `source = "sim"` and a `kind` field identifying the variant. No workload code needed. These are not production traces — there is no simulator in production — so the engine records them internally and the runner merges them into the timeline after each step (engine-level tests can drain them directly with `SimWorld::take_faults()`).
 
 ```rust
 use std::cell::Cell;
-use moonpool_sim::{Invariant, SimFaultEvent, SIM_FAULT_TRAIL, TrailQuery, TrailQueryExt};
+use moonpool_sim::{Invariant, SIM_FAULT_EVENT_NAME, TraceQuery, assert_always};
 
 pub struct KillRateInvariant {
     cursor: Cell<usize>,
@@ -171,10 +160,9 @@ pub struct KillRateInvariant {
 impl Invariant for KillRateInvariant {
     fn name(&self) -> &str { "kill_rate" }
 
-    fn observe(&self, q: &dyn TrailQuery, _t: u64) {
-        let new = q.since::<SimFaultEvent>(SIM_FAULT_TRAIL, &self.cursor);
-        for entry in new {
-            if matches!(entry.event, SimFaultEvent::ProcessForceKill { .. }) {
+    fn observe(&self, q: &dyn TraceQuery, _t: u64) {
+        for e in q.since(SIM_FAULT_EVENT_NAME, &self.cursor) {
+            if e.str("kind") == Some("process_force_kill") {
                 self.kill_count.set(self.kill_count.get() + 1);
             }
         }
@@ -191,15 +179,13 @@ impl Invariant for KillRateInvariant {
 }
 ```
 
-`SimFaultEvent` covers fault variants across three categories:
+The `kind` values cover three categories:
 
-- **Process lifecycle**: `ProcessGracefulShutdown`, `ProcessForceKill`, `ProcessRestart`
-- **Network**: `PartitionCreated`, `PartitionHealed`, `ConnectionCut`, `CutRestored`, `HalfOpenError`, `SendPartitionCreated`, `RecvPartitionCreated`, `RandomClose`, `PeerCrash`, `BitFlip`
-- **Storage**: `StorageReadFault`, `StorageWriteFault`, `StorageSyncFault`, `StorageCrash`, `StorageWipe`
+- **Process lifecycle**: `process_graceful_shutdown` (with `grace_period_ms`), `process_force_kill`, `process_restart` (all with `ip`)
+- **Network**: `partition_created`, `partition_healed` (with `from`/`to`), `connection_cut`, `cut_restored`, `half_open_error`, `random_close`, `peer_crash`, `bit_flip` (with `connection_id`), `send_partition_created`, `recv_partition_created` (with `ip`)
+- **Storage**: `storage_read_fault`, `storage_write_fault` (with `write_kind`), `storage_sync_fault`, `storage_crash`, `storage_wipe` (all with `ip`)
 
-The real power is **correlation**. When an application-level invariant fires, cross-reference the fault trail to understand what the infrastructure was doing at that moment. A conservation law violation at `t=5000` that coincides with a `ProcessForceKill` at `t=4980` tells a very different story than one with no faults nearby.
-
-Because fault events also flow through `tracing`, the same correlation works in production. Capture the same events into a log aggregator and search around the alert window.
+The real power is **correlation**. When an application-level invariant fires, cross-reference the fault events to understand what the infrastructure was doing at that moment. A conservation law violation at `t=5000` that coincides with a `process_force_kill` at `t=4980` tells a very different story than one with no faults nearby. Both kinds of events sit in one timeline with one clock, which is exactly how you would correlate an alert window against infrastructure events in a production log aggregator.
 
 ## Simulation Time in Log Output
 
@@ -214,8 +200,6 @@ use tracing_subscriber::layer::SubscriberExt;
 let sim_layer = SimulationLayer::new();
 let handle = sim_layer.handle();
 
-// SimulationLayer must precede fmt in the registry chain so its on_event
-// updates the layer's sim time *before* fmt formats the event.
 let subscriber = tracing_subscriber::registry()
     .with(sim_layer)
     .with(
@@ -226,48 +210,46 @@ let subscriber = tracing_subscriber::registry()
 let _guard = tracing::subscriber::set_default(subscriber);
 ```
 
-`Clock` is the only thing `SimTime` depends on. Implement it for a test stub or an alternate time source if you need one.
-
 Output:
 
 ```text
-sim+    1.234s  INFO myservice: trail="delivery.at_most_once" event=Replied { seq_id: 7 }
+sim+    1.234s  INFO raft: term=3 leader=10.0.1.2 leader_elected
 sim+    1.235s  INFO myservice::handler: processing request id=42
-sim+    5.000s  WARN moonpool::sim: trail="sim:faults" event=PartitionCreated { from: "10.0.1.1", to: "10.0.1.2" }
 ```
 
-The orchestrator advances the clock by calling `handle.set_sim_time_ms(sim.current_time())` after each `sim.step()`. All `tracing::*!` calls between events, captured or not, see the right time. The handle is per-layer, so two parallel sims keep their clocks isolated.
+The orchestrator advances the clock by calling `handle.set_sim_time_ms(...)` after each `sim.step()`. All `tracing::*!` calls between steps, captured or not, see the right time. The handle is per-layer, so two parallel sims keep their clocks isolated.
 
 In production, no `SimulationLayer` is registered and the formatter falls back to its default zero. Use plain wall-clock `fmt::layer()` there, and only pull `SimTime` in for sim and test runs.
 
-## Snapshots vs Trails
+## Snapshots vs Timelines
 
 Use both. They solve different problems.
 
 **`StateHandle::publish/get`** stores the latest snapshot. Good for properties about the current state: the sum of all balances equals total deposits minus total withdrawals. Workloads call `ctx.state().publish("model", model.clone())` and read the snapshot at the end of the simulation in `Workload::check`.
 
-**`ctx.emit` and `ctx.trail`** store append-only history. Good for properties about how the state changed over time: no message was received before it was sent, the leader term never decreased, every debit has a matching credit.
+**The trace timeline** stores append-only history. Good for properties about how the state changed over time: no message was received before it was sent, the leader term never decreased, every debit has a matching credit.
 
-Invariants can derive snapshots from event histories by keeping an internal counter and updating it as events arrive. The fault trail adds infrastructure context for free, and every event you emit is one that production observability can also see.
+Invariants can derive snapshots from event histories by keeping an internal counter and updating it as events arrive. The fault timeline adds infrastructure context for free, and every event you emit is one that production observability also sees.
 
 ## When to Use Invariants vs Assertions
 
 **Assertions** (`assert_always!`, `assert_sometimes!`) belong inside workloads. They validate local properties from the workload's perspective: this response has the right balance, this error path was exercised.
 
-**Invariants** validate global, cross-workload properties from an omniscient perspective. They watch trails and check that the system's history is consistent. Use them for:
+**Invariants** validate global, cross-workload properties from an omniscient perspective. They watch the trace timeline and check that the system's history is consistent. Use them for:
 
 - Conservation laws (messages, resources, committed values)
 - No-phantom properties (never receive something that was not sent)
-- Consistency across processes (leader election: at most one leader at any time)
+- Consistency across processes (leader election: at most one leader per term)
 - Monotonicity properties (ballot numbers only increase)
 - Causal ordering (a write to `x` must come before a read that returns it)
+- Time-shaped anomalies (retry rates that stay elevated after the trigger fault healed — the metastable failure signature)
 
-A useful rule of thumb: if the property involves state from more than one process or workload, it is an invariant. If it is about one workload's local view, it is an assertion.
+A useful rule of thumb: if the property involves state from more than one process or workload, it is an invariant. If it is about one workload's local view, it is an assertion. Inside an invariant, prefer the assertion macros over a raw `panic!` so failures are recorded with the seed.
 
 ## Performance
 
-Invariants run after **every** simulation event. A typical simulation processes thousands of events per iteration, and you might run hundreds of iterations. Keep invariants fast.
+Invariants run after **every** simulation step. A typical simulation processes thousands of steps per iteration, and you might run hundreds of iterations. Keep invariants fast.
 
-Concretely: use cursor-based `since` rather than full `snapshot`, iterate only the new entries, compare a few counters, check a simple predicate. Avoid expensive operations like sorting large datasets or formatting strings on the happy path. The `format!` in the panic message is fine because it only runs when the invariant fails.
+Concretely: use cursor-based `since` rather than full `snapshot`, iterate only the new events, compare a few counters, check a simple predicate. Avoid expensive operations like sorting large datasets or formatting strings on the happy path. The `format!` in the failure message is fine because it only runs when the invariant fails.
 
-If you find yourself wanting a slow invariant, like replaying a log to verify consistency, run it only in the workload's `check()` method at the end of the simulation rather than after every event.
+If you find yourself wanting a slow invariant, like replaying a log to verify consistency, run it only in the workload's `check()` method at the end of the simulation rather than on every step.

--- a/book/src/part3-building/23-pitfalls.md
+++ b/book/src/part3-building/23-pitfalls.md
@@ -94,11 +94,11 @@ When working on simulation internals, you may need to access a connection (`inne
 
 ## Forgetting to Emit Events for Invariants
 
-Invariants read events emitted via `ctx.emit(...)`. If your workload changes state but forgets to emit a corresponding event, invariants see an incomplete history and either miss bugs or report false violations.
+Invariants read plain `tracing` events captured into the timeline. If your workload changes state but forgets to emit a corresponding event, invariants see an incomplete history and either miss bugs or report false violations.
 
-**Fix**: Emit a typed event for every state change you want invariants to observe. The same event also flows to production observability subscribers, so this serves a dual purpose.
+**Fix**: Emit a trace event for every state change you want invariants to observe. The same event also flows to production observability subscribers, so this serves a dual purpose.
 
 ```rust
 self.model.record_commit(slot, value);
-ctx.emit("commits", CommitEvent { slot, value });
+tracing::info!(slot, value, "commit");
 ```

--- a/moonpool-sim/Cargo.toml
+++ b/moonpool-sim/Cargo.toml
@@ -28,9 +28,7 @@ thiserror = "2.0"
 parking_lot = "0.12"
 tokio = { version = "1", features = ["full", "tracing"] }
 tokio-util = { version = "0.7", features = ["compat"] }
-tracing = { version = "0.1", features = ["valuable"] }
-valuable = { version = "0.1", features = ["derive"] }
-valuable-serde = "0.1"
+tracing = "0.1"
 
 tracing-subscriber = { version = "0.3", features = ["registry"] }
 

--- a/moonpool-sim/src/chaos/fault_events.rs
+++ b/moonpool-sim/src/chaos/fault_events.rs
@@ -1,22 +1,25 @@
-//! Simulator-emitted fault events for the fault trail.
+//! Simulator-emitted fault events for the timeline.
 //!
 //! When faults are injected (network partitions, process reboots, storage corruption, etc.),
-//! the simulator automatically emits [`SimFaultEvent`]s to the [`SIM_FAULT_TRAIL`] trail.
+//! the simulation engine records [`SimFaultEvent`]s and the runner drains them into the
+//! captured timeline under the [`SIM_FAULT_EVENT_NAME`] event name, with a `kind` field
+//! identifying the fault variant and the payload flattened into fields.
 //! Invariants can read these to correlate application behavior with infrastructure faults.
 //!
 //! # Usage
 //!
 //! ```ignore
 //! use std::cell::Cell;
-//! use moonpool_sim::{Invariant, SimFaultEvent, SIM_FAULT_TRAIL, TrailQuery, TrailQueryExt};
+//! use moonpool_sim::{Invariant, SIM_FAULT_EVENT_NAME, TraceQuery};
 //!
 //! struct FaultCounter { cursor: Cell<usize> }
 //!
 //! impl Invariant for FaultCounter {
 //!     fn name(&self) -> &str { "fault_counter" }
-//!     fn observe(&self, q: &dyn TrailQuery, _t: u64) {
-//!         for entry in q.since::<SimFaultEvent>(SIM_FAULT_TRAIL, &self.cursor) {
-//!             if let SimFaultEvent::ProcessForceKill { ip } = &entry.event {
+//!     fn observe(&self, q: &dyn TraceQuery, _t: u64) {
+//!         for e in q.since(SIM_FAULT_EVENT_NAME, &self.cursor) {
+//!             if e.str("kind") == Some("process_force_kill") {
+//!                 let ip = e.str("ip");
 //!                 // ...
 //!             }
 //!         }
@@ -24,17 +27,21 @@
 //! }
 //! ```
 
-use serde::{Deserialize, Serialize};
-use valuable::Valuable;
+use std::collections::BTreeMap;
 
-/// Well-known trail name for simulator-emitted fault events.
-pub const SIM_FAULT_TRAIL: &str = "sim:faults";
+use serde::Serialize;
 
-/// Fault events automatically emitted by the simulator.
+use crate::observability::FieldValue;
+
+/// Well-known event name for simulator-emitted fault events.
+pub const SIM_FAULT_EVENT_NAME: &str = "sim_fault";
+
+/// Fault events automatically recorded by the simulator.
 ///
-/// Invariants read these via the [`crate::TrailQuery`] / [`crate::TrailQueryExt`]
-/// API: `q.since::<SimFaultEvent>(SIM_FAULT_TRAIL, &cursor)`.
-#[derive(Debug, Clone, Valuable, Serialize, Deserialize)]
+/// Invariants read these from the timeline via [`crate::TraceQuery`]:
+/// `q.since(SIM_FAULT_EVENT_NAME, &cursor)`, matching on the `kind` field
+/// (see [`SimFaultEvent::kind`]).
+#[derive(Debug, Clone, Serialize)]
 pub enum SimFaultEvent {
     // -- Process lifecycle --
     /// Process graceful shutdown initiated.
@@ -130,7 +137,9 @@ pub enum SimFaultEvent {
         /// File identifier.
         file_id: u64,
         /// Kind of write fault: "phantom", "misdirected", or "corruption".
-        kind: String,
+        /// (Named `write_kind` to avoid colliding with the timeline's
+        /// variant-discriminator `kind` field.)
+        write_kind: String,
     },
     /// Sync failure injected.
     StorageSyncFault {
@@ -149,4 +158,69 @@ pub enum SimFaultEvent {
         /// IP of the wiped process.
         ip: String,
     },
+}
+
+impl SimFaultEvent {
+    /// Stable `snake_case` identifier for this fault variant, stored in the
+    /// timeline event's `kind` field.
+    #[must_use]
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::ProcessGracefulShutdown { .. } => "process_graceful_shutdown",
+            Self::ProcessForceKill { .. } => "process_force_kill",
+            Self::ProcessRestart { .. } => "process_restart",
+            Self::PartitionCreated { .. } => "partition_created",
+            Self::PartitionHealed { .. } => "partition_healed",
+            Self::ConnectionCut { .. } => "connection_cut",
+            Self::CutRestored { .. } => "cut_restored",
+            Self::HalfOpenError { .. } => "half_open_error",
+            Self::SendPartitionCreated { .. } => "send_partition_created",
+            Self::RecvPartitionCreated { .. } => "recv_partition_created",
+            Self::RandomClose { .. } => "random_close",
+            Self::PeerCrash { .. } => "peer_crash",
+            Self::BitFlip { .. } => "bit_flip",
+            Self::StorageReadFault { .. } => "storage_read_fault",
+            Self::StorageWriteFault { .. } => "storage_write_fault",
+            Self::StorageSyncFault { .. } => "storage_sync_fault",
+            Self::StorageCrash { .. } => "storage_crash",
+            Self::StorageWipe { .. } => "storage_wipe",
+        }
+    }
+
+    /// Flatten this fault's payload into timeline fields.
+    ///
+    /// Serializes via serde's external tagging (`{"Variant": {fields}}`) and
+    /// maps the inner object's scalars to [`FieldValue`]s. Returns an empty
+    /// map if serialization fails (it cannot for these variants).
+    pub(crate) fn to_fields(&self) -> BTreeMap<String, FieldValue> {
+        let mut fields = BTreeMap::new();
+        let Ok(serde_json::Value::Object(tagged)) = serde_json::to_value(self) else {
+            return fields;
+        };
+        for payload in tagged.into_values() {
+            let serde_json::Value::Object(entries) = payload else {
+                continue;
+            };
+            for (key, value) in entries {
+                let field = match value {
+                    serde_json::Value::Bool(b) => FieldValue::Bool(b),
+                    serde_json::Value::Number(n) => {
+                        if let Some(u) = n.as_u64() {
+                            FieldValue::U64(u)
+                        } else if let Some(i) = n.as_i64() {
+                            FieldValue::I64(i)
+                        } else if let Some(f) = n.as_f64() {
+                            FieldValue::F64(f)
+                        } else {
+                            continue;
+                        }
+                    }
+                    serde_json::Value::String(s) => FieldValue::Str(s),
+                    _ => continue,
+                };
+                fields.insert(key, field);
+            }
+        }
+        fields
+    }
 }

--- a/moonpool-sim/src/chaos/mod.rs
+++ b/moonpool-sim/src/chaos/mod.rs
@@ -139,5 +139,5 @@ pub use assertions::{
     reset_always_violations, reset_assertion_results, validate_assertion_contracts,
 };
 pub use buggify::{buggify_init, buggify_internal, buggify_reset};
-pub use fault_events::{SIM_FAULT_TRAIL, SimFaultEvent};
+pub use fault_events::{SIM_FAULT_EVENT_NAME, SimFaultEvent};
 pub use state_handle::StateHandle;

--- a/moonpool-sim/src/lib.rs
+++ b/moonpool-sim/src/lib.rs
@@ -145,8 +145,8 @@ pub mod simulations;
 
 // Sim module re-exports
 pub use sim::{
-    ConnectionStateChange, Event, EventQueue, NetworkOperation, ScheduledEvent, SimWorld,
-    SleepFuture, StorageOperation, WeakSimWorld, clear_rng_breakpoints, current_sim_seed,
+    ConnectionStateChange, Event, EventQueue, NetworkOperation, ScheduledEvent, SimFaultRecord,
+    SimWorld, SleepFuture, StorageOperation, WeakSimWorld, clear_rng_breakpoints, current_sim_seed,
     reset_rng_call_count, reset_sim_rng, rng_call_count, set_rng_breakpoints, set_sim_seed,
     sim_random, sim_random_range, sim_random_range_or_default,
 };
@@ -160,15 +160,15 @@ pub use runner::{
 
 // Chaos module re-exports
 pub use chaos::{
-    AssertionStats, SIM_FAULT_TRAIL, SimFaultEvent, StateHandle, assertion_results, buggify_init,
-    buggify_reset, has_always_violations, reset_always_violations, reset_assertion_results,
-    validate_assertion_contracts,
+    AssertionStats, SIM_FAULT_EVENT_NAME, SimFaultEvent, StateHandle, assertion_results,
+    buggify_init, buggify_reset, has_always_violations, reset_always_violations,
+    reset_assertion_results, validate_assertion_contracts,
 };
 
 // Observability module re-exports (plain-tracing capture + invariants)
 pub use observability::{
-    CapturedEvent, Clock, InstallGuard, Invariant, SimTime, SimulationLayer, SimulationLayerHandle,
-    TrailQuery, TrailQueryExt, TypedEntry, init_sim_tracing, invariant_fn,
+    Clock, FieldValue, InstallGuard, Invariant, SimTime, SimulationLayer, SimulationLayerHandle,
+    TraceEvent, TraceQuery, init_sim_tracing, invariant_fn,
 };
 
 // Network exports

--- a/moonpool-sim/src/observability/event.rs
+++ b/moonpool-sim/src/observability/event.rs
@@ -1,70 +1,98 @@
-//! Captured event records and typed views.
+//! Captured trace events and field values.
 //!
-//! Events emitted as plain `tracing::*!` macros with the `capture = true` marker
-//! field are picked up by [`crate::observability::SimulationLayer`] and stored
-//! as [`CapturedEvent`] records. Invariants and inspection code read them as
-//! [`TypedEntry<T>`] via cursor-based incremental queries that deserialize the
-//! payload on demand.
+//! Plain `tracing` events emitted by processes and workloads are picked up by
+//! [`crate::observability::SimulationLayer`] and stored as [`TraceEvent`]
+//! records — the same shape a production log pipeline would see. Invariants
+//! and inspection code read them through [`crate::observability::TraceQuery`]
+//! and extract typed fields by key.
 
-use serde::de::DeserializeOwned;
-use serde_json::Value;
+use std::collections::BTreeMap;
 
-/// A single event captured by the simulation layer.
-///
-/// The payload is stored as a [`serde_json::Value`] produced from the
-/// `event = valuable(&p)` field at capture time. Invariants downcast via
-/// [`crate::observability::TrailQueryExt::since`], which deserializes into
-/// the requested type.
-#[derive(Debug, Clone)]
-pub struct CapturedEvent {
-    /// Trail name (e.g. [`crate::SIM_FAULT_TRAIL`]).
-    pub trail: String,
-    /// Simulation time in milliseconds when the event was captured. Stamped
-    /// by the layer from its current clock; not carried as a tracing field.
-    pub time_ms: u64,
-    /// Source identifier — process IP, `"sim"` for simulator-emitted events,
-    /// or empty if no `source` field was supplied.
-    pub source: String,
-    /// Global monotonic sequence number across all trails.
-    pub seq: u64,
-    /// Serialized payload from the `event` field, deserializable into the
-    /// caller-chosen `T` via [`TypedEntry::deserialize`].
-    pub payload: Value,
+/// A single structured field value captured from a `tracing` event.
+#[derive(Debug, Clone, PartialEq)]
+pub enum FieldValue {
+    /// Boolean field.
+    Bool(bool),
+    /// Signed integer field.
+    I64(i64),
+    /// Unsigned integer field.
+    U64(u64),
+    /// Floating-point field.
+    F64(f64),
+    /// String field. Also produced by `%`-formatted (`Display`) and
+    /// `?`-formatted (`Debug`) values.
+    Str(String),
 }
 
-/// A typed view of a captured event for use by invariants and tests.
+/// One captured trace event — the same shape as a production log line.
 #[derive(Debug, Clone)]
-pub struct TypedEntry<T> {
-    /// Deserialized payload.
-    pub event: T,
+pub struct TraceEvent {
+    /// Global monotonic sequence number across all event names. Reset per seed.
+    pub seq: u64,
     /// Simulation time in milliseconds when the event was captured.
     pub time_ms: u64,
-    /// Source identifier (process IP, `"sim"`, or empty).
+    /// Originating actor: the `ip` recorded on the nearest enclosing process
+    /// or workload span, or `"sim"` for runner-injected fault events.
     pub source: String,
-    /// Global monotonic sequence number across all trails.
-    pub seq: u64,
+    /// The `tracing` target (defaults to the emitting module path).
+    pub target: String,
+    /// Event severity level.
+    pub level: tracing::Level,
+    /// Event name: the `tracing` message, e.g. `"leader_elected"`.
+    pub name: String,
+    /// Structured fields recorded on the event.
+    pub fields: BTreeMap<String, FieldValue>,
 }
 
-impl<T: DeserializeOwned> TypedEntry<T> {
-    /// Deserialize a [`CapturedEvent`] into a typed entry.
-    ///
-    /// Returns `None` if the payload does not deserialize as `T`.
-    ///
-    /// **Payload shape note:** `valuable-serde` emits enum unit variants as
-    /// `{"VariantName": []}` while `serde`'s default external tagging expects
-    /// the bare string `"VariantName"`. To avoid this round-trip mismatch,
-    /// payload types should use **structs** or struct/tuple enum variants —
-    /// not unit-variant enums. The `Heartbeat`/`LeaderElected`-style structs
-    /// in `observability` tests and `tests/leader_election.rs` are the
-    /// canonical shape.
+impl TraceEvent {
+    /// Read field `key` as a `u64`. Also accepts non-negative `i64` values.
     #[must_use]
-    pub fn deserialize(e: &CapturedEvent) -> Option<Self> {
-        let event: T = serde_json::from_value(e.payload.clone()).ok()?;
-        Some(Self {
-            event,
-            time_ms: e.time_ms,
-            source: e.source.clone(),
-            seq: e.seq,
-        })
+    pub fn u64(&self, key: &str) -> Option<u64> {
+        match self.fields.get(key)? {
+            FieldValue::U64(v) => Some(*v),
+            FieldValue::I64(v) => u64::try_from(*v).ok(),
+            _ => None,
+        }
+    }
+
+    /// Read field `key` as an `i64`. Also accepts `u64` values that fit.
+    #[must_use]
+    pub fn i64(&self, key: &str) -> Option<i64> {
+        match self.fields.get(key)? {
+            FieldValue::I64(v) => Some(*v),
+            FieldValue::U64(v) => i64::try_from(*v).ok(),
+            _ => None,
+        }
+    }
+
+    /// Read field `key` as an `f64`.
+    #[must_use]
+    pub fn f64(&self, key: &str) -> Option<f64> {
+        match self.fields.get(key)? {
+            FieldValue::F64(v) => Some(*v),
+            _ => None,
+        }
+    }
+
+    /// Read field `key` as a `bool`.
+    #[must_use]
+    pub fn bool(&self, key: &str) -> Option<bool> {
+        match self.fields.get(key)? {
+            FieldValue::Bool(v) => Some(*v),
+            _ => None,
+        }
+    }
+
+    /// Read field `key` as a string slice.
+    ///
+    /// Values recorded with `%` (`Display`) arrive unquoted; values recorded
+    /// with `?` (`Debug`) keep their `Debug` formatting (a `String` recorded
+    /// with `?` includes quotes — prefer `%` for strings).
+    #[must_use]
+    pub fn str(&self, key: &str) -> Option<&str> {
+        match self.fields.get(key)? {
+            FieldValue::Str(v) => Some(v),
+            _ => None,
+        }
     }
 }

--- a/moonpool-sim/src/observability/invariant.rs
+++ b/moonpool-sim/src/observability/invariant.rs
@@ -1,34 +1,34 @@
-//! Cross-process invariant trait checked after every captured event.
+//! Cross-process invariant trait checked after every simulation step.
 //!
 //! Invariants are registered on the [`crate::SimulationBuilder`] and run by
-//! the [`crate::observability::SimulationLayer`] each time an event marked
-//! with `capture = true` is captured. They receive a [`TrailQuery`] view of
-//! all events seen so far and panic on violation.
+//! the orchestrator after each `sim.step()`. They receive a [`TraceQuery`]
+//! view of all trace events captured so far and panic on violation.
 
-use super::query::TrailQuery;
+use super::query::TraceQuery;
 
-/// An invariant validated after every captured simulation event.
+/// An invariant validated after every simulation step.
 ///
-/// Invariants should panic with a descriptive message if violated. Use the
-/// `assert_always!` macros from [`crate::chaos`] for structured failure reporting.
+/// Invariants should report violations with the `assert_always!` macros from
+/// [`crate::chaos`] for structured failure reporting.
 ///
-/// `Send` is required because invariants live inside a tracing `Subscriber`
+/// `Send` is required because invariants are stored behind the layer handle,
 /// which must be `Send + Sync`. moonpool runs single-threaded so this is a
 /// type-system constraint only.
+///
+/// Invariants run from the orchestrator loop, not from inside tracing
+/// dispatch, so emitting a `tracing` event from `observe` is captured like
+/// any other — but treat invariants as read-only observers; emitting from a
+/// checker blurs the line between system and oracle.
 pub trait Invariant: 'static + Send {
     /// Name of this invariant, used in reports.
     fn name(&self) -> &str;
 
     /// Observe the latest captured events and validate properties.
     ///
-    /// `q` exposes cursor-based incremental scans over typed trails.
-    /// `sim_time_ms` is the simulated time of the event that just fired.
-    ///
-    /// **Don't emit captured events from here.** `tracing-core`'s dispatch
-    /// reentrancy guard silently drops events emitted while another event is
-    /// being processed, so an emit from inside `observe` is a no-op — not an
-    /// error. Treat invariants as read-only.
-    fn observe(&self, q: &dyn TrailQuery, sim_time_ms: u64);
+    /// `q` exposes cursor-based incremental scans over events by name.
+    /// `sim_time_ms` is the simulated time of the step that just completed.
+    /// Calls batch events: one `observe` may see several new events.
+    fn observe(&self, q: &dyn TraceQuery, sim_time_ms: u64);
 
     /// Reset internal state at the start of each seed.
     ///
@@ -37,7 +37,7 @@ pub trait Invariant: 'static + Send {
     fn reset(&mut self) {}
 }
 
-type InvariantFn = Box<dyn Fn(&dyn TrailQuery, u64) + Send>;
+type InvariantFn = Box<dyn Fn(&dyn TraceQuery, u64) + Send>;
 
 struct FnInvariant {
     name: String,
@@ -49,7 +49,7 @@ impl Invariant for FnInvariant {
         &self.name
     }
 
-    fn observe(&self, q: &dyn TrailQuery, sim_time_ms: u64) {
+    fn observe(&self, q: &dyn TraceQuery, sim_time_ms: u64) {
         (self.check)(q, sim_time_ms);
     }
 }
@@ -57,7 +57,7 @@ impl Invariant for FnInvariant {
 /// Wrap a closure as an [`Invariant`].
 pub fn invariant_fn(
     name: impl Into<String>,
-    f: impl Fn(&dyn TrailQuery, u64) + Send + 'static,
+    f: impl Fn(&dyn TraceQuery, u64) + Send + 'static,
 ) -> Box<dyn Invariant + Send> {
     Box::new(FnInvariant {
         name: name.into(),

--- a/moonpool-sim/src/observability/layer.rs
+++ b/moonpool-sim/src/observability/layer.rs
@@ -1,67 +1,50 @@
-//! Custom `tracing` layer that captures correctness events and runs invariants.
+//! Custom `tracing` layer that captures plain trace events for invariants.
 //!
-//! [`SimulationLayer`] subscribes to ordinary `tracing` events. An event is
-//! captured iff it carries `capture = true` as a structured field. Required
-//! companion field: `trail = "..."` selects the named stream. Optional field:
-//! `source = "..."` (defaults to empty string). The typed payload is carried
-//! as `event = valuable(&p)` and converted to a [`serde_json::Value`] at
-//! capture time.
+//! [`SimulationLayer`] subscribes to ordinary `tracing` events — the same
+//! emissions production observability consumes. An event is captured iff:
+//!
+//! 1. its level is `INFO` or more severe, and
+//! 2. it is emitted inside a span carrying an `ip` field (the orchestrator
+//!    wraps every process and workload task in such a span), and
+//! 3. it has a non-empty message, which becomes the event's name.
+//!
+//! Runner-injected fault events bypass tracing entirely: the orchestrator
+//! drains them from the simulation engine and records them via
+//! [`SimulationLayerHandle::record_sim_fault`] with `source = "sim"`.
 //!
 //! Simulation time is stamped from the layer's internal clock, advanced by
-//! the orchestrator via [`SimulationLayerHandle::set_sim_time_ms`] between
-//! events. In production (no orchestrator), the clock stays at 0 unless the
-//! user pushes wall time themselves.
+//! the orchestrator via [`SimulationLayerHandle::set_sim_time_ms`] after each
+//! step. Invariants are run by the orchestrator through
+//! [`SimulationLayerHandle::run_invariants`] — never from inside tracing
+//! dispatch.
 //!
 //! Storage is held behind a [`parking_lot::Mutex`] to satisfy the
 //! `Send + Sync` bound on `tracing::Layer`. moonpool simulations run
 //! single-threaded so the mutex is uncontended.
-//!
-//! ## Invariants are read-only by construction
-//!
-//! `tracing-core`'s dispatch reentrancy guard silently drops any event emitted
-//! while another event is being processed. So an invariant that calls
-//! `tracing::info!(capture = true, ...)` from inside `observe(...)` is a no-op,
-//! not a panic — there is no deadlock risk and no need for an explicit guard
-//! in the layer.
 
 use std::cell::Cell;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicI32, Ordering};
 
 use parking_lot::Mutex;
-use serde::de::DeserializeOwned;
-use serde_json::Value;
 use tracing::Subscriber;
 use tracing::field::{Field, Visit};
 use tracing_subscriber::Layer;
 use tracing_subscriber::layer::{Context, SubscriberExt};
 use tracing_subscriber::registry::LookupSpan;
 
-use super::event::{CapturedEvent, TypedEntry};
+use crate::chaos::{SIM_FAULT_EVENT_NAME, SimFaultEvent};
+
+use super::event::{FieldValue, TraceEvent};
 use super::invariant::Invariant;
-use super::query::TrailQuery;
-
-#[allow(unused_imports)]
-use super::query::TrailQueryExt;
-
-/// Tracks how many [`SimulationLayer`]s are currently installed as a default
-/// subscriber. Used by tests; not part of the capture path.
-static INSTALL_COUNT: AtomicI32 = AtomicI32::new(0);
-
-/// Returns true when at least one [`SimulationLayer`] is currently installed.
-#[inline]
-#[must_use]
-pub fn layer_installed() -> bool {
-    INSTALL_COUNT.load(Ordering::Relaxed) > 0
-}
+use super::query::TraceQuery;
 
 /// Mutable storage for captured events.
-pub(crate) struct EventStore {
+struct EventStore {
     /// Monotonic sequence counter assigned to each captured event.
     seq_counter: u64,
-    /// Captured events grouped by their trail name.
-    by_trail: HashMap<String, Vec<CapturedEvent>>,
+    /// Captured events grouped by their name (the tracing message).
+    by_name: HashMap<String, Vec<TraceEvent>>,
     /// Latest known sim time. Advanced by `SimulationLayerHandle::set_sim_time_ms`
     /// (orchestrator pushes after each `sim.step()`) and read at capture time.
     last_sim_time_ms: u64,
@@ -71,13 +54,37 @@ impl EventStore {
     fn new() -> Self {
         Self {
             seq_counter: 0,
-            by_trail: HashMap::new(),
+            by_name: HashMap::new(),
             last_sim_time_ms: 0,
         }
     }
+
+    fn push(
+        &mut self,
+        time_ms: u64,
+        source: String,
+        target: String,
+        level: tracing::Level,
+        name: String,
+        fields: BTreeMap<String, FieldValue>,
+    ) {
+        let seq = self.seq_counter;
+        self.seq_counter += 1;
+        let event = TraceEvent {
+            seq,
+            time_ms,
+            source,
+            target,
+            level,
+            name: name.clone(),
+            fields,
+        };
+        self.by_name.entry(name).or_default().push(event);
+    }
 }
 
-/// A `tracing::Layer` that captures `capture = true` events and pumps invariants.
+/// A `tracing::Layer` that captures plain trace events emitted inside
+/// process/workload spans.
 pub struct SimulationLayer {
     events: Arc<Mutex<EventStore>>,
     invariants: Arc<Mutex<Vec<Box<dyn Invariant + Send>>>>,
@@ -107,17 +114,16 @@ impl SimulationLayer {
     #[must_use]
     pub fn install(self) -> (SimulationLayerHandle, InstallGuard) {
         let handle = self.handle();
-        INSTALL_COUNT.fetch_add(1, Ordering::Relaxed);
         // Anchor: an inert, always-interested dispatcher kept alive for the
         // lifetime of the guard. `tracing` caches callsite interest globally and
         // recomputes it (against whichever dispatchers are currently live)
-        // whenever that set changes. Without an anchor, a `capture = true`
-        // callsite can be re-cached as `Interest::never` the moment the only
-        // live capturing dispatcher's thread default is a `NoSubscriber` (a
-        // sibling test on another thread, or a guard dropping mid-run), silently
-        // dropping our events. Holding one dispatcher that votes "interested" for
-        // every callsite guarantees the cache can never collapse to `never` while
-        // a layer is installed. See issue #112.
+        // whenever that set changes. Without an anchor, a callsite can be
+        // re-cached as `Interest::never` the moment the only live capturing
+        // dispatcher's thread default is a `NoSubscriber` (a sibling test on
+        // another thread, or a guard dropping mid-run), silently dropping our
+        // events. Holding one dispatcher that votes "interested" for every
+        // callsite guarantees the cache can never collapse to `never` while a
+        // layer is installed. See issue #112.
         let interest_anchor = tracing::Dispatch::new(tracing_subscriber::registry());
         let subscriber = tracing_subscriber::registry().with(self);
         let guard = tracing::subscriber::set_default(subscriber);
@@ -142,19 +148,13 @@ impl Default for SimulationLayer {
 }
 
 /// Drop-guard returned by [`SimulationLayer::install`]. Restores the previous
-/// subscriber and decrements the install count when dropped.
+/// subscriber when dropped.
 pub struct InstallGuard {
     _guard: tracing::subscriber::DefaultGuard,
     /// Inert dispatcher kept alive so tracing's global callsite-interest cache
-    /// cannot collapse capture callsites to `Interest::never` while a layer is
+    /// cannot collapse callsites to `Interest::never` while a layer is
     /// installed. See `SimulationLayer::install`.
     _interest_anchor: tracing::Dispatch,
-}
-
-impl Drop for InstallGuard {
-    fn drop(&mut self) {
-        INSTALL_COUNT.fetch_sub(1, Ordering::Relaxed);
-    }
 }
 
 /// Cheap-to-clone handle to a [`SimulationLayer`]'s captured state.
@@ -165,19 +165,19 @@ pub struct SimulationLayerHandle {
 }
 
 impl SimulationLayerHandle {
-    /// Register an invariant. Subsequently called after every captured event.
+    /// Register an invariant, run on every [`Self::run_invariants`] call.
     pub fn register(&self, inv: Box<dyn Invariant + Send>) {
         self.invariants.lock().push(inv);
     }
 
     /// Reset captured events and invariant state for a new seed.
     ///
-    /// Clears all event vectors, resets sequence counter, calls `Invariant::reset`
-    /// on each registered invariant.
+    /// Clears all event vectors, resets the sequence counter, and calls
+    /// `Invariant::reset` on each registered invariant.
     pub fn reset_for_seed(&self) {
         {
             let mut store = self.events.lock();
-            store.by_trail.clear();
+            store.by_name.clear();
             store.seq_counter = 0;
             store.last_sim_time_ms = 0;
         }
@@ -187,60 +187,63 @@ impl SimulationLayerHandle {
         }
     }
 
-    /// Read all events captured under `trail` as typed entries.
-    ///
-    /// Entries whose payload does not deserialize as `T` are skipped.
-    pub fn trail<T: DeserializeOwned>(&self, trail: &str) -> Vec<TypedEntry<T>> {
-        let store = self.events.lock();
-        let Some(entries) = store.by_trail.get(trail) else {
-            return Vec::new();
-        };
-        entries
-            .iter()
-            .filter_map(TypedEntry::<T>::deserialize)
-            .collect()
-    }
-
     /// Latest known simulation time in milliseconds.
     ///
     /// Updated by [`Self::set_sim_time_ms`] (the orchestrator pushes after
-    /// each `sim.step()`). Read at capture time to stamp the captured event.
+    /// each `sim.step()`). Read at capture time to stamp captured events.
     #[must_use]
     pub fn current_sim_time_ms(&self) -> u64 {
         self.events.lock().last_sim_time_ms
     }
 
     /// Override the latest known simulation time. Called by the orchestrator
-    /// to keep the layer's clock advancing between events.
+    /// to keep the layer's clock advancing between steps.
     pub fn set_sim_time_ms(&self, ms: u64) {
         self.events.lock().last_sim_time_ms = ms;
     }
+
+    /// Record a runner-injected fault into the timeline.
+    ///
+    /// Stored under the [`SIM_FAULT_EVENT_NAME`] event name with
+    /// `source = "sim"`, a `kind` field identifying the fault variant, and
+    /// the fault's payload flattened into fields. `time_ms` is the sim time
+    /// at which the fault occurred (stamped by the engine, not at drain time).
+    pub fn record_sim_fault(&self, time_ms: u64, fault: &SimFaultEvent) {
+        let mut fields = fault.to_fields();
+        fields.insert("kind".to_owned(), FieldValue::Str(fault.kind().to_owned()));
+        self.events.lock().push(
+            time_ms,
+            "sim".to_owned(),
+            "moonpool_sim::fault".to_owned(),
+            tracing::Level::INFO,
+            SIM_FAULT_EVENT_NAME.to_owned(),
+            fields,
+        );
+    }
+
+    /// Run all registered invariants against the captured events at the
+    /// current sim time. Called by the orchestrator after each step.
+    pub fn run_invariants(&self) {
+        let sim_time_ms = self.current_sim_time_ms();
+        let invariants = self.invariants.lock();
+        for inv in invariants.iter() {
+            inv.observe(self, sim_time_ms);
+        }
+    }
 }
 
-/// `TrailQuery` view backed by an [`EventStore`]. Created on the fly inside
-/// `on_event` so invariants can read from the live store without holding the
-/// invariants lock during their `observe` call.
-struct LayerQuery {
-    events: Arc<Mutex<EventStore>>,
-}
-
-impl TrailQuery for LayerQuery {
-    fn len(&self, trail: &str) -> usize {
+impl TraceQuery for SimulationLayerHandle {
+    fn len(&self, name: &str) -> usize {
         self.events
             .lock()
-            .by_trail
-            .get(trail)
+            .by_name
+            .get(name)
             .map_or(0, std::vec::Vec::len)
     }
 
-    fn last_seq(&self) -> u64 {
+    fn since(&self, name: &str, cursor: &Cell<usize>) -> Vec<TraceEvent> {
         let store = self.events.lock();
-        store.seq_counter.saturating_sub(1)
-    }
-
-    fn drain_since(&self, trail: &str, cursor: &Cell<usize>) -> Vec<CapturedEvent> {
-        let store = self.events.lock();
-        let Some(entries) = store.by_trail.get(trail) else {
+        let Some(entries) = store.by_name.get(name) else {
             return Vec::new();
         };
         let len = entries.len();
@@ -248,62 +251,112 @@ impl TrailQuery for LayerQuery {
         if from >= len {
             return Vec::new();
         }
-        let result: Vec<CapturedEvent> = entries[from..].to_vec();
+        let result: Vec<TraceEvent> = entries[from..].to_vec();
         cursor.set(len);
         result
     }
+
+    fn snapshot(&self, name: &str) -> Vec<TraceEvent> {
+        self.events
+            .lock()
+            .by_name
+            .get(name)
+            .cloned()
+            .unwrap_or_default()
+    }
 }
 
-/// Visitor that scans a `tracing::Event` for the capture marker and required
-/// companion fields. After visiting, the populated fields tell the layer
-/// whether and how to record the event.
-struct CaptureVisitor {
-    capture: bool,
-    trail: Option<String>,
-    source: String,
-    payload: Option<Value>,
+/// Span-extension marker storing the `ip` field recorded on a process or
+/// workload span. Read back at event time to attribute the event's source.
+struct SourceIp(String);
+
+/// Visitor that extracts an `ip` field from span attributes.
+struct SpanIpVisitor {
+    ip: Option<String>,
 }
 
-impl CaptureVisitor {
-    fn new() -> Self {
-        Self {
-            capture: false,
-            trail: None,
-            source: String::new(),
-            payload: None,
+impl Visit for SpanIpVisitor {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if field.name() == "ip" {
+            self.ip = Some(value.to_owned());
+        }
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "ip" {
+            self.ip = Some(format!("{value:?}"));
         }
     }
 }
 
-impl Visit for CaptureVisitor {
-    fn record_bool(&mut self, field: &Field, value: bool) {
-        if field.name() == "capture" {
-            self.capture = value;
+/// Visitor that collects an event's message (as its name) and structured
+/// fields.
+struct EventVisitor {
+    name: Option<String>,
+    fields: BTreeMap<String, FieldValue>,
+}
+
+impl EventVisitor {
+    fn new() -> Self {
+        Self {
+            name: None,
+            fields: BTreeMap::new(),
         }
+    }
+}
+
+impl Visit for EventVisitor {
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.fields
+            .insert(field.name().to_owned(), FieldValue::Bool(value));
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.fields
+            .insert(field.name().to_owned(), FieldValue::I64(value));
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.fields
+            .insert(field.name().to_owned(), FieldValue::U64(value));
+    }
+
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        self.fields
+            .insert(field.name().to_owned(), FieldValue::F64(value));
     }
 
     fn record_str(&mut self, field: &Field, value: &str) {
-        match field.name() {
-            "trail" => self.trail = Some(value.to_owned()),
-            "source" => value.clone_into(&mut self.source),
-            _ => {}
-        }
+        self.fields
+            .insert(field.name().to_owned(), FieldValue::Str(value.to_owned()));
     }
 
-    fn record_value(&mut self, field: &Field, value: valuable::Value<'_>) {
-        if field.name() == "event" {
-            // Serialize the Valuable into a serde_json::Value. valuable-serde's
-            // Serializable wrapper bridges Valuable → serde::Serialize.
-            let serializable = valuable_serde::Serializable::new(value);
-            if let Ok(v) = serde_json::to_value(serializable) {
-                self.payload = Some(v);
-            }
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        // `%`-formatted (Display) values also land here, formatted without
+        // quotes by tracing's DisplayValue wrapper.
+        let formatted = format!("{value:?}");
+        if field.name() == "message" {
+            self.name = Some(formatted);
+        } else {
+            self.fields
+                .insert(field.name().to_owned(), FieldValue::Str(formatted));
         }
     }
+}
 
-    fn record_debug(&mut self, _field: &Field, _value: &dyn std::fmt::Debug) {
-        // Other fields (e.g. tracing's auto-added `message`) are ignored.
+/// Walk the event's span scope from the innermost span outwards and return
+/// the first recorded `ip`.
+fn nearest_source<S>(ctx: &Context<'_, S>, event: &tracing::Event<'_>) -> Option<String>
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    let scope = ctx.event_scope(event)?;
+    for span in scope {
+        if let Some(ip) = span.extensions().get::<SourceIp>() {
+            return Some(ip.0.clone());
+        }
     }
+    None
 }
 
 impl<S> Layer<S> for SimulationLayer
@@ -322,49 +375,47 @@ where
         tracing::subscriber::Interest::sometimes()
     }
 
-    fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
-        let mut visitor = CaptureVisitor::new();
-        event.record(&mut visitor);
-        if !visitor.capture {
-            return;
-        }
-        let Some(trail) = visitor.trail else {
-            return;
-        };
-        let Some(payload) = visitor.payload else {
-            return;
-        };
-
-        // Phase 1: append the event under the events lock.
-        let sim_time_ms;
+    fn on_new_span(
+        &self,
+        attrs: &tracing::span::Attributes<'_>,
+        id: &tracing::span::Id,
+        ctx: Context<'_, S>,
+    ) {
+        let mut visitor = SpanIpVisitor { ip: None };
+        attrs.record(&mut visitor);
+        if let Some(ip) = visitor.ip
+            && let Some(span) = ctx.span(id)
         {
-            let mut store = self.events.lock();
-            let seq = store.seq_counter;
-            store.seq_counter += 1;
-            sim_time_ms = store.last_sim_time_ms;
-            store
-                .by_trail
-                .entry(trail.clone())
-                .or_default()
-                .push(CapturedEvent {
-                    trail,
-                    time_ms: sim_time_ms,
-                    source: visitor.source,
-                    seq,
-                    payload,
-                });
+            span.extensions_mut().insert(SourceIp(ip));
         }
+    }
 
-        // Phase 2: run each invariant. The invariants lock is held during the
-        // call; the event store is released so LayerQuery can re-acquire it.
-        // Any captured event an invariant tries to emit is silently dropped by
-        // tracing-core's dispatch reentrancy guard.
-        let query = LayerQuery {
-            events: self.events.clone(),
-        };
-        let invariants = self.invariants.lock();
-        for inv in invariants.iter() {
-            inv.observe(&query, sim_time_ms);
+    fn on_event(&self, event: &tracing::Event<'_>, ctx: Context<'_, S>) {
+        // 1. INFO or more severe only (Level::TRACE > Level::INFO in tracing's
+        //    ordering).
+        if *event.metadata().level() > tracing::Level::INFO {
+            return;
         }
+        // 2. Only events attributable to an actor span carrying an `ip`.
+        let Some(source) = nearest_source(&ctx, event) else {
+            return;
+        };
+        // 3. The message becomes the event name; drop unnamed events.
+        let mut visitor = EventVisitor::new();
+        event.record(&mut visitor);
+        let Some(name) = visitor.name.filter(|n| !n.is_empty()) else {
+            return;
+        };
+
+        let mut store = self.events.lock();
+        let time_ms = store.last_sim_time_ms;
+        store.push(
+            time_ms,
+            source,
+            event.metadata().target().to_owned(),
+            *event.metadata().level(),
+            name,
+            visitor.fields,
+        );
     }
 }

--- a/moonpool-sim/src/observability/mod.rs
+++ b/moonpool-sim/src/observability/mod.rs
@@ -1,55 +1,53 @@
-//! Production-friendly observability layer for moonpool simulations.
+//! Trace-based observability for moonpool simulations.
 //!
-//! Captures correctness-relevant events emitted as ordinary `tracing` events
-//! and runs registered [`Invariant`]s against them after each capture. The
-//! same emission API works in simulation AND in production: any subscriber —
-//! including [`SimulationLayer`] — can consume the events.
+//! Processes and workloads emit ordinary `tracing` events — the exact same
+//! instrumentation production observability consumes (`fmt`, OpenTelemetry,
+//! Loki, ...). In simulation, [`SimulationLayer`] captures those events into
+//! a timeline and registered [`Invariant`]s cross-validate them after every
+//! simulation step. The point: anomalies like dual leaders or metastable
+//! failures are detected in simulation with the same signals you would use
+//! to find them in production — traces.
 //!
 //! # Emission convention
 //!
-//! Use a standard `tracing::*!` macro with three structured fields:
-//!
-//! - `capture = true` — the marker; events without it are ignored by the layer.
-//! - `trail = "name"` — selects which append-only stream the event joins.
-//! - `event = valuable(&payload)` — typed payload via the [`valuable`] crate.
-//!
-//! An optional `source = "..."` field records the originating actor (e.g. a
-//! process IP or `"sim"`). Sim time is stamped automatically from the
-//! orchestrator-pushed clock; do not include it as a field.
+//! Emit a plain `tracing` event with a constant message (the event name) and
+//! structured fields. No special markers, no derives:
 //!
 //! ```ignore
-//! use serde::{Deserialize, Serialize};
-//! use tracing::field::valuable;
-//! use valuable::Valuable;
-//!
-//! #[derive(Valuable, Serialize, Deserialize, Clone)]
-//! struct LeaderElected { term: u64, leader: String }
-//!
-//! tracing::info!(
-//!     capture = true,
-//!     trail = "leader",
-//!     source = node_ip,
-//!     event = valuable(&LeaderElected { term: 5, leader: node_ip.to_string() }),
-//!     "elected",
-//! );
+//! tracing::info!(target: "raft", term, leader = %my_ip, "leader_elected");
 //! ```
 //!
-//! Invariants read the trail via [`TrailQueryExt::since`]:
+//! - Use `%` (`Display`) for strings and IPs — `?` (`Debug`) on a `String`
+//!   includes quotes.
+//! - The message must be a constant name (`"leader_elected"`), not an
+//!   interpolated sentence: events are grouped and queried by name.
+//!
+//! An event is captured iff it is `INFO` or more severe, carries a non-empty
+//! message, and fires inside a process/workload span (the orchestrator wraps
+//! every actor task in a span carrying its `ip`, which becomes the event's
+//! `source`). In production, where no [`SimulationLayer`] is installed, the
+//! same emission flows to whatever subscriber is configured.
+//!
+//! # Querying
+//!
+//! Invariants receive a [`TraceQuery`] and read events by name, extracting
+//! typed fields by key — the same way you would query a production trace
+//! store:
 //!
 //! ```ignore
-//! for entry in q.since::<LeaderElected>("leader", &cursor) {
-//!     // panic on split-brain, validate term monotonicity, etc.
+//! fn observe(&self, q: &dyn TraceQuery, _sim_time_ms: u64) {
+//!     for e in q.since("leader_elected", &self.cursor) {
+//!         let term = e.u64("term");
+//!         let leader = e.str("leader");
+//!         // assert one leader per term...
+//!     }
 //! }
 //! ```
 //!
-//! # Payload type guidance
-//!
-//! Payload types should be **structs** or struct/tuple enum variants. Avoid
-//! unit-variant enums: `valuable-serde` emits them as `{"VariantName": []}`
-//! while `serde`'s default external tagging deserializes from the bare string
-//! `"VariantName"`, so the round-trip silently fails. Add at least one field
-//! (e.g. a `reason: String` for catch-all variants) and the shape is
-//! unambiguous in both directions.
+//! Sim-injected faults (partitions, kills, storage corruption) are recorded
+//! by the runner under the [`crate::SIM_FAULT_EVENT_NAME`] name with a
+//! `kind` field and `source = "sim"`, so invariants can correlate
+//! application anomalies with infrastructure faults in one timeline.
 
 pub mod event;
 pub mod fmt;
@@ -58,40 +56,24 @@ pub mod invariant;
 pub mod layer;
 pub mod query;
 
-pub use event::{CapturedEvent, TypedEntry};
+pub use event::{FieldValue, TraceEvent};
 pub use fmt::{Clock, SimTime};
 pub use init::init_sim_tracing;
 pub use invariant::{Invariant, invariant_fn};
-pub use layer::{InstallGuard, SimulationLayer, SimulationLayerHandle, layer_installed};
-pub use query::{TrailQuery, TrailQueryExt};
+pub use layer::{InstallGuard, SimulationLayer, SimulationLayerHandle};
+pub use query::TraceQuery;
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::cell::Cell;
     use std::sync::Arc;
-    use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
-    use serde::{Deserialize, Serialize};
-    use tracing::field::valuable;
-    use valuable::Valuable;
-
-    use crate::observability::TrailQueryExt;
-
-    /// Realistic correctness fact used by the capture-path tests. A `Heartbeat`
-    /// is the kind of payload a user actually emits: a struct with named
-    /// fields that round-trips cleanly through valuable-serde and serde.
-    #[derive(Debug, Clone, PartialEq, Valuable, Serialize, Deserialize)]
-    struct Heartbeat {
-        node: String,
-        term: u64,
-    }
-
-    fn heartbeat(node: &str, term: u64) -> Heartbeat {
-        Heartbeat {
-            node: node.into(),
-            term,
-        }
+    fn in_actor_span(ip: &str, f: impl FnOnce()) {
+        let span = tracing::info_span!("process", ip = %ip);
+        let _enter = span.enter();
+        f();
     }
 
     // ------------------------------------------------------------------
@@ -102,243 +84,225 @@ mod tests {
     fn emit_without_layer_is_safe() {
         // No layer installed: tracing::info! does not panic and there's
         // nothing to observe. We just check the macro compiles and runs.
-        tracing::info!(
-            capture = true,
-            trail = "hb",
-            source = "10.0.1.1",
-            event = valuable(&heartbeat("n1", 1)),
-        );
+        tracing::info!(term = 1_u64, leader = %"10.0.1.1", "leader_elected");
     }
 
     #[test]
-    fn layer_captures_marked_event() {
-        let layer = SimulationLayer::new();
-        let (handle, _guard) = layer.install();
+    fn layer_captures_event_inside_actor_span() {
+        let (handle, _guard) = SimulationLayer::new().install();
 
         handle.set_sim_time_ms(1234);
-        tracing::info!(
-            capture = true,
-            trail = "hb",
-            source = "10.0.1.1",
-            event = valuable(&heartbeat("n1", 7)),
-        );
+        in_actor_span("10.0.1.1", || {
+            tracing::info!(term = 7_u64, leader = %"10.0.1.1", "leader_elected");
+        });
 
-        let entries = handle.trail::<Heartbeat>("hb");
+        let entries = handle.snapshot("leader_elected");
         assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].event, heartbeat("n1", 7));
-        assert_eq!(entries[0].source, "10.0.1.1");
-        assert_eq!(entries[0].seq, 0);
-        assert_eq!(entries[0].time_ms, 1234);
+        let e = &entries[0];
+        assert_eq!(e.name, "leader_elected");
+        assert_eq!(e.source, "10.0.1.1");
+        assert_eq!(e.seq, 0);
+        assert_eq!(e.time_ms, 1234);
+        assert_eq!(e.level, tracing::Level::INFO);
+        assert_eq!(e.u64("term"), Some(7));
+        assert_eq!(e.str("leader"), Some("10.0.1.1"));
     }
 
     #[test]
-    fn event_missing_capture_marker_is_ignored() {
-        let layer = SimulationLayer::new();
-        let (handle, _guard) = layer.install();
+    fn event_outside_actor_span_is_dropped() {
+        let (handle, _guard) = SimulationLayer::new().install();
 
-        // Note: no `capture = true`.
-        tracing::info!(trail = "hb", event = valuable(&heartbeat("n1", 1)));
+        tracing::info!(term = 7_u64, "leader_elected");
 
-        assert!(handle.trail::<Heartbeat>("hb").is_empty());
+        assert!(handle.snapshot("leader_elected").is_empty());
     }
 
     #[test]
-    fn event_missing_trail_is_ignored() {
-        let layer = SimulationLayer::new();
-        let (handle, _guard) = layer.install();
+    fn debug_level_is_dropped() {
+        let (handle, _guard) = SimulationLayer::new().install();
 
-        tracing::info!(capture = true, event = valuable(&heartbeat("n1", 1)));
+        in_actor_span("10.0.1.1", || {
+            tracing::debug!(term = 7_u64, "leader_elected");
+            tracing::trace!(term = 8_u64, "leader_elected");
+            tracing::warn!(term = 9_u64, "leader_elected");
+        });
 
-        // Without a trail name there's no key to read under.
-        assert!(handle.trail::<Heartbeat>("").is_empty());
-        assert!(handle.trail::<Heartbeat>("hb").is_empty());
+        let entries = handle.snapshot("leader_elected");
+        assert_eq!(entries.len(), 1, "only the WARN event is captured");
+        assert_eq!(entries[0].u64("term"), Some(9));
+        assert_eq!(entries[0].level, tracing::Level::WARN);
     }
 
     #[test]
-    fn event_missing_payload_is_ignored() {
-        let layer = SimulationLayer::new();
-        let (handle, _guard) = layer.install();
+    fn event_without_message_is_dropped() {
+        let (handle, _guard) = SimulationLayer::new().install();
 
-        tracing::info!(capture = true, trail = "hb", "no payload");
+        in_actor_span("10.0.1.1", || {
+            tracing::info!(term = 7_u64);
+        });
 
-        assert!(handle.trail::<Heartbeat>("hb").is_empty());
+        // No message → no name to group under; nothing captured anywhere.
+        assert_eq!(handle.len("leader_elected"), 0);
     }
 
     #[test]
-    fn multiple_trails_are_independent() {
-        let layer = SimulationLayer::new();
-        let (handle, _guard) = layer.install();
+    fn nearest_enclosing_span_wins() {
+        let (handle, _guard) = SimulationLayer::new().install();
 
-        tracing::info!(
-            capture = true,
-            trail = "a",
-            event = valuable(&heartbeat("n1", 1))
-        );
-        tracing::info!(
-            capture = true,
-            trail = "b",
-            event = valuable(&heartbeat("n2", 2))
-        );
-        tracing::info!(
-            capture = true,
-            trail = "a",
-            event = valuable(&heartbeat("n3", 3))
-        );
+        in_actor_span("10.0.1.1", || {
+            in_actor_span("10.0.1.2", || {
+                tracing::info!("ping_sent");
+            });
+        });
 
-        let a = handle.trail::<Heartbeat>("a");
-        let b = handle.trail::<Heartbeat>("b");
-        assert_eq!(a.len(), 2);
-        assert_eq!(b.len(), 1);
-        assert_eq!(a[0].event.node, "n1");
-        assert_eq!(a[1].event.node, "n3");
-        assert_eq!(b[0].event.node, "n2");
+        let entries = handle.snapshot("ping_sent");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].source, "10.0.1.2", "innermost ip attributes");
     }
 
     #[test]
-    fn seq_is_monotonic_across_trails() {
-        let layer = SimulationLayer::new();
-        let (handle, _guard) = layer.install();
+    fn field_accessors_extract_typed_values() {
+        let (handle, _guard) = SimulationLayer::new().install();
 
-        tracing::info!(
-            capture = true,
-            trail = "a",
-            event = valuable(&heartbeat("n", 1))
-        );
-        tracing::info!(
-            capture = true,
-            trail = "b",
-            event = valuable(&heartbeat("n", 2))
-        );
-        tracing::info!(
-            capture = true,
-            trail = "a",
-            event = valuable(&heartbeat("n", 3))
-        );
+        in_actor_span("10.0.1.1", || {
+            tracing::info!(
+                count = 5_u64,
+                delta = -3_i64,
+                ratio = 0.5_f64,
+                ok = true,
+                name = %"alpha",
+                detail = ?vec![1, 2],
+                "mixed_fields"
+            );
+        });
 
-        let a = handle.trail::<Heartbeat>("a");
-        let b = handle.trail::<Heartbeat>("b");
+        let entries = handle.snapshot("mixed_fields");
+        assert_eq!(entries.len(), 1);
+        let e = &entries[0];
+        assert_eq!(e.u64("count"), Some(5));
+        assert_eq!(e.i64("count"), Some(5), "u64 readable as i64 when it fits");
+        assert_eq!(e.i64("delta"), Some(-3));
+        assert_eq!(e.u64("delta"), None, "negative i64 not readable as u64");
+        assert!((e.f64("ratio").expect("ratio field") - 0.5).abs() < f64::EPSILON);
+        assert_eq!(e.bool("ok"), Some(true));
+        assert_eq!(e.str("name"), Some("alpha"), "% display value unquoted");
+        assert_eq!(e.str("detail"), Some("[1, 2]"), "? debug formatting");
+        assert_eq!(e.u64("missing"), None);
+    }
+
+    #[test]
+    fn seq_is_monotonic_across_names() {
+        let (handle, _guard) = SimulationLayer::new().install();
+
+        in_actor_span("10.0.1.1", || {
+            tracing::info!("event_a");
+            tracing::info!("event_b");
+            tracing::info!("event_a");
+        });
+
+        let a = handle.snapshot("event_a");
+        let b = handle.snapshot("event_b");
         assert_eq!(a[0].seq, 0);
         assert_eq!(b[0].seq, 1);
         assert_eq!(a[1].seq, 2);
     }
 
-    /// Send+Sync wrapper around `Cell` for sharing cursors with a `Send`
-    /// invariant closure. moonpool runs single-threaded so this is sound.
-    struct SendCell(Cell<usize>);
-    unsafe impl Send for SendCell {}
-    unsafe impl Sync for SendCell {}
-
     #[test]
     fn cursor_since_returns_only_new_entries() {
-        let layer = SimulationLayer::new();
-        let (handle, _guard) = layer.install();
+        let (handle, _guard) = SimulationLayer::new().install();
 
-        let cursor = Arc::new(SendCell(Cell::new(0)));
-        let cursor_clone = cursor.clone();
-        let observed = Arc::new(AtomicUsize::new(0));
-        let observed_clone = observed.clone();
-        handle.register(invariant_fn("counter", move |q, _t| {
-            let new = q.since::<Heartbeat>("hb", &cursor_clone.0);
-            observed_clone.fetch_add(new.len(), Ordering::Relaxed);
-        }));
+        let cursor = Cell::new(0);
+        in_actor_span("10.0.1.1", || {
+            tracing::info!(n = 1_u64, "hb");
+        });
+        assert_eq!(handle.since("hb", &cursor).len(), 1);
+        assert!(handle.since("hb", &cursor).is_empty(), "cursor advanced");
 
-        tracing::info!(
-            capture = true,
-            trail = "hb",
-            event = valuable(&heartbeat("n", 1))
-        );
-        tracing::info!(
-            capture = true,
-            trail = "hb",
-            event = valuable(&heartbeat("n", 2))
-        );
-
-        // 2 events, but each invariant call sees only the NEW entries past
-        // the cursor: 1 then 1, total 2.
-        assert_eq!(observed.load(Ordering::Relaxed), 2);
+        in_actor_span("10.0.1.1", || {
+            tracing::info!(n = 2_u64, "hb");
+        });
+        let new = handle.since("hb", &cursor);
+        assert_eq!(new.len(), 1);
+        assert_eq!(new[0].u64("n"), Some(2));
     }
 
     #[test]
     fn reset_for_seed_clears_state() {
-        let layer = SimulationLayer::new();
-        let (handle, _guard) = layer.install();
+        let (handle, _guard) = SimulationLayer::new().install();
 
-        tracing::info!(
-            capture = true,
-            trail = "hb",
-            event = valuable(&heartbeat("n", 1))
-        );
+        in_actor_span("10.0.1.1", || {
+            tracing::info!(n = 1_u64, "hb");
+        });
+        handle.set_sim_time_ms(500);
         handle.reset_for_seed();
-        tracing::info!(
-            capture = true,
-            trail = "hb",
-            event = valuable(&heartbeat("n", 2))
-        );
+        in_actor_span("10.0.1.1", || {
+            tracing::info!(n = 2_u64, "hb");
+        });
 
-        let entries = handle.trail::<Heartbeat>("hb");
+        let entries = handle.snapshot("hb");
         assert_eq!(entries.len(), 1, "reset cleared the first event");
         assert_eq!(entries[0].seq, 0, "seq counter resets per seed");
         assert_eq!(handle.current_sim_time_ms(), 0, "clock resets per seed");
     }
 
     #[test]
-    fn invariants_run_after_each_event_with_sim_time() {
-        let layer = SimulationLayer::new();
-        let (handle, _guard) = layer.install();
+    fn run_invariants_pumps_registered_invariants() {
+        let (handle, _guard) = SimulationLayer::new().install();
 
-        let last_time = Arc::new(AtomicU64::new(u64::MAX));
-        let last_time_clone = last_time.clone();
-        let calls = Arc::new(AtomicUsize::new(0));
-        let calls_clone = calls.clone();
-        handle.register(invariant_fn("witness", move |_q, t| {
-            last_time_clone.store(t, Ordering::Relaxed);
-            calls_clone.fetch_add(1, Ordering::Relaxed);
+        let observed = Arc::new(AtomicUsize::new(0));
+        let observed_clone = observed.clone();
+        let cursor = Cell::new(0);
+        handle.register(invariant_fn("counter", move |q, _t| {
+            let new = q.since("hb", &cursor);
+            observed_clone.fetch_add(new.len(), Ordering::Relaxed);
         }));
 
-        handle.set_sim_time_ms(100);
-        tracing::info!(
-            capture = true,
-            trail = "hb",
-            event = valuable(&heartbeat("n", 1))
+        in_actor_span("10.0.1.1", || {
+            tracing::info!(n = 1_u64, "hb");
+            tracing::info!(n = 2_u64, "hb");
+        });
+        assert_eq!(
+            observed.load(Ordering::Relaxed),
+            0,
+            "invariants do not run inside tracing dispatch"
         );
-        assert_eq!(calls.load(Ordering::Relaxed), 1);
-        assert_eq!(last_time.load(Ordering::Relaxed), 100);
 
-        handle.set_sim_time_ms(250);
-        tracing::info!(
-            capture = true,
-            trail = "hb",
-            event = valuable(&heartbeat("n", 2))
-        );
-        assert_eq!(calls.load(Ordering::Relaxed), 2);
-        assert_eq!(last_time.load(Ordering::Relaxed), 250);
+        handle.run_invariants();
+        assert_eq!(observed.load(Ordering::Relaxed), 2, "batched at pump time");
+
+        handle.run_invariants();
+        assert_eq!(observed.load(Ordering::Relaxed), 2, "cursor advanced");
     }
 
     #[test]
-    fn invariant_emitting_event_is_silently_dropped() {
-        // tracing-core's dispatch reentrancy guard suppresses events emitted
-        // from inside another event's processing. So an invariant that emits
-        // captured events is a no-op — no deadlock, no double-capture, no
-        // panic. We document and lock in this behavior.
-        let layer = SimulationLayer::new();
-        let (handle, _guard) = layer.install();
+    fn record_sim_fault_lands_in_timeline() {
+        use crate::chaos::{SIM_FAULT_EVENT_NAME, SimFaultEvent};
 
-        handle.register(invariant_fn("noisy", |_q, _t| {
-            tracing::info!(
-                capture = true,
-                trail = "from_invariant",
-                event = valuable(&heartbeat("from_inv", 99)),
-            );
-        }));
+        let (handle, _guard) = SimulationLayer::new().install();
 
-        tracing::info!(
-            capture = true,
-            trail = "outer",
-            event = valuable(&heartbeat("outer", 1)),
+        handle.record_sim_fault(
+            42,
+            &SimFaultEvent::PartitionCreated {
+                from: "10.0.1.1".to_owned(),
+                to: "10.0.1.2".to_owned(),
+            },
+        );
+        handle.record_sim_fault(
+            43,
+            &SimFaultEvent::ProcessForceKill {
+                ip: "10.0.1.1".to_owned(),
+            },
         );
 
-        assert_eq!(handle.trail::<Heartbeat>("outer").len(), 1);
-        assert!(handle.trail::<Heartbeat>("from_invariant").is_empty());
+        let entries = handle.snapshot(SIM_FAULT_EVENT_NAME);
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].source, "sim");
+        assert_eq!(entries[0].time_ms, 42);
+        assert_eq!(entries[0].str("kind"), Some("partition_created"));
+        assert_eq!(entries[0].str("from"), Some("10.0.1.1"));
+        assert_eq!(entries[0].str("to"), Some("10.0.1.2"));
+        assert_eq!(entries[1].str("kind"), Some("process_force_kill"));
+        assert_eq!(entries[1].str("ip"), Some("10.0.1.1"));
     }
 
     // ------------------------------------------------------------------

--- a/moonpool-sim/src/observability/query.rs
+++ b/moonpool-sim/src/observability/query.rs
@@ -1,54 +1,29 @@
-//! Read-side traits used by invariants to inspect captured events.
+//! Read-side trait used by invariants to inspect captured trace events.
 //!
-//! [`TrailQuery`] is dyn-safe (no generic methods) so invariants can take
-//! `&dyn TrailQuery`. The generic helpers live on [`TrailQueryExt`], which is
-//! auto-implemented for every `TrailQuery`. Cursor-based incremental scans
-//! deserialize the payload into the caller-chosen `T` on demand.
+//! [`TraceQuery`] is dyn-safe so invariants can take `&dyn TraceQuery`.
+//! Events are keyed by their name (the `tracing` message), mirroring how a
+//! production trace store is queried by event name. Typed values are
+//! extracted per field via the accessors on
+//! [`TraceEvent`](super::event::TraceEvent).
 
 use std::cell::Cell;
 
-use serde::de::DeserializeOwned;
+use super::event::TraceEvent;
 
-use super::event::{CapturedEvent, TypedEntry};
+/// Read-only view of captured trace events provided to invariants.
+pub trait TraceQuery {
+    /// Total number of events captured under `name`.
+    fn len(&self, name: &str) -> usize;
 
-/// Read-only view of captured events provided to invariants.
-///
-/// Dyn-safe core; for the generic `since::<T>` helper, see [`TrailQueryExt`].
-pub trait TrailQuery {
-    /// Total number of events captured under `trail`.
-    fn len(&self, trail: &str) -> usize;
-
-    /// Highest sequence number assigned so far. Returns 0 if no events yet.
-    fn last_seq(&self) -> u64;
-
-    /// Drain new captured events under `trail` past `cursor`, advance `cursor`
-    /// to the new end, and return clones.
-    fn drain_since(&self, trail: &str, cursor: &Cell<usize>) -> Vec<CapturedEvent>;
-}
-
-/// Generic helpers on top of [`TrailQuery`].
-///
-/// Provides the typed `since::<T>` and `snapshot::<T>` APIs. Auto-implemented
-/// for every type that implements [`TrailQuery`], including `dyn TrailQuery`.
-pub trait TrailQueryExt: TrailQuery {
-    /// Drain new typed events under `trail` past `cursor`, advance `cursor`,
-    /// and deserialize each payload into `T`.
+    /// Return clones of events named `name` past `cursor`, and advance the
+    /// cursor to the new end.
     ///
-    /// Entries whose payload does not deserialize as `T` are skipped. The
-    /// cursor is always advanced to the current length of the trail.
-    fn since<T: DeserializeOwned>(&self, trail: &str, cursor: &Cell<usize>) -> Vec<TypedEntry<T>> {
-        self.drain_since(trail, cursor)
-            .iter()
-            .filter_map(TypedEntry::<T>::deserialize)
-            .collect()
-    }
+    /// Cursors index into the per-name event list and stay stable within a
+    /// seed; reset them in [`Invariant::reset`](super::Invariant::reset).
+    fn since(&self, name: &str, cursor: &Cell<usize>) -> Vec<TraceEvent>;
 
-    /// Snapshot all typed events under `trail`. Convenience for full re-scans;
-    /// prefer [`since`](Self::since) when an incremental cursor will do.
-    fn snapshot<T: DeserializeOwned>(&self, trail: &str) -> Vec<TypedEntry<T>> {
-        let cursor = Cell::new(0);
-        self.since::<T>(trail, &cursor)
-    }
+    /// All events captured under `name` since the start of the seed.
+    /// Convenience for full re-scans; prefer [`since`](Self::since) when an
+    /// incremental cursor will do.
+    fn snapshot(&self, name: &str) -> Vec<TraceEvent>;
 }
-
-impl<Q: TrailQuery + ?Sized> TrailQueryExt for Q {}

--- a/moonpool-sim/src/runner/builder.rs
+++ b/moonpool-sim/src/runner/builder.rs
@@ -9,7 +9,7 @@ use std::time::{Duration, Instant};
 use tracing::instrument;
 
 use crate::SimulationError;
-use crate::observability::{Invariant, SimulationLayer, SimulationLayerHandle, TrailQuery};
+use crate::observability::{Invariant, SimulationLayer, SimulationLayerHandle, TraceQuery};
 use crate::runner::fault_injector::FaultInjector;
 use crate::runner::process::{Attrition, Process};
 use crate::runner::tags::TagDistribution;
@@ -487,7 +487,7 @@ impl SimulationBuilder {
         self
     }
 
-    /// Add an invariant to be checked after every simulation event.
+    /// Add an invariant to be checked after every simulation step.
     #[must_use]
     pub fn invariant<I: Invariant>(mut self, i: I) -> Self {
         self.invariants.push(Box::new(i));
@@ -499,7 +499,7 @@ impl SimulationBuilder {
     pub fn invariant_fn(
         mut self,
         name: impl Into<String>,
-        f: impl Fn(&dyn TrailQuery, u64) + Send + 'static,
+        f: impl Fn(&dyn TraceQuery, u64) + Send + 'static,
     ) -> Self {
         self.invariants
             .push(crate::observability::invariant_fn(name, f));

--- a/moonpool-sim/src/runner/context.rs
+++ b/moonpool-sim/src/runner/context.rs
@@ -16,14 +16,9 @@
 //! }
 //! ```
 
-use serde::Serialize;
-use serde::de::DeserializeOwned;
-use tracing::field::valuable;
-use valuable::Valuable;
-
 use crate::chaos::state_handle::StateHandle;
 use crate::network::SimNetworkProvider;
-use crate::observability::{SimulationLayerHandle, TypedEntry};
+use crate::observability::SimulationLayerHandle;
 use crate::providers::{SimProviders, SimRandomProvider, SimTimeProvider};
 use crate::storage::SimStorageProvider;
 
@@ -154,37 +149,14 @@ impl SimContext {
         &self.state
     }
 
-    /// Emit a typed event to a named trail.
+    /// Get a clonable handle to the observability layer.
     ///
-    /// Emits a `tracing::info!` with `capture = true`, `trail = key`,
-    /// `source = my_ip`, and `event = valuable(&event)`. A
-    /// [`crate::observability::SimulationLayer`] subscribed alongside other
-    /// `tracing` subscribers captures the typed payload and runs invariants.
-    /// Without a layer (e.g. in production), the event still reaches
-    /// subscribers like `fmt` or `OTel` with structured fields.
-    pub fn emit<T>(&self, trail: &'static str, event: T)
-    where
-        T: Valuable + Serialize,
-    {
-        tracing::info!(
-            capture = true,
-            trail = trail,
-            source = self.my_ip(),
-            event = valuable(&event),
-        );
-    }
-
-    /// Read all captured events under `trail` as typed entries.
-    ///
-    /// Returns an empty vector if no [`crate::observability::SimulationLayer`]
-    /// is installed, no events were captured, or none of them match `T`.
-    #[must_use]
-    pub fn trail<T: DeserializeOwned>(&self, trail: &str) -> Vec<TypedEntry<T>> {
-        self.obs.trail(trail)
-    }
-
-    /// Get a clonable handle to the observability layer, for advanced
-    /// post-simulation inspection.
+    /// The handle implements [`crate::TraceQuery`], so workloads can read
+    /// the captured timeline (e.g. in `check()`) the same way invariants do.
+    /// To get events INTO the timeline, emit plain `tracing` events — e.g.
+    /// `tracing::info!(term, leader = %ip, "leader_elected")` — from inside
+    /// a process or workload task; the orchestrator's actor spans attribute
+    /// them automatically.
     #[must_use]
     pub fn observability(&self) -> &SimulationLayerHandle {
         &self.obs

--- a/moonpool-sim/src/runner/orchestrator.rs
+++ b/moonpool-sim/src/runner/orchestrator.rs
@@ -8,9 +8,9 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
-use tracing::field::valuable;
+use tracing::Instrument as _;
 
-use crate::chaos::fault_events::{SIM_FAULT_TRAIL, SimFaultEvent};
+use crate::chaos::fault_events::SimFaultEvent;
 use crate::chaos::state_handle::StateHandle;
 use crate::observability::SimulationLayerHandle;
 use crate::runner::builder::WorkloadClientInfo;
@@ -244,11 +244,14 @@ impl<'a> ProcessManager<'a> {
         let providers = crate::SimProviders::new(sim.clone(), seed, ip);
         let ctx = SimContext::new(providers, topology, state.clone(), obs.clone());
         let ip_for_log = ip_str.clone();
-        let handle = tokio::spawn(async move {
-            if let Err(e) = process.run(&ctx).await {
-                tracing::debug!("Restarted process at {} exited: {}", ip_for_log, e);
+        let handle = tokio::spawn(
+            async move {
+                if let Err(e) = process.run(&ctx).await {
+                    tracing::debug!("Restarted process at {} exited: {}", ip_for_log, e);
+                }
             }
-        });
+            .instrument(tracing::info_span!("process", ip = %ip_str)),
+        );
         self.handles[idx] = Some(handle);
         // Process is alive again
         let current = self.dead_count.load(Ordering::Relaxed);
@@ -872,6 +875,9 @@ impl WorkloadOrchestrator {
                 metrics: sim.extract_metrics(),
             });
         }
+        // Faults recorded during settle carry their own timestamps; one pump
+        // suffices to flush them into the timeline.
+        Self::pump_observability(sim, obs);
 
         // === 7. CHECK PHASE (tokio::spawn + cooperative stepping) ===
         let final_workloads = Self::do_check_phase(CheckPhaseInputs {
@@ -947,7 +953,7 @@ impl WorkloadOrchestrator {
             state,
             obs,
         })?;
-        Ok(Self::run_check_phase(sim, workloads, check_contexts).await)
+        Ok(Self::run_check_phase(sim, workloads, check_contexts, obs).await)
     }
 
     /// Run the entire setup phase: spawn `setup()` futures, drive the
@@ -984,11 +990,15 @@ impl WorkloadOrchestrator {
     ) -> Vec<SetupHandle> {
         let mut setup_handles = Vec::with_capacity(workloads.len());
         for (workload, ctx) in workloads.into_iter().zip(contexts) {
-            let handle = tokio::spawn(async move {
-                let mut w = workload;
-                let result = w.setup(&ctx).await;
-                (w, ctx, result)
-            });
+            let ip = ctx.my_ip().to_string();
+            let handle = tokio::spawn(
+                async move {
+                    let mut w = workload;
+                    let result = w.setup(&ctx).await;
+                    (w, ctx, result)
+                }
+                .instrument(tracing::info_span!("workload", ip = %ip)),
+            );
             setup_handles.push(handle);
         }
         setup_handles
@@ -1002,11 +1012,15 @@ impl WorkloadOrchestrator {
     ) -> WorkloadHandleSlots {
         let mut workload_handles = Vec::with_capacity(workloads.len());
         for (workload, ctx) in workloads.into_iter().zip(contexts) {
-            let handle = tokio::spawn(async move {
-                let mut w = workload;
-                let result = w.run(&ctx).await;
-                (w, result)
-            });
+            let ip = ctx.my_ip().to_string();
+            let handle = tokio::spawn(
+                async move {
+                    let mut w = workload;
+                    let result = w.run(&ctx).await;
+                    (w, result)
+                }
+                .instrument(tracing::info_span!("workload", ip = %ip)),
+            );
             workload_handles.push(Some(handle));
         }
         workload_handles
@@ -1076,9 +1090,6 @@ impl WorkloadOrchestrator {
 
             if sim.pending_event_count() > 0 {
                 sim.step();
-                obs.set_sim_time_ms(
-                    u64::try_from(sim.current_time().as_millis()).unwrap_or(u64::MAX),
-                );
                 Self::handle_process_events(
                     sim,
                     process_manager,
@@ -1087,6 +1098,7 @@ impl WorkloadOrchestrator {
                     obs,
                     shutdown_signal,
                 );
+                Self::pump_observability(sim, obs);
             }
 
             let any_finished =
@@ -1130,6 +1142,8 @@ impl WorkloadOrchestrator {
                 tokio::task::yield_now().await;
             }
         }
+        // Final pump: capture events emitted after the last step.
+        Self::pump_observability(sim, obs);
         Ok(())
     }
 
@@ -1415,11 +1429,15 @@ impl WorkloadOrchestrator {
             let providers = crate::SimProviders::new(sim.downgrade(), seed, ip_addr);
             let ctx = SimContext::new(providers, topology, state.clone(), obs.clone());
             let ip_for_log = ip.clone();
-            let handle = tokio::spawn(async move {
-                if let Err(e) = process.run(&ctx).await {
-                    tracing::debug!("Process at {} exited: {}", ip_for_log, e);
+            let span_ip = ip.clone();
+            let handle = tokio::spawn(
+                async move {
+                    if let Err(e) = process.run(&ctx).await {
+                        tracing::debug!("Process at {} exited: {}", ip_for_log, e);
+                    }
                 }
-            });
+                .instrument(tracing::info_span!("process", ip = %span_ip)),
+            );
             process_handles.push(Some(handle));
             process_tokens.push(Some(process_token));
             tracing::debug!("Booted process {} at {}", i, ip);
@@ -1433,17 +1451,22 @@ impl WorkloadOrchestrator {
         sim: &mut crate::sim::SimWorld,
         workloads: Vec<Box<dyn Workload>>,
         contexts: Vec<SimContext>,
+        obs: &SimulationLayerHandle,
     ) -> Vec<Box<dyn Workload>> {
         let mut check_handles = Vec::with_capacity(workloads.len());
         for (workload, ctx) in workloads.into_iter().zip(contexts) {
-            let handle = tokio::spawn(async move {
-                let mut w = workload;
-                let result = w.check(&ctx).await;
-                if let Err(ref e) = result {
-                    tracing::error!("Workload '{}' check failed: {}", w.name(), e);
+            let ip = ctx.my_ip().to_string();
+            let handle = tokio::spawn(
+                async move {
+                    let mut w = workload;
+                    let result = w.check(&ctx).await;
+                    if let Err(ref e) = result {
+                        tracing::error!("Workload '{}' check failed: {}", w.name(), e);
+                    }
+                    w
                 }
-                w
-            });
+                .instrument(tracing::info_span!("workload", ip = %ip)),
+            );
             check_handles.push(handle);
         }
 
@@ -1457,9 +1480,11 @@ impl WorkloadOrchestrator {
             }
             if sim.pending_event_count() > 0 {
                 sim.step();
+                Self::pump_observability(sim, obs);
             }
             tokio::task::yield_now().await;
         }
+        Self::pump_observability(sim, obs);
 
         // Collect check results.
         let mut final_workloads = Vec::with_capacity(check_handles.len());
@@ -1639,9 +1664,11 @@ impl WorkloadOrchestrator {
                     obs,
                     shutdown_signal,
                 );
+                Self::pump_observability(sim, obs);
             }
             tokio::task::yield_now().await;
         }
+        Self::pump_observability(sim, obs);
     }
 
     /// Collect results from spawned `setup()` tasks.
@@ -1675,6 +1702,24 @@ impl WorkloadOrchestrator {
             }
         }
         (workloads, contexts, setup_results, setup_failed)
+    }
+
+    /// Current simulation time in milliseconds, saturating at `u64::MAX`.
+    fn sim_now_ms(sim: &crate::sim::SimWorld) -> u64 {
+        u64::try_from(sim.current_time().as_millis()).unwrap_or(u64::MAX)
+    }
+
+    /// Pump the observability pipeline after a simulation step.
+    ///
+    /// Pushes the sim clock into the layer (stamping subsequently captured
+    /// trace events), drains engine-recorded faults into the timeline, and
+    /// runs registered invariants over everything captured so far.
+    fn pump_observability(sim: &crate::sim::SimWorld, obs: &SimulationLayerHandle) {
+        obs.set_sim_time_ms(Self::sim_now_ms(sim));
+        for record in sim.take_faults() {
+            obs.record_sim_fault(record.time_ms, &record.event);
+        }
+        obs.run_invariants();
     }
 
     /// Drain remaining simulation events synchronously after all workloads
@@ -1727,12 +1772,7 @@ impl WorkloadOrchestrator {
                     ip: ip.to_string(),
                     grace_period_ms,
                 };
-                tracing::info!(
-                    capture = true,
-                    trail = SIM_FAULT_TRAIL,
-                    source = "sim",
-                    event = valuable(&event),
-                );
+                obs.record_sim_fault(Self::sim_now_ms(sim), &event);
                 process_manager.signal_graceful_shutdown(ip);
                 sim.schedule_event(
                     crate::sim::Event::ProcessForceKill {
@@ -1747,12 +1787,7 @@ impl WorkloadOrchestrator {
                 recovery_delay_ms,
             }) => {
                 let event = SimFaultEvent::ProcessForceKill { ip: ip.to_string() };
-                tracing::info!(
-                    capture = true,
-                    trail = SIM_FAULT_TRAIL,
-                    source = "sim",
-                    event = valuable(&event),
-                );
+                obs.record_sim_fault(Self::sim_now_ms(sim), &event);
                 process_manager.abort_process(ip);
                 sim.abort_all_connections_for_ip(ip);
                 sim.schedule_process_restart(ip, Duration::from_millis(recovery_delay_ms));
@@ -1760,12 +1795,7 @@ impl WorkloadOrchestrator {
             Some(crate::sim::Event::ProcessRestart { ip }) => {
                 assert_reachable!("event: ProcessRestart");
                 let event = SimFaultEvent::ProcessRestart { ip: ip.to_string() };
-                tracing::info!(
-                    capture = true,
-                    trail = SIM_FAULT_TRAIL,
-                    source = "sim",
-                    event = valuable(&event),
-                );
+                obs.record_sim_fault(Self::sim_now_ms(sim), &event);
                 let weak_sim = sim.downgrade();
                 process_manager.handle_restart(ip, &weak_sim, seed, state, obs, shutdown_signal);
             }

--- a/moonpool-sim/src/sim/mod.rs
+++ b/moonpool-sim/src/sim/mod.rs
@@ -29,4 +29,4 @@ pub use rng::{
     set_rng_breakpoints, set_sim_seed, sim_random, sim_random_range, sim_random_range_or_default,
 };
 pub use sleep::SleepFuture;
-pub use world::{SimWorld, WeakSimWorld};
+pub use world::{SimFaultRecord, SimWorld, WeakSimWorld};

--- a/moonpool-sim/src/sim/storage_ops.rs
+++ b/moonpool-sim/src/sim/storage_ops.rs
@@ -112,7 +112,7 @@ fn handle_read_complete(inner: &mut SimInner, file_id: FileId) {
     if read_faulted {
         let ip = inner.storage.files.get(&file_id).map(|f| f.owner_ip);
         if let Some(ip) = ip {
-            SimInner::emit_fault(&SimFaultEvent::StorageReadFault {
+            inner.record_fault(SimFaultEvent::StorageReadFault {
                 ip: ip.to_string(),
                 file_id: file_id.0,
             });
@@ -214,10 +214,10 @@ fn handle_write_complete(inner: &mut SimInner, file_id: FileId) {
         }
     }
     if let (Some(kind), Some(ip)) = (write_fault_kind, owner_ip) {
-        SimInner::emit_fault(&SimFaultEvent::StorageWriteFault {
+        inner.record_fault(SimFaultEvent::StorageWriteFault {
             ip: ip.to_string(),
             file_id: file_id.0,
-            kind: kind.to_string(),
+            write_kind: kind.to_string(),
         });
     }
 
@@ -254,7 +254,7 @@ fn handle_sync_complete(inner: &mut SimInner, file_id: FileId) {
         // Data remains in pending state and may be lost on crash
         let ip = inner.storage.files.get(&file_id).map(|f| f.owner_ip);
         if let Some(ip) = ip {
-            SimInner::emit_fault(&SimFaultEvent::StorageSyncFault {
+            inner.record_fault(SimFaultEvent::StorageSyncFault {
                 ip: ip.to_string(),
                 file_id: file_id.0,
             });
@@ -946,7 +946,7 @@ impl SimWorld {
             }
         }
 
-        SimInner::emit_fault(&SimFaultEvent::StorageCrash { ip: ip.to_string() });
+        inner.record_fault(SimFaultEvent::StorageCrash { ip: ip.to_string() });
 
         tracing::info!(
             "Storage crash simulated for {}: {} files affected, close_files={}",
@@ -1003,7 +1003,7 @@ impl SimWorld {
             }
         }
 
-        SimInner::emit_fault(&SimFaultEvent::StorageWipe { ip: ip.to_string() });
+        inner.record_fault(SimFaultEvent::StorageWipe { ip: ip.to_string() });
 
         tracing::info!("Storage wiped for {}: {} files deleted", ip, file_ids.len(),);
     }

--- a/moonpool-sim/src/sim/world.rs
+++ b/moonpool-sim/src/sim/world.rs
@@ -12,11 +12,9 @@ use std::{
 };
 use tracing::instrument;
 
-use tracing::field::valuable;
-
 use crate::{
     SimulationError, SimulationResult,
-    chaos::fault_events::{SIM_FAULT_TRAIL, SimFaultEvent},
+    chaos::fault_events::SimFaultEvent,
     network::{
         NetworkConfiguration, PartitionStrategy,
         sim::{ConnectionId, ListenerId, SimNetworkProvider},
@@ -65,6 +63,10 @@ pub(crate) struct SimInner {
 
     // Last event processed by step() — used by orchestrator to detect ProcessRestart
     pub(crate) last_processed_event: Option<Event>,
+
+    /// Faults recorded by the engine since the last [`SimWorld::take_faults`]
+    /// drain. The runner pumps these into the observability timeline.
+    pub(crate) pending_faults: Vec<SimFaultRecord>,
 }
 
 impl SimInner {
@@ -82,6 +84,7 @@ impl SimInner {
             events_processed: 0,
             last_bit_flip_time: Duration::ZERO,
             last_processed_event: None,
+            pending_faults: Vec::new(),
         }
     }
 
@@ -99,22 +102,18 @@ impl SimInner {
             events_processed: 0,
             last_bit_flip_time: Duration::ZERO,
             last_processed_event: None,
+            pending_faults: Vec::new(),
         }
     }
 
-    /// Emit a fault event to the [`SIM_FAULT_TRAIL`].
+    /// Record an engine-injected fault, stamped with the current sim time.
     ///
-    /// Emits a `tracing::info!` with `capture = true`, `trail = SIM_FAULT_TRAIL`,
-    /// `source = "sim"`, and the typed event. The active
-    /// [`crate::observability::SimulationLayer`] (if any) captures it for
-    /// invariants; production subscribers see structured fields.
-    pub(crate) fn emit_fault(event: &SimFaultEvent) {
-        tracing::info!(
-            capture = true,
-            trail = SIM_FAULT_TRAIL,
-            source = "sim",
-            event = valuable(event),
-        );
+    /// Faults accumulate in [`SimInner::pending_faults`] until the runner
+    /// drains them via [`SimWorld::take_faults`] into the observability
+    /// timeline. The engine never touches `tracing` for faults.
+    pub(crate) fn record_fault(&mut self, event: SimFaultEvent) {
+        let time_ms = u64::try_from(self.current_time.as_millis()).unwrap_or(u64::MAX);
+        self.pending_faults.push(SimFaultRecord { time_ms, event });
     }
 
     /// Calculate the number of bits to flip using a power-law distribution.
@@ -138,6 +137,20 @@ impl SimInner {
         // Clamp to configured range
         bit_count.clamp(min_bits, max_bits)
     }
+}
+
+/// A fault recorded by the simulation engine, stamped with the sim time at
+/// which it occurred.
+///
+/// Drained by the runner via [`SimWorld::take_faults`] and recorded into the
+/// observability timeline under
+/// [`crate::SIM_FAULT_EVENT_NAME`](crate::chaos::SIM_FAULT_EVENT_NAME).
+#[derive(Debug, Clone)]
+pub struct SimFaultRecord {
+    /// Simulation time in milliseconds when the fault occurred.
+    pub time_ms: u64,
+    /// The fault event.
+    pub event: SimFaultEvent,
 }
 
 /// The central simulation coordinator that manages time and event processing.
@@ -174,6 +187,24 @@ impl SimWorld {
     #[must_use]
     pub fn new() -> Self {
         Self::create(None, 0)
+    }
+
+    /// Drain engine-recorded faults accumulated since the last call.
+    ///
+    /// The runner calls this after each `step()` to pump faults into the
+    /// observability timeline; tests can call it directly to assert on the
+    /// fault sequence.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the simulation lock is poisoned by a prior task panic.
+    #[must_use]
+    pub fn take_faults(&self) -> Vec<SimFaultRecord> {
+        let mut inner = self
+            .inner
+            .write()
+            .expect("RwLock poisoned: prior task panicked");
+        std::mem::take(&mut inner.pending_faults)
     }
 
     /// Creates a new simulation world with a specific seed for deterministic randomness.
@@ -1002,13 +1033,13 @@ impl SimWorld {
                 {
                     conn.flags.set_is_cut(false);
                     conn.cut_expiry = None;
-                    SimInner::emit_fault(&SimFaultEvent::CutRestored { connection_id: id });
+                    inner.record_fault(SimFaultEvent::CutRestored { connection_id: id });
                     tracing::debug!("Connection {} restored via scheduled event", id);
                     Self::wake_all(&mut inner.wakers.cuts, connection_id);
                 }
             }
             ConnectionStateChange::HalfOpenError => {
-                SimInner::emit_fault(&SimFaultEvent::HalfOpenError { connection_id: id });
+                inner.record_fault(SimFaultEvent::HalfOpenError { connection_id: id });
                 tracing::debug!("Connection {} half-open error time reached", id);
                 if let Some(waker) = inner.wakers.reads.remove(&connection_id) {
                     waker.wake();
@@ -1251,7 +1282,7 @@ impl SimWorld {
             flipped_positions.len()
         );
 
-        SimInner::emit_fault(&SimFaultEvent::BitFlip {
+        inner.record_fault(SimFaultEvent::BitFlip {
             connection_id: connection_id.0,
             flip_count: flipped_positions.len(),
         });
@@ -2308,7 +2339,7 @@ impl SimWorld {
 
         inner.network.last_random_close_time = current_time;
 
-        SimInner::emit_fault(&SimFaultEvent::RandomClose {
+        inner.record_fault(SimFaultEvent::RandomClose {
             connection_id: connection_id.0,
         });
 
@@ -2542,7 +2573,7 @@ impl SimWorld {
         let scheduled_event = ScheduledEvent::new(expires_at, restore_event, sequence);
         inner.event_queue.schedule(scheduled_event);
 
-        SimInner::emit_fault(&SimFaultEvent::PartitionCreated {
+        inner.record_fault(SimFaultEvent::PartitionCreated {
             from: from_ip.to_string(),
             to: to_ip.to_string(),
         });
@@ -2587,7 +2618,7 @@ impl SimWorld {
         let scheduled_event = ScheduledEvent::new(expires_at, clear_event, sequence);
         inner.event_queue.schedule(scheduled_event);
 
-        SimInner::emit_fault(&SimFaultEvent::SendPartitionCreated { ip: ip.to_string() });
+        inner.record_fault(SimFaultEvent::SendPartitionCreated { ip: ip.to_string() });
         tracing::debug!("Partitioned sends from {} until {:?}", ip, expires_at);
         Ok(())
     }
@@ -2623,7 +2654,7 @@ impl SimWorld {
         let scheduled_event = ScheduledEvent::new(expires_at, clear_event, sequence);
         inner.event_queue.schedule(scheduled_event);
 
-        SimInner::emit_fault(&SimFaultEvent::RecvPartitionCreated { ip: ip.to_string() });
+        inner.record_fault(SimFaultEvent::RecvPartitionCreated { ip: ip.to_string() });
         tracing::debug!("Partitioned receives to {} until {:?}", ip, expires_at);
         Ok(())
     }
@@ -2647,7 +2678,7 @@ impl SimWorld {
             .write()
             .expect("RwLock poisoned: prior task panicked");
         inner.network.ip_partitions.remove(&(from_ip, to_ip));
-        SimInner::emit_fault(&SimFaultEvent::PartitionHealed {
+        inner.record_fault(SimFaultEvent::PartitionHealed {
             from: from_ip.to_string(),
             to: to_ip.to_string(),
         });
@@ -2774,9 +2805,15 @@ impl SimWorld {
                     .ip_partitions
                     .insert((to_ip, from_ip), PartitionState { expires_at });
 
-                SimInner::emit_fault(&SimFaultEvent::PartitionCreated {
-                    from: from_ip.to_string(),
-                    to: to_ip.to_string(),
+                // Disjoint-field push: `partition_config` still borrows
+                // `inner.network`, so go through `pending_faults` directly.
+                let time_ms = u64::try_from(inner.current_time.as_millis()).unwrap_or(u64::MAX);
+                inner.pending_faults.push(SimFaultRecord {
+                    time_ms,
+                    event: SimFaultEvent::PartitionCreated {
+                        from: from_ip.to_string(),
+                        to: to_ip.to_string(),
+                    },
                 });
 
                 tracing::debug!(
@@ -3035,63 +3072,39 @@ mod tests {
     }
 
     #[test]
-    fn emit_fault_without_layer_is_noop() {
-        // No SimulationLayer installed — emit_fault should still not panic.
-        SimInner::emit_fault(&SimFaultEvent::StorageCrash {
-            ip: "10.0.1.1".to_string(),
-        });
-    }
-
-    #[test]
-    fn emit_fault_with_layer_writes_to_trail() {
-        use crate::observability::SimulationLayer;
-        let layer = SimulationLayer::new();
-        let (handle, _guard) = layer.install();
-
-        // The layer stamps `time_ms` from its own clock, which the
-        // orchestrator advances after each `sim.step()`. In this unit test
-        // we push the time directly.
-        handle.set_sim_time_ms(500);
-
-        SimInner::emit_fault(&SimFaultEvent::StorageCrash {
+    fn record_fault_stamps_current_time() {
+        let mut inner = SimInner::new();
+        inner.current_time = Duration::from_millis(500);
+        inner.record_fault(SimFaultEvent::StorageCrash {
             ip: "10.0.1.1".to_string(),
         });
 
-        let entries = handle.trail::<SimFaultEvent>(SIM_FAULT_TRAIL);
-        assert_eq!(entries.len(), 1);
-        let entry = &entries[0];
-        assert_eq!(entry.time_ms, 500);
-        assert_eq!(entry.source, "sim");
-        assert!(matches!(entry.event, SimFaultEvent::StorageCrash { .. }));
+        assert_eq!(inner.pending_faults.len(), 1);
+        let record = &inner.pending_faults[0];
+        assert_eq!(record.time_ms, 500);
+        assert!(matches!(record.event, SimFaultEvent::StorageCrash { .. }));
     }
 
     #[test]
-    fn partition_pair_emits_fault_event() {
-        use crate::observability::SimulationLayer;
-        let layer = SimulationLayer::new();
-        let (handle, _guard) = layer.install();
-
+    fn partition_pair_records_fault() {
         let sim = SimWorld::new();
         let from: std::net::IpAddr = "10.0.1.1".parse().expect("valid ip");
         let to: std::net::IpAddr = "10.0.1.2".parse().expect("valid ip");
         sim.partition_pair(from, to, Duration::from_secs(10))
             .expect("partition should succeed");
 
-        let entries = handle.trail::<SimFaultEvent>(SIM_FAULT_TRAIL);
-        assert_eq!(entries.len(), 1);
+        let faults = sim.take_faults();
+        assert_eq!(faults.len(), 1);
         assert!(matches!(
-            &entries[0].event,
+            &faults[0].event,
             SimFaultEvent::PartitionCreated { from, to }
             if from == "10.0.1.1" && to == "10.0.1.2"
         ));
+        assert!(sim.take_faults().is_empty(), "drained on take");
     }
 
     #[test]
-    fn restore_partition_emits_fault_event() {
-        use crate::observability::SimulationLayer;
-        let layer = SimulationLayer::new();
-        let (handle, _guard) = layer.install();
-
+    fn restore_partition_records_fault() {
         let sim = SimWorld::new();
         let from: std::net::IpAddr = "10.0.1.1".parse().expect("valid ip");
         let to: std::net::IpAddr = "10.0.1.2".parse().expect("valid ip");
@@ -3099,14 +3112,14 @@ mod tests {
             .expect("partition");
         sim.restore_partition(from, to).expect("restore");
 
-        let entries = handle.trail::<SimFaultEvent>(SIM_FAULT_TRAIL);
-        assert_eq!(entries.len(), 2);
+        let faults = sim.take_faults();
+        assert_eq!(faults.len(), 2);
         assert!(matches!(
-            &entries[0].event,
+            &faults[0].event,
             SimFaultEvent::PartitionCreated { .. }
         ));
         assert!(matches!(
-            &entries[1].event,
+            &faults[1].event,
             SimFaultEvent::PartitionHealed { .. }
         ));
     }

--- a/moonpool-sim/tests/leader_election.rs
+++ b/moonpool-sim/tests/leader_election.rs
@@ -1,15 +1,18 @@
 //! Canonical leader-election example: detect split-brain via captured traces.
 //!
-//! Demonstrates the end-to-end story for moonpool's plain-`tracing` capture
-//! convention:
+//! Demonstrates the end-to-end story for moonpool's trace-based
+//! cross-validation:
 //!
-//! 1. Define a correctness-fact payload (`LeaderElected`) with the required
-//!    derives.
-//! 2. Workloads emit the fact via `SimContext::emit` (which expands to
-//!    `tracing::info!(capture = true, trail = "leader", event = valuable(&..))`).
-//! 3. Register a `SplitBrainInvariant` on the builder; it scans the `"leader"`
-//!    trail after every captured event and asserts that no two distinct
-//!    nodes claim leadership for the same term.
+//! 1. Workloads emit a plain `tracing` event — exactly the instrumentation
+//!    production observability would consume:
+//!    `tracing::info!(term, leader = %ip, "leader_elected")`.
+//! 2. The simulation captures every such event into a timeline, attributing
+//!    its `source` from the actor span the orchestrator wraps around each
+//!    task.
+//! 3. A `SplitBrainInvariant` registered on the builder scans the
+//!    `"leader_elected"` events after every simulation step and asserts that
+//!    no two distinct nodes claim leadership for the same term — the same
+//!    query you would run against production traces to find a dual leader.
 //!
 //! Happy path: only one leader per term. Invariant passes; the simulation
 //! reports zero failed runs.
@@ -23,28 +26,16 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use serde::{Deserialize, Serialize};
-use valuable::Valuable;
 
 use moonpool_sim::{
-    Invariant, SimContext, SimulationBuilder, SimulationResult, TimeProvider, TrailQuery,
-    TrailQueryExt, Workload, assert_always,
+    Invariant, SimContext, SimulationBuilder, SimulationResult, TimeProvider, TraceQuery, Workload,
+    assert_always,
 };
 
-/// Trail name shared by emitter and invariant.
-const LEADER_TRAIL: &str = "leader";
+/// Event name shared by emitter and invariant.
+const LEADER_ELECTED: &str = "leader_elected";
 
-/// Correctness fact emitted on every successful leader election.
-///
-/// Uses a struct (not a unit-variant enum) so it round-trips cleanly through
-/// `valuable-serde` and `serde`.
-#[derive(Debug, Clone, Valuable, Serialize, Deserialize)]
-struct LeaderElected {
-    term: u64,
-    leader: String,
-}
-
-/// Invariant: at most one distinct leader per term. Panics via
+/// Invariant: at most one distinct leader per term. Records a failure via
 /// `assert_always!` on conflict.
 struct SplitBrainInvariant {
     cursor: Cell<usize>,
@@ -67,12 +58,14 @@ impl Invariant for SplitBrainInvariant {
         "no_split_brain"
     }
 
-    fn observe(&self, q: &dyn TrailQuery, _sim_time_ms: u64) {
-        let new_entries = q.since::<LeaderElected>(LEADER_TRAIL, &self.cursor);
+    fn observe(&self, q: &dyn TraceQuery, _sim_time_ms: u64) {
         let mut seen = self.seen.borrow_mut();
-        for entry in new_entries {
-            let term = entry.event.term;
-            let leader = entry.event.leader.clone();
+        for e in q.since(LEADER_ELECTED, &self.cursor) {
+            let term = e.u64("term").expect("leader_elected carries a term");
+            let leader = e
+                .str("leader")
+                .expect("leader_elected carries a leader")
+                .to_owned();
             if let Some(prior) = seen.get(&term) {
                 assert_always!(
                     prior == &leader,
@@ -90,7 +83,7 @@ impl Invariant for SplitBrainInvariant {
     }
 }
 
-/// Workload emitting `LeaderElected` events. `bug_split_brain` controls
+/// Workload emitting `leader_elected` events. `bug_split_brain` controls
 /// whether the workload also emits a *conflicting* leader for term 1, which
 /// the invariant must catch.
 struct LeaderWorkload {
@@ -104,28 +97,16 @@ impl Workload for LeaderWorkload {
     }
 
     async fn run(&mut self, ctx: &SimContext) -> SimulationResult<()> {
-        // Elect node1 across a few terms with small delays so the layer
+        // Elect node1 across a few terms with small delays so the timeline
         // captures them in order with distinct sim times.
-        for term in 1..=3 {
-            ctx.emit(
-                LEADER_TRAIL,
-                LeaderElected {
-                    term,
-                    leader: "node1".into(),
-                },
-            );
+        for term in 1..=3_u64 {
+            tracing::info!(term, leader = %"node1", "leader_elected");
             ctx.time().sleep(Duration::from_millis(10)).await.ok();
         }
 
         if self.bug_split_brain {
             // Conflict: claim node2 as leader for term 1.
-            ctx.emit(
-                LEADER_TRAIL,
-                LeaderElected {
-                    term: 1,
-                    leader: "node2".into(),
-                },
-            );
+            tracing::info!(term = 1_u64, leader = %"node2", "leader_elected");
             ctx.time().sleep(Duration::from_millis(10)).await.ok();
         }
 

--- a/moonpool-sim/tests/network/partition.rs
+++ b/moonpool-sim/tests/network/partition.rs
@@ -1,7 +1,4 @@
-use moonpool_sim::{
-    SIM_FAULT_TRAIL, SimFaultEvent, SimWorld, SimulationLayer,
-    network::config::NetworkConfiguration,
-};
+use moonpool_sim::{SimFaultEvent, SimWorld, network::config::NetworkConfiguration};
 use std::{net::IpAddr, time::Duration};
 
 /// Test basic partition functionality by directly testing the `SimWorld` API
@@ -139,12 +136,11 @@ fn test_partition_behavior() {
     assert!(!sim.is_partitioned(client_ip, server_ip).unwrap());
 }
 
-/// Test that fault events are emitted to the timeline during partition operations.
+/// Test that fault events are recorded by the engine during partition
+/// operations, in order. The engine records faults internally; the runner
+/// (or a test, like here) drains them via `take_faults()`.
 #[test]
 fn test_partition_fault_timeline() {
-    let layer = SimulationLayer::new();
-    let (handle, _guard) = layer.install();
-
     let sim = SimWorld::new_with_network_config(NetworkConfiguration::fast_local());
 
     let a: IpAddr = "10.0.1.1".parse().unwrap();
@@ -158,34 +154,27 @@ fn test_partition_fault_timeline() {
     sim.partition_send_from(a, Duration::from_secs(5)).unwrap();
     sim.partition_recv_to(b, Duration::from_secs(5)).unwrap();
 
-    // Read the fault timeline from the captured layer
-    let entries = handle.trail::<SimFaultEvent>(SIM_FAULT_TRAIL);
-    assert_eq!(entries.len(), 4, "should have 4 fault events");
+    // Drain the engine-recorded faults
+    let faults = sim.take_faults();
+    assert_eq!(faults.len(), 4, "should have 4 fault events");
 
     // Verify event types in order
     assert!(
-        matches!(&entries[0].event, SimFaultEvent::PartitionCreated { from, to } if from == "10.0.1.1" && to == "10.0.1.2")
+        matches!(&faults[0].event, SimFaultEvent::PartitionCreated { from, to } if from == "10.0.1.1" && to == "10.0.1.2")
     );
     assert!(matches!(
-        &entries[1].event,
+        &faults[1].event,
         SimFaultEvent::PartitionHealed { .. }
     ));
     assert!(matches!(
-        &entries[2].event,
+        &faults[2].event,
         SimFaultEvent::SendPartitionCreated { ip } if ip == "10.0.1.1"
     ));
     assert!(matches!(
-        &entries[3].event,
+        &faults[3].event,
         SimFaultEvent::RecvPartitionCreated { ip } if ip == "10.0.1.2"
     ));
 
-    // Verify all events have source "sim"
-    for entry in &entries {
-        assert_eq!(entry.source, "sim");
-    }
-
-    // Verify sequence numbers are monotonically increasing
-    for window in entries.windows(2) {
-        assert!(window[1].seq > window[0].seq);
-    }
+    // A second drain returns nothing
+    assert!(sim.take_faults().is_empty());
 }

--- a/moonpool-sim/tests/reboot.rs
+++ b/moonpool-sim/tests/reboot.rs
@@ -8,8 +8,8 @@ use std::time::Duration;
 use async_trait::async_trait;
 use moonpool_sim::{
     Attrition, FaultContext, FaultInjector, Invariant, NetworkProvider, Process, RebootKind,
-    SIM_FAULT_TRAIL, SimContext, SimFaultEvent, SimulationBuilder, SimulationResult,
-    TcpListenerTrait, TimeProvider, TrailQuery, TrailQueryExt, Workload, assert_always,
+    SIM_FAULT_EVENT_NAME, SimContext, SimulationBuilder, SimulationResult, TcpListenerTrait,
+    TimeProvider, TraceQuery, Workload, assert_always,
 };
 
 use std::cell::Cell;
@@ -447,9 +447,9 @@ fn test_graceful_reboot_force_kills_stuck_process() {
 
 /// Invariant that validates process lifecycle timing from the fault timeline.
 ///
-/// Checks after every simulation event:
-/// - `GracefulShutdown` → `ForceKill`: delta == `grace_period_ms`
-/// - `ForceKill` → Restart: delta > 0 (recovery delay is positive)
+/// Checks after every simulation step:
+/// - `process_graceful_shutdown` → `process_force_kill`: delta == `grace_period_ms`
+/// - `process_force_kill` → `process_restart`: delta > 0 (recovery delay is positive)
 /// - Events for same IP appear in correct order
 struct RebootTimingInvariant {
     last_checked: Cell<usize>,
@@ -468,29 +468,30 @@ impl Invariant for RebootTimingInvariant {
         "reboot_timing"
     }
 
-    fn observe(&self, q: &dyn TrailQuery, _sim_time_ms: u64) {
-        let len = q.len(SIM_FAULT_TRAIL);
+    fn observe(&self, q: &dyn TraceQuery, _sim_time_ms: u64) {
+        let len = q.len(SIM_FAULT_EVENT_NAME);
         if len == self.last_checked.get() {
             return; // No new events
         }
         self.last_checked.set(len);
 
-        let entries = q.snapshot::<SimFaultEvent>(SIM_FAULT_TRAIL);
+        let entries = q.snapshot(SIM_FAULT_EVENT_NAME);
 
-        // Check grace period timing: GracefulShutdown → ForceKill for same IP
+        // Check grace period timing: graceful shutdown → force kill for same IP
         for (i, entry) in entries.iter().enumerate() {
-            if let SimFaultEvent::ProcessForceKill { ip } = &entry.event {
-                // Look backwards for matching GracefulShutdown
+            if entry.str("kind") == Some("process_force_kill") {
+                let ip = entry.str("ip").expect("force kill carries an ip");
+                // Look backwards for matching graceful shutdown
                 for j in (0..i).rev() {
-                    if let SimFaultEvent::ProcessGracefulShutdown {
-                        ip: gs_ip,
-                        grace_period_ms,
-                    } = &entries[j].event
-                        && gs_ip == ip
+                    if entries[j].str("kind") == Some("process_graceful_shutdown")
+                        && entries[j].str("ip") == Some(ip)
                     {
+                        let grace_period_ms = entries[j]
+                            .u64("grace_period_ms")
+                            .expect("graceful shutdown carries grace_period_ms");
                         let actual_delta = entry.time_ms - entries[j].time_ms;
                         assert_always!(
-                            actual_delta == *grace_period_ms,
+                            actual_delta == grace_period_ms,
                             format!(
                                 "Grace period mismatch for {}: expected {}ms, got {}ms",
                                 ip, grace_period_ms, actual_delta
@@ -502,17 +503,18 @@ impl Invariant for RebootTimingInvariant {
             }
         }
 
-        // Check ordering: ForceKill → Restart for same IP
+        // Check ordering: force kill → restart for same IP
         for (i, entry) in entries.iter().enumerate() {
-            if let SimFaultEvent::ProcessRestart { ip } = &entry.event {
+            if entry.str("kind") == Some("process_restart") {
+                let ip = entry.str("ip").expect("restart carries an ip");
                 for j in (0..i).rev() {
-                    if let SimFaultEvent::ProcessForceKill { ip: fk_ip } = &entries[j].event
-                        && fk_ip == ip
+                    if entries[j].str("kind") == Some("process_force_kill")
+                        && entries[j].str("ip") == Some(ip)
                     {
                         assert_always!(
                             entry.time_ms > entries[j].time_ms,
                             format!(
-                                "ProcessRestart at {}ms should be after ProcessForceKill at {}ms for {}",
+                                "process_restart at {}ms should be after process_force_kill at {}ms for {}",
                                 entry.time_ms, entries[j].time_ms, ip
                             )
                         );
@@ -521,6 +523,10 @@ impl Invariant for RebootTimingInvariant {
                 }
             }
         }
+    }
+
+    fn reset(&mut self) {
+        self.last_checked.set(0);
     }
 }
 

--- a/moonpool-transport-sim/Cargo.toml
+++ b/moonpool-transport-sim/Cargo.toml
@@ -15,9 +15,8 @@ moonpool-transport = { path = "../moonpool-transport", version = "0.7.0" }
 async-trait = "0.1"
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["macros"] }
-tracing = { version = "0.1", features = ["valuable"] }
+tracing = "0.1"
 tracing-subscriber = "0.3"
-valuable = { version = "0.1", features = ["derive"] }
 
 [[bin]]
 name = "sim-transport"

--- a/moonpool-transport-sim/src/hash.rs
+++ b/moonpool-transport-sim/src/hash.rs
@@ -30,6 +30,30 @@ pub fn fold(prev: u64, block: &[u8]) -> u64 {
     h
 }
 
+/// Hex-encode bytes for carrying a block in a tracing string field.
+#[must_use]
+pub fn hex_encode(bytes: &[u8]) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        write!(out, "{b:02x}").expect("writing to a String never fails");
+    }
+    out
+}
+
+/// Decode a hex string produced by [`hex_encode`]. Returns `None` on
+/// malformed input (odd length or non-hex characters).
+#[must_use]
+pub fn hex_decode(s: &str) -> Option<Vec<u8>> {
+    if !s.len().is_multiple_of(2) {
+        return None;
+    }
+    (0..s.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(s.get(i..i + 2)?, 16).ok())
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -52,5 +76,15 @@ mod tests {
     #[test]
     fn distinct_prev_diff() {
         assert_ne!(fold(0, b"a"), fold(1, b"a"));
+    }
+
+    #[test]
+    fn hex_round_trip() {
+        let bytes = vec![0x00, 0x0f, 0xff, 0x42];
+        assert_eq!(hex_decode(&hex_encode(&bytes)), Some(bytes));
+        assert_eq!(hex_encode(&[]), "");
+        assert_eq!(hex_decode(""), Some(Vec::new()));
+        assert_eq!(hex_decode("0"), None, "odd length");
+        assert_eq!(hex_decode("zz"), None, "non-hex");
     }
 }

--- a/moonpool-transport-sim/src/invariants.rs
+++ b/moonpool-transport-sim/src/invariants.rs
@@ -1,20 +1,17 @@
 //! Hash-chain integrity invariant.
 //!
-//! Replays the server-side timeline of [`AppendBlockEvent`]s starting from
-//! `(0, INITIAL_DIGEST)` and asserts every event satisfies the chain rule
-//! `n == last_n + 1` and `h == fold(last_h, &block)`. Catches transport bugs
-//! that reorder, drop, or duplicate server-side events — bugs the workload's
-//! per-response reference-model check cannot see on its own.
+//! Replays the server-side timeline of `append_block` trace events starting
+//! from `(0, INITIAL_DIGEST)` and asserts every event satisfies the chain
+//! rule `n == last_n + 1` and `h == fold(last_h, &block)`. Catches transport
+//! bugs that reorder, drop, or duplicate server-side events — bugs the
+//! workload's per-response reference-model check cannot see on its own.
 
 use std::cell::Cell;
 
-use moonpool_sim::{
-    Invariant, SIM_FAULT_TRAIL, SimFaultEvent, TrailQuery, TrailQueryExt, assert_always,
-    assert_sometimes,
-};
+use moonpool_sim::{Invariant, SIM_FAULT_EVENT_NAME, TraceQuery, assert_always, assert_sometimes};
 
-use crate::hash::{INITIAL_DIGEST, fold};
-use crate::process::{AppendBlockEvent, TL_APPEND};
+use crate::hash::{INITIAL_DIGEST, fold, hex_decode};
+use crate::process::EV_APPEND_BLOCK;
 
 /// Replay-based invariant over the server's append timeline.
 pub struct TransportIntegrityInvariant {
@@ -52,23 +49,33 @@ impl Invariant for TransportIntegrityInvariant {
         "transport_integrity"
     }
 
-    fn observe(&self, q: &dyn TrailQuery, _sim_time_ms: u64) {
-        let new_entries = q.since::<AppendBlockEvent>(TL_APPEND, &self.cursor);
-        for entry in &new_entries {
+    fn observe(&self, q: &dyn TraceQuery, _sim_time_ms: u64) {
+        for entry in q.since(EV_APPEND_BLOCK, &self.cursor) {
+            let n = entry.u64("n");
+            let h = entry.u64("h");
+            let block = entry.str("block").and_then(hex_decode);
+            assert_always!(
+                n.is_some() && h.is_some() && block.is_some(),
+                "append_block_event_well_formed"
+            );
+            let (Some(n), Some(h), Some(block)) = (n, h, block) else {
+                continue;
+            };
             let expected_n = self.last_n.get() + 1;
-            let expected_h = fold(self.last_h.get(), &entry.event.block);
-            assert_always!(entry.event.n == expected_n, "invariant_n_matches_replay");
-            assert_always!(entry.event.h == expected_h, "invariant_h_matches_replay");
-            self.last_n.set(entry.event.n);
-            self.last_h.set(entry.event.h);
+            let expected_h = fold(self.last_h.get(), &block);
+            assert_always!(n == expected_n, "invariant_n_matches_replay");
+            assert_always!(h == expected_h, "invariant_h_matches_replay");
+            self.last_n.set(n);
+            self.last_h.set(h);
             self.any_progress.set(true);
         }
 
-        if !self.any_faults.get() {
-            let new_faults = q.since::<SimFaultEvent>(SIM_FAULT_TRAIL, &self.cursor_faults);
-            if !new_faults.is_empty() {
-                self.any_faults.set(true);
-            }
+        if !self.any_faults.get()
+            && !q
+                .since(SIM_FAULT_EVENT_NAME, &self.cursor_faults)
+                .is_empty()
+        {
+            self.any_faults.set(true);
         }
 
         assert_sometimes!(

--- a/moonpool-transport-sim/src/process.rs
+++ b/moonpool-transport-sim/src/process.rs
@@ -6,28 +6,16 @@ use tracing::instrument;
 use moonpool_sim::{Process, SimContext, SimulationResult, assert_sometimes, buggify};
 use moonpool_transport::{NetTransport, NetTransportBuilder, ReplyPromise};
 
-use crate::hash::{INITIAL_DIGEST, fold};
+use crate::hash::{INITIAL_DIGEST, fold, hex_encode};
 use crate::service::{
     APPEND_INTERFACE, AppendBlockRequest, AppendBlockResponse, METHOD_APPEND_BLOCK, parse_sim_addr,
 };
 
-/// Trail name for server-side append events. The integrity invariant replays
-/// from this trail.
-pub const TL_APPEND: &str = "append";
-
-/// Event emitted per successful append. Includes the block bytes so the
-/// invariant can replay the chain end-to-end from `(0, INITIAL_DIGEST)`.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, valuable::Valuable)]
-pub struct AppendBlockEvent {
-    /// Block count after this append (`N` post-transition).
-    pub n: u64,
-    /// Chain digest after this append (`H` post-transition).
-    pub h: u64,
-    /// Block bytes that were folded in.
-    pub block: Vec<u8>,
-    /// IP of the server that produced this event.
-    pub server_ip: String,
-}
+/// Event name for server-side append events. Emitted as a plain `tracing`
+/// event with fields `n`, `h`, and `block` (hex-encoded bytes, so the
+/// integrity invariant can replay the chain end-to-end from
+/// `(0, INITIAL_DIGEST)`).
+pub const EV_APPEND_BLOCK: &str = "append_block";
 
 /// Hash-chain server. State is in-memory only and resets on every boot.
 pub struct TransportServerProcess;
@@ -66,7 +54,7 @@ impl Process for TransportServerProcess {
         loop {
             tokio::select! {
                 Some((req, reply)) = append_stream.recv() => {
-                    handle_append(&mut h, &mut n, &req, reply, ctx, my_ip);
+                    handle_append(&mut h, &mut n, &req, reply, my_ip);
                 }
                 () = shutdown.cancelled() => {
                     tracing::info!(final_n = n, final_h = h, "transport server shutting down");
@@ -82,7 +70,6 @@ fn handle_append(
     n: &mut u64,
     req: &AppendBlockRequest,
     reply: ReplyPromise<AppendBlockResponse>,
-    ctx: &SimContext,
     server_ip: &str,
 ) {
     // Drop the reply mid-RPC without mutating state. Simulates "server crashed
@@ -103,14 +90,11 @@ fn handle_append(
     *h = new_h;
     *n = new_n;
 
-    ctx.emit(
-        TL_APPEND,
-        AppendBlockEvent {
-            n: new_n,
-            h: new_h,
-            block: req.block.clone(),
-            server_ip: server_ip.to_string(),
-        },
+    tracing::info!(
+        n = new_n,
+        h = new_h,
+        block = %hex_encode(&req.block),
+        "append_block"
     );
 
     assert_sometimes!(req.block.is_empty(), "handled_empty_block");

--- a/moonpool-transport-sim/src/workload.rs
+++ b/moonpool-transport-sim/src/workload.rs
@@ -12,11 +12,11 @@
 use std::time::Duration;
 
 use async_trait::async_trait;
-use serde::{Deserialize, Serialize};
 use tracing::instrument;
 
 use moonpool_sim::{
-    SimContext, SimulationResult, Workload, assert_always, assert_sometimes, sim_random_range,
+    SimContext, SimulationResult, TraceQuery, Workload, assert_always, assert_sometimes,
+    sim_random_range,
 };
 use moonpool_transport::{
     Endpoint, JsonCodec, NetTransportBuilder, Providers, ReplyError, TimeProvider, UID, get_reply,
@@ -24,50 +24,27 @@ use moonpool_transport::{
 };
 
 use crate::hash::{INITIAL_DIGEST, fold};
-use crate::process::{AppendBlockEvent, TL_APPEND};
+use crate::process::EV_APPEND_BLOCK;
 use crate::service::{
     AppendBlockRequest, AppendBlockResponse, METHOD_APPEND_BLOCK, append_method_uid, parse_sim_addr,
 };
 
-/// Trail name for client-side append attempts and outcomes.
-pub const TL_CLIENT: &str = "client";
+/// Event name: request issued; outcome not yet known. Fields: `seq_id`,
+/// `block_len`.
+pub const EV_CLIENT_ISSUED: &str = "client_issued";
 
-/// Client-side trail event recording the outcome of each attempted append.
-#[derive(Debug, Clone, Serialize, Deserialize, valuable::Valuable)]
-pub enum ClientEvent {
-    /// Request issued; outcome not yet known.
-    Issued {
-        /// Workload-side request id.
-        seq_id: u64,
-        /// Number of bytes in the block.
-        block_len: usize,
-    },
-    /// Server returned a response; compared bit-for-bit against the reference model.
-    Acknowledged {
-        /// Workload-side request id.
-        seq_id: u64,
-        /// `n` reported by the server.
-        server_n: u64,
-        /// `h` reported by the server.
-        server_h: u64,
-        /// `n` projected by the local reference model.
-        expected_n: u64,
-        /// `h` projected by the local reference model.
-        expected_h: u64,
-    },
-    /// At-least-once RPC failed terminally.
-    Failed {
-        /// Workload-side request id.
-        seq_id: u64,
-        /// Stringified error.
-        error: String,
-    },
-    /// Ambiguous outcome (`MaybeDelivered`, drain timeout, or shutdown mid-await).
-    Ambiguous {
-        /// Workload-side request id.
-        seq_id: u64,
-    },
-}
+/// Event name: server response compared bit-for-bit against the reference
+/// model. Fields: `seq_id`, `server_n`, `server_h`, `expected_n`,
+/// `expected_h`.
+pub const EV_CLIENT_ACKNOWLEDGED: &str = "client_acknowledged";
+
+/// Event name: at-least-once RPC failed terminally. Fields: `seq_id`,
+/// `error`.
+pub const EV_CLIENT_FAILED: &str = "client_failed";
+
+/// Event name: ambiguous outcome (`MaybeDelivered`, drain timeout, or
+/// shutdown mid-await). Fields: `seq_id`.
+pub const EV_CLIENT_AMBIGUOUS: &str = "client_ambiguous";
 
 #[derive(Debug, Clone, Copy)]
 enum Op {
@@ -212,13 +189,7 @@ impl Workload for TransportClientWorkload {
             let projected_n = expected_n + 1;
             let projected_h = fold(expected_h, &block);
 
-            ctx.emit(
-                TL_CLIENT,
-                ClientEvent::Issued {
-                    seq_id,
-                    block_len: block.len(),
-                },
-            );
+            tracing::info!(seq_id, block_len = block.len(), "client_issued");
 
             let req = AppendBlockRequest {
                 seq_id,
@@ -239,19 +210,13 @@ impl Workload for TransportClientWorkload {
                             if let Some(r) = drained {
                                 r
                             } else {
-                                ctx.emit(TL_CLIENT, ClientEvent::Ambiguous { seq_id });
+                                tracing::info!(seq_id, "client_ambiguous");
                                 stopped_after_ambiguous = true;
                                 continue;
                             }
                         }
                         Err(e) => {
-                            ctx.emit(
-                                TL_CLIENT,
-                                ClientEvent::Failed {
-                                    seq_id,
-                                    error: e.to_string(),
-                                },
-                            );
+                            tracing::info!(seq_id, error = %e, "client_failed");
                             continue;
                         }
                     }
@@ -284,31 +249,23 @@ impl Workload for TransportClientWorkload {
                     expected_n = projected_n;
                     expected_h = projected_h;
 
-                    ctx.emit(
-                        TL_CLIENT,
-                        ClientEvent::Acknowledged {
-                            seq_id,
-                            server_n: resp.n,
-                            server_h: resp.h,
-                            expected_n: projected_n,
-                            expected_h: projected_h,
-                        },
+                    tracing::info!(
+                        seq_id,
+                        server_n = resp.n,
+                        server_h = resp.h,
+                        expected_n = projected_n,
+                        expected_h = projected_h,
+                        "client_acknowledged"
                     );
                 }
                 Err(ReplyError::MaybeDelivered) => {
                     assert_sometimes!(true, "maybe_delivered_observed");
-                    ctx.emit(TL_CLIENT, ClientEvent::Ambiguous { seq_id });
+                    tracing::info!(seq_id, "client_ambiguous");
                     stopped_after_ambiguous = true;
                 }
                 Err(e) => {
                     assert_sometimes!(true, "terminal_error_observed");
-                    ctx.emit(
-                        TL_CLIENT,
-                        ClientEvent::Failed {
-                            seq_id,
-                            error: e.to_string(),
-                        },
-                    );
+                    tracing::info!(seq_id, error = %e, "client_failed");
                 }
             }
         }
@@ -330,26 +287,14 @@ impl Workload for TransportClientWorkload {
                     client_id,
                     block: block.clone(),
                 };
-                ctx.emit(
-                    TL_CLIENT,
-                    ClientEvent::Issued {
-                        seq_id,
-                        block_len: block.len(),
-                    },
-                );
+                tracing::info!(seq_id, block_len = block.len(), "client_issued");
                 match send(&*transport, &endpoint, req, &encode) {
                     Ok(()) => {
                         assert_sometimes!(true, "fire_and_forget_sent");
-                        ctx.emit(TL_CLIENT, ClientEvent::Ambiguous { seq_id });
+                        tracing::info!(seq_id, "client_ambiguous");
                     }
                     Err(e) => {
-                        ctx.emit(
-                            TL_CLIENT,
-                            ClientEvent::Failed {
-                                seq_id,
-                                error: e.to_string(),
-                            },
-                        );
+                        tracing::info!(seq_id, error = %e, "client_failed");
                     }
                 }
             }
@@ -366,21 +311,23 @@ impl Workload for TransportClientWorkload {
 
     #[instrument(skip(self, ctx), fields(client = self.index))]
     async fn check(&mut self, ctx: &SimContext) -> SimulationResult<()> {
-        // Every Acknowledged event must have a matching server-side AppendBlockEvent
-        // with the same (n, h). Catches "transport claimed delivery, server never
-        // emitted" — a lost server-side event.
-        let client_events = ctx.trail::<ClientEvent>(TL_CLIENT);
-        let server_events = ctx.trail::<AppendBlockEvent>(TL_APPEND);
-        for entry in &client_events {
-            if let ClientEvent::Acknowledged {
-                server_n, server_h, ..
-            } = &entry.event
-            {
-                let matched = server_events
-                    .iter()
-                    .any(|s| s.event.n == *server_n && s.event.h == *server_h);
-                assert_always!(matched, "check_ack_has_matching_server_event");
-            }
+        // Every acknowledged append must have a matching server-side
+        // `append_block` event with the same (n, h). Catches "transport
+        // claimed delivery, server never emitted" — a lost server-side event.
+        let q = ctx.observability();
+        let acks = q.snapshot(EV_CLIENT_ACKNOWLEDGED);
+        let server_events = q.snapshot(EV_APPEND_BLOCK);
+        for ack in &acks {
+            let server_n = ack.u64("server_n");
+            let server_h = ack.u64("server_h");
+            assert_always!(
+                server_n.is_some() && server_h.is_some(),
+                "check_ack_event_well_formed"
+            );
+            let matched = server_events
+                .iter()
+                .any(|s| s.u64("n") == server_n && s.u64("h") == server_h);
+            assert_always!(matched, "check_ack_has_matching_server_event");
         }
         tracing::info!("check passed");
         Ok(())


### PR DESCRIPTION
## Summary

Redesign the event capture system so the timeline is built from ordinary production-style tracing events instead of the capture/trail/valuable convention (#115). The goal: detect anomalies like dual leaders in simulation using the same signals used in production — traces.

- **Plain tracing emission**: `tracing::info!(term, leader = %ip, "leader_elected")`. Deletes `ctx.emit`/`ctx.trail`, the `capture=true` marker, and the `valuable` + `valuable-serde` dependencies.
- **Source attribution via actor spans**: the orchestrator wraps each process/workload task in `info_span!("process"/"workload", ip = %ip)`; the layer resolves `TraceEvent::source` from the nearest enclosing span.
- **Loki/OTel-flavored TraceQuery**: query by event name (the message), extract typed fields by key (`e.u64("term")`, `e.str("leader")`).
- **Runner-owned sim faults** (per #115): `SimWorld` records `SimFaultEvent`s internally, exposed via `take_faults()`; the orchestrator drains them into the timeline under `"sim_fault"` with a `kind` field. This deletes the ambient static emit site behind the #114 flake. `StorageWriteFault.kind` renamed to `write_kind`.
- **Invariants run from the runner loop** after each `sim.step()`, not inside tracing dispatch (removes the reentrancy footgun where invariant emissions were silently dropped).
- Migrate `leader_election`, `reboot`, `partition` tests and `moonpool-transport-sim` (block bytes hex-encoded into a string field); rewrite book chapter 17 and CLAUDE.md invariant docs.

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)