### PR TITLE
build: remove unused --cfg tracing_unstable flag

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [build]
-rustflags = ["--cfg", "tokio_unstable", "--cfg", "tracing_unstable"]
+rustflags = ["--cfg", "tokio_unstable"]
 
 [alias]
 xtask = "run --package xtask --"


### PR DESCRIPTION
## Summary

Removes the inert `--cfg tracing_unstable` rustflag from `.cargo/config.toml`.

Nothing in the workspace uses `valuable` or any unstable `tracing` API. The flag
was originally added (commit `1668280`) for `valuable`-based typed event capture
in sim invariants — `event = valuable(&payload)` survived the tracing boundary as
structured data. A later refactor replaced that with plain tracing **field
extraction** (`e.u64(...)`, `e.str(...)`), which dropped `valuable` entirely and
left the flag orphaned.

`--cfg tokio_unstable` **stays**: `moonpool-sim` uses `RngSeed` /
`Builder::rng_seed` (`runner/builder.rs`) for deterministic per-iteration runtime
seeding — that is the only remaining consumer of an unstable cfg.

```diff
-rustflags = ["--cfg", "tokio_unstable", "--cfg", "tracing_unstable"]
+rustflags = ["--cfg", "tokio_unstable"]
```

## Test plan

- `cargo clippy --workspace --all-targets` — clean
- `cargo nextest run --workspace` — 528 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)
