### PR TITLE
Portable sim: run a moonpool simulation in the browser (wasm), split the explorer, lean production path

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -21,6 +21,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main
+      - name: Build and stage the wasm demo embedded in the book
+        run: nix develop --command book/build-wasm-demo.sh
       - name: Build book
         run: nix develop --command mdbook build
       - uses: actions/upload-pages-artifact@v5

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,6 +44,31 @@ jobs:
       - name: Run cargo nextest
         run: nix develop --command cargo nextest run
 
+  # The simulation must stay buildable without the fork-based explorer (libc) so
+  # it can compile to wasm. Guards the explorer-optional path + the wasm target.
+  portability:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - name: Clippy (no exploration, all targets)
+        run: nix develop --command cargo clippy -p moonpool-sim --no-default-features --all-targets -- --deny warnings
+      - name: Tests (no exploration)
+        run: nix develop --command cargo nextest run -p moonpool-sim --no-default-features
+      - name: Build for wasm32-unknown-unknown
+        run: |
+          nix develop --command cargo check --target wasm32-unknown-unknown -p moonpool-assertions
+          nix develop --command cargo check --target wasm32-unknown-unknown -p moonpool-sim --no-default-features
+      - name: Lean production dependency tree excludes sim/explorer
+        run: |
+          tree=$(nix develop --command cargo tree -p moonpool --no-default-features --features tokio,transport -e no-dev)
+          echo "$tree"
+          if echo "$tree" | grep -qE "moonpool-sim|moonpool-explorer|moonpool-assertions"; then
+            echo "::error::lean production build pulled in a sim/explorer crate"
+            exit 1
+          fi
+
   sim:
     runs-on: ubuntu-latest
     strategy:

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ Cargo.lock
 # mdbook
 book/output
 book/book
+# Generated wasm demo staged into the book (built by book/build-wasm-demo.sh)
+/book/src/wasm-demo/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,14 +65,33 @@ Types: `fix` (bugfix), `feat` (new feature), `build`, `chore`, `ci`, `docs`, `st
 
 ## Crate Architecture
 ```
-moonpool/                    - Facade crate, re-exports everything
-moonpool-core/               - Provider traits (Time, Task, Network, Random, Storage) and core types
-moonpool-sim/                - Simulation runtime, chaos testing, buggify, assertions
-moonpool-transport/          - Peer connections, wire format, FlowTransport, RPC
+moonpool/                    - Facade crate; features: sim/tokio/transport (default = all)
+moonpool-core/               - Provider traits (Time, Task, Network, Random, Storage) + core types.
+                               Granular tokio features: tokio-task/-time/-net/-fs/-random
+                               (umbrella `tokio-providers`). wasm-clean with all off.
+moonpool-assertions/         - Antithesis-style assertion accounting (pure std, ZERO deps, wasm-able).
+                               Heap table by default; explorer overlays MAP_SHARED + a discovery hook.
+moonpool-sim/                - Simulation runtime, chaos testing, buggify, assertions wiring.
+                               feature `exploration` (default ON) gates moonpool-explorer; without it
+                               the sim compiles to wasm32-unknown-unknown.
+moonpool-transport/          - Peer connections, wire format, FlowTransport, RPC. Generic over
+                               `P: Providers`; feature `tokio` adds TokioTransport + Builder::tokio().
 moonpool-transport-derive/   - Proc-macro: #[service]
-moonpool-explorer/           - Fork-based multiverse exploration, coverage, energy budgets
+moonpool-explorer/           - Fork-based multiverse exploration (libc/fork/mmap; never wasm).
+                               Depends on moonpool-assertions; optional dep of moonpool-sim.
 xtask/                       - Cargo xtask automation (simulation runner)
 ```
+
+**Dispatch**: providers stay **static-generic** (traits aren't object-safe: Clone supertrait,
+generic `random<T>`, RPIT futures, associated types; sim is test-only so no runtime selection).
+Where generics hurt, erase at a boundary (precedent: `Arc<dyn TransportHandle>`).
+
+**Production builds** keep sim/explorer out entirely:
+`moonpool = { default-features = false, features = ["tokio", "transport"] }`.
+
+**Portability checks** (must also pass when touching crate structure / features):
+- `nix develop --command cargo clippy -p moonpool-sim --no-default-features --all-targets -- -D warnings`
+- `nix develop --command cargo check --target wasm32-unknown-unknown -p moonpool-sim --no-default-features`
 
 ## Testing Philosophy
 **Goal**: 100% sometimes assertion coverage via chaos testing + comprehensive invariant validation

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 
-members = ["moonpool", "moonpool-core", "moonpool-explorer", "moonpool-sim", "moonpool-sim-examples", "moonpool-transport", "moonpool-transport-derive", "moonpool-transport-sim", "xtask"]
+members = ["moonpool", "moonpool-assertions", "moonpool-core", "moonpool-explorer", "moonpool-sim", "moonpool-sim-examples", "moonpool-transport", "moonpool-transport-derive", "moonpool-transport-sim", "xtask"]
 resolver = "2"
 
 [workspace.package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 
-members = ["moonpool", "moonpool-assertions", "moonpool-core", "moonpool-explorer", "moonpool-sim", "moonpool-sim-examples", "moonpool-transport", "moonpool-transport-derive", "moonpool-transport-sim", "xtask"]
+members = ["moonpool", "moonpool-assertions", "moonpool-core", "moonpool-explorer", "moonpool-sim", "moonpool-sim-examples", "moonpool-transport", "moonpool-transport-derive", "moonpool-transport-sim", "moonpool-wasm-demo", "xtask"]
 resolver = "2"
 
 [workspace.package]

--- a/README.md
+++ b/README.md
@@ -9,13 +9,17 @@ Inspired by [FoundationDB's simulation testing](https://apple.github.io/foundati
 ## Architecture
 
 ```text
-moonpool                          Facade crate, re-exports everything
+moonpool                          Facade crate (features: sim / tokio / transport)
 ├── moonpool-transport            RPC, peer connections, wire format
 │   └── moonpool-transport-derive #[service] proc-macro
-├── moonpool-sim                  Simulation engine, chaos testing, assertions
-│   └── moonpool-explorer         Fork-based multiverse exploration
+├── moonpool-sim                  Simulation engine, chaos testing, assertion wiring
+│   ├── moonpool-assertions       Assertion accounting (pure std, zero deps, wasm-able)
+│   └── moonpool-explorer         Fork-based multiverse exploration (optional, libc)
 └── moonpool-core                 Provider traits and core types
 ```
+
+The simulation runtime compiles to `wasm32-unknown-unknown` (build `moonpool-sim`
+with `--no-default-features`); only the fork-based explorer is Linux-first.
 
 ## Which Crate to Use
 
@@ -25,8 +29,27 @@ moonpool                          Facade crate, re-exports everything
 | Provider traits only | `moonpool-core` |
 | Simulation without transport | `moonpool-sim` |
 | Transport without simulation | `moonpool-transport` |
+| Assertion accounting only | `moonpool-assertions` |
 | Fork-based exploration internals | `moonpool-explorer` |
 | Proc-macro internals | `moonpool-transport-derive` |
+
+## Using in Production
+
+The code you test is the code you ship — write it once against the provider
+traits, then deploy on the real `TokioProviders` backend. Keep the simulation
+runtime and the fork-based explorer out of your release binary with a lean
+dependency stanza:
+
+```toml
+[dependencies]
+moonpool = { version = "0.8", default-features = false, features = ["tokio", "transport"] }
+```
+
+That pulls the provider contract, `TokioProviders`/`TokioTransport`, and the
+transport layer — no `moonpool-sim`, no `moonpool-explorer`, no `libc` fork
+machinery. See [`moonpool/examples/retrying_worker.rs`](moonpool/examples/retrying_worker.rs)
+for a worker that runs on Tokio in `main` and is driven through the simulator by
+its own `#[test]`, and the "Using Providers in Production" chapter of the book.
 
 ## Key Features
 

--- a/book/build-wasm-demo.sh
+++ b/book/build-wasm-demo.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Build the wasm ping-pong demo and stage it as a book asset so the wasm chapter
+# can embed it live. Run before `mdbook build` (locally and in CI). The staged
+# directory book/src/wasm-demo/ is generated and gitignored.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+echo "building moonpool-wasm-demo for wasm32…"
+cargo build --release --target wasm32-unknown-unknown -p moonpool-wasm-demo --lib
+wasm-bindgen --target web --out-dir moonpool-wasm-demo/web/pkg \
+  target/wasm32-unknown-unknown/release/moonpool_wasm_demo.wasm
+
+echo "staging assets in book/src/wasm-demo/…"
+rm -rf book/src/wasm-demo
+mkdir -p book/src/wasm-demo
+cp moonpool-wasm-demo/web/index.html book/src/wasm-demo/index.html
+cp -r moonpool-wasm-demo/web/pkg book/src/wasm-demo/pkg
+
+echo "done. book/src/wasm-demo/ ready for mdbook build."

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -69,6 +69,7 @@
   - [Wiring a Web Service](./part4-integration/03-wiring-a-web-service.md)
   - [What You're Testing (and What You're Not)](./part4-integration/04-scope-and-tradeoffs.md)
 - [Using Providers in Production](./part4-integration/05-production.md)
+- [Simulation in the Browser](./part4-integration/06-wasm.md)
 
 ---
 

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -68,6 +68,7 @@
   - [Where to Draw the Line](./part4-integration/02-mock-boundaries.md)
   - [Wiring a Web Service](./part4-integration/03-wiring-a-web-service.md)
   - [What You're Testing (and What You're Not)](./part4-integration/04-scope-and-tradeoffs.md)
+- [Using Providers in Production](./part4-integration/05-production.md)
 
 ---
 

--- a/book/src/index.md
+++ b/book/src/index.md
@@ -13,6 +13,7 @@ A sitemap of every chapter in the Moonpool book. Each entry links to a chapter w
 - **"How do I use assertions?"** — [Assertions: Finding Bugs](./part3-building/12-assertions.md)
 - **"How does networking/RPC work?"** — [Simulating the Network](./part4-networking/01-simulating-network.md)
 - **"How do I test an existing app (e.g. axum)?"** — [Using moonpool-sim Standalone](./part4-integration/01-standalone-sim.md)
+- **"How do I ship this to production?"** — [Using Providers in Production](./part4-integration/05-production.md)
 - **"How does multiverse exploration work?"** — [Multiverse Exploration](./part5-building-on-top/01-exploration.md)
 - **"What assertions are available?"** — [Assertion Reference](./appendix/01-assertion-reference.md)
 - **"What configuration options exist?"** — [Configuration Reference](./appendix/03-configuration.md)
@@ -70,6 +71,7 @@ A sitemap of every chapter in the Moonpool book. Each entry links to a chapter w
 - [Where to Draw the Line](./part4-integration/02-mock-boundaries.md) — Fakes vs test containers; binary failure limitations
 - [Wiring a Web Service](./part4-integration/03-wiring-a-web-service.md) — Worked example: axum service in simulation with Store trait fake, chaos, assertions
 - [What You're Testing (and What You're Not)](./part4-integration/04-scope-and-tradeoffs.md) — Tests handler logic and HTTP under chaos; doesn't test TLS, proxies, startup code
+- [Using Providers in Production](./part4-integration/05-production.md) — Deploying the same code on TokioProviders/TokioTransport; the lean dependency stanza; feature + platform matrices; the now() gotcha
 
 ## Part V: Networking and RPC
 

--- a/book/src/index.md
+++ b/book/src/index.md
@@ -14,6 +14,7 @@ A sitemap of every chapter in the Moonpool book. Each entry links to a chapter w
 - **"How does networking/RPC work?"** — [Simulating the Network](./part4-networking/01-simulating-network.md)
 - **"How do I test an existing app (e.g. axum)?"** — [Using moonpool-sim Standalone](./part4-integration/01-standalone-sim.md)
 - **"How do I ship this to production?"** — [Using Providers in Production](./part4-integration/05-production.md)
+- **"Can the simulation run in a browser?"** — [Simulation in the Browser](./part4-integration/06-wasm.md)
 - **"How does multiverse exploration work?"** — [Multiverse Exploration](./part5-building-on-top/01-exploration.md)
 - **"What assertions are available?"** — [Assertion Reference](./appendix/01-assertion-reference.md)
 - **"What configuration options exist?"** — [Configuration Reference](./appendix/03-configuration.md)
@@ -72,6 +73,7 @@ A sitemap of every chapter in the Moonpool book. Each entry links to a chapter w
 - [Wiring a Web Service](./part4-integration/03-wiring-a-web-service.md) — Worked example: axum service in simulation with Store trait fake, chaos, assertions
 - [What You're Testing (and What You're Not)](./part4-integration/04-scope-and-tradeoffs.md) — Tests handler logic and HTTP under chaos; doesn't test TLS, proxies, startup code
 - [Using Providers in Production](./part4-integration/05-production.md) — Deploying the same code on TokioProviders/TokioTransport; the lean dependency stanza; feature + platform matrices; the now() gotcha
+- [Simulation in the Browser](./part4-integration/06-wasm.md) — Why the sim compiles to wasm; whether block_on parks; building a wasm-able crate; the moonpool-wasm-demo example; the portability CI gate
 
 ## Part V: Networking and RPC
 

--- a/book/src/part4-integration/05-production.md
+++ b/book/src/part4-integration/05-production.md
@@ -1,0 +1,114 @@
+# Using Providers in Production
+
+<!-- toc -->
+
+Every chapter so far has been about testing. But the whole point of writing
+against the provider traits is that the code you tested is the code you ship.
+There is no separate "production version" to keep in sync, no `#[cfg(test)]`
+fork in behavior. The function you ran ten million times under simulation is the
+exact function that now handles real traffic.
+
+So how do we actually deploy it?
+
+## The production backend
+
+Simulation swaps in `SimProviders`. Production swaps in `TokioProviders` — a
+zero-cost bundle of the five real implementations: wall-clock time, tokio task
+spawning, real TCP, OS randomness, and real filesystem I/O. Code that is generic
+over `P: Providers` accepts either one.
+
+```rust
+use moonpool::prelude::*;
+
+// The same signature you used in tests.
+async fn fetch_with_retry<P: Providers>(providers: &P, max_attempts: u32)
+    -> Result<u32, String>
+{
+    // time().sleep(), random().random_bool(), task().spawn_task() ...
+}
+
+#[tokio::main]
+async fn main() {
+    let providers = TokioProviders::new();
+    let result = fetch_with_retry(&providers, 5).await;
+    println!("{result:?}");
+}
+```
+
+The complete, runnable version lives in
+[`moonpool/examples/retrying_worker.rs`](https://github.com/PierreZ/moonpool/blob/main/moonpool/examples/retrying_worker.rs).
+Its `main` runs on Tokio; its `#[test]` drives the same `fetch_with_retry`
+through `SimulationBuilder` across 50 seeds. One function, two worlds, verified
+by `cargo test --example retrying_worker`.
+
+For the transport layer the production path is just as short. The `tokio` feature
+gives you a `TokioTransport` alias and a builder shortcut, so you skip naming the
+providers bundle:
+
+```rust
+let transport = NetTransportBuilder::tokio()
+    .local_address(NetworkAddress::parse("127.0.0.1:4500")?)
+    .build_listening()
+    .await?;
+```
+
+## A lean dependency tree
+
+The simulation runtime and the fork-based explorer have no business in a
+production binary. The explorer in particular pulls in `libc`, `fork`, and
+`mmap` — machinery that exists only to branch timelines during testing. A
+production build should never compile it.
+
+Moonpool keeps it out with features. The default pulls the whole framework
+(that is what the crate's audience uses day to day). Production opts out:
+
+```toml
+[dependencies]
+moonpool = { version = "0.8", default-features = false, features = ["tokio", "transport"] }
+```
+
+That stanza gives you the provider contract, the production backend, and the
+transport layer — and nothing else. `cargo tree` on such a build shows no
+`moonpool-sim`, no `moonpool-explorer`, no `moonpool-assertions`. The only system
+libraries present are the ones tokio itself needs for real sockets and files.
+
+| Feature | Pulls in | Use it when |
+|---------|----------|-------------|
+| `tokio` | `TokioProviders`, `TokioTransport` | Always, in production |
+| `transport` | `NetTransport`, `#[service]` RPC | You speak the moonpool wire protocol |
+| `sim` | the simulation runtime + explorer | Tests, benchmarks, local dev (default) |
+
+Keep `sim` on as a `dev-dependency` feature and off in your release profile, and
+your tests still run the full simulator while your shipped binary stays lean.
+
+## One gotcha: `TokioTimeProvider::now()`
+
+In simulation, `time().now()` returns the canonical simulation clock. In
+production, `TokioTimeProvider::now()` returns elapsed time since the provider
+was **created**, not wall-clock time. It is a monotonic stopwatch, perfect for
+measuring durations and scheduling relative deadlines, and deliberately not a
+calendar. If you need a wall-clock timestamp for logging or persistence, reach
+for `std::time::SystemTime` directly at that call site. Everything that drives
+sleeps, timeouts, and backoff should keep going through the provider so it stays
+testable.
+
+## Where it runs
+
+The provider contract and the production backend compile broadly. The sim
+runtime is portable too, with one boundary: the fork-based explorer is POSIX and
+Linux-first.
+
+| Target | core + tokio | transport | sim runtime | explorer (fork) |
+|--------|:---:|:---:|:---:|:---:|
+| Linux | yes | yes | yes | yes |
+| macOS | yes | yes | yes | best-effort |
+| `wasm32-unknown-unknown` | task/time only | no (no sockets) | yes, `--no-default-features` | no |
+
+The simulation engine compiles to `wasm32-unknown-unknown` because it derives
+everything from a seeded RNG, a logical clock, and a cooperative scheduler — no
+operating system required. The explorer cannot follow it there, and on macOS its
+`fork`-without-`exec` model is fragile, so treat exploration as a Linux
+amplifier. Everywhere else the full simulator runs via the in-process assertion
+table; you lose multiverse forking, not correctness checking. If a build refuses
+to include the explorer, the fallback is one line:
+`moonpool-sim = { default-features = false }`.

--- a/book/src/part4-integration/06-wasm.md
+++ b/book/src/part4-integration/06-wasm.md
@@ -1,0 +1,130 @@
+# Simulation in the Browser
+
+<!-- toc -->
+
+The same simulation that grinds through thousands of seeds in CI also runs in a
+browser tab, with no server and no install. Type a seed, watch your system take
+traffic under a chaotic network, and share a link that reproduces the exact run
+on anyone's machine. That makes a great demo. It is also a proof. If the engine
+runs inside a sandbox with no operating system, then nothing in the simulation
+secretly depends on one.
+
+## Why a simulator compiles to wasm at all
+
+In simulation the network and the disk are not devices. `SimNetwork` is an
+in-memory state machine that schedules "deliver this packet at logical time T"
+events on a queue. `SimStorage` is the same idea for reads and writes. Time is a
+counter the engine advances. Randomness is a seeded ChaCha8 stream. The scheduler
+is tokio's current-thread runtime. Add those up and there is no syscall anywhere
+on the path.
+
+The production providers are the opposite. `TokioProviders` is real TCP, real
+files, and OS randomness, every one of them a trip into the kernel. That single
+difference is why the simulator crosses over to `wasm32-unknown-unknown` and the
+production backend does not.
+
+One piece is shared rather than derived, and it is the key to the whole thing.
+`SimProviders` spawns tasks through the real `TokioTaskProvider`, not a simulated
+one, so the executor primitive is literally tokio in both worlds. tokio's `rt`,
+`sync`, and `macros` features compile to wasm. Its `net` and `fs` features do
+not. The simulator brings the half of tokio that crosses over and leaves the
+half that cannot.
+
+## What had to change
+
+Getting there was four narrow fixes, not a rewrite.
+
+- The fork-based explorer (`libc`, `fork`, `mmap`) moved behind a default-on
+  `exploration` feature you switch off for wasm.
+- Three wall-clock call sites the harness uses for reporting got a shim, because
+  `Instant::now()` and `SystemTime::now()` compile on wasm and then **panic the
+  moment you call them**.
+- The `tokio` dependency narrowed to `rt`, `sync`, and `macros`.
+- `rand` dropped its default features so it never reaches for `getrandom` and the
+  OS entropy that a browser has no answer for. The sim never needed it: its RNG
+  is seeded ChaCha8.
+
+## Does `block_on` park?
+
+Compiling is necessary, not sufficient. A current-thread runtime that runs out of
+ready work tries to **park** the thread, and parking panics on
+`wasm32-unknown-unknown`. So the real question was whether `block_on` ever parks
+while driving a simulation.
+
+It does not. The simulation is ready-driven. Every wakeup fires inline as the
+orchestrator steps the event queue, and there is no external reactor sitting on a
+socket or a timer to wake the thread later. The runtime always has the next step
+in front of it until the run ends. (If an engine change ever broke that, the
+fallback is a hand-rolled poll loop with a no-op waker in place of `block_on`. We
+have not needed it.)
+
+## Building a wasm-able crate
+
+Putting a simulation in a browser is mostly a Cargo question, not a code
+question. Your workload, your processes, and your invariants stay exactly as they
+are. The one rule is to keep the heavy, non-portable dependencies out of the
+build:
+
+```toml
+[dependencies]
+moonpool-sim       = { version = "0.8", default-features = false }
+moonpool-transport = { version = "0.8", default-features = false }
+```
+
+`default-features = false` drops the explorer and the production tokio providers
+and leaves a simulator that targets wasm. Anything native, the same crate's
+tests, a multi-seed chaos binary, a CI runner, depends on the same code with the
+heavier features switched back on. Cargo resolves features per build, so
+`cargo build -p your-wasm-crate` never drags exploration into the bundle. Write
+the simulation once, run it in both places.
+
+## A worked example
+
+The repository ships one:
+[`moonpool-wasm-demo`](https://github.com/PierreZ/moonpool/tree/main/moonpool-wasm-demo).
+It runs a single seed of two nodes trading ping/pong RPCs over the **real
+transport stack**, driven by the **simulated** network, and animates the result.
+The client and server are ordinary `Process` and `Workload` code with no browser
+awareness. `.random_network()` injects seeded latency and connection drops, so
+some round trips come back slow and some never come back at all. A generic
+recorder reads the same trace timeline your invariants read and turns it into the
+picture.
+
+It is running right here, compiled to wasm and served as a page asset. Press
+**Run**, type a seed, or pick a preset. `256` is chaotic, `7` is a storm, `42` is
+calm. The same seed always replays the same history.
+
+<iframe
+  src="../wasm-demo/index.html?embed=1&amp;seed=256"
+  title="moonpool ping-pong wasm demo"
+  loading="lazy"
+  style="width:100%;height:640px;border:1px solid #30363d;border-radius:12px;background:#0d1117;color-scheme:dark">
+</iframe>
+
+You can also run it outside the book. The build is three commands and no bundler:
+
+```bash
+cargo build --release --target wasm32-unknown-unknown -p moonpool-wasm-demo --lib
+wasm-bindgen --target web --out-dir web/pkg \
+  target/wasm32-unknown-unknown/release/moonpool_wasm_demo.wasm
+cd web && python3 -m http.server   # open the page, press Run
+```
+
+Run a seed natively with `cargo run -p moonpool-wasm-demo 42`, then run the same
+seed in the browser. You get the **byte-identical** history. Same seed, same run,
+on your laptop and in a stranger's tab. That is seed-driven reproducibility with
+nowhere left to hide.
+
+## What stays behind
+
+Two things do not cross over, by design. The production providers cannot run in a
+browser, because a tab has no raw TCP and no filesystem. And the explorer cannot
+follow, because there is no `fork` in wasm. You lose multiverse forking, not
+correctness: the in-process assertion table still tracks every `assert_always!`
+and `assert_sometimes!`. The full platform matrix lives in
+[Using Providers in Production](./05-production.md).
+
+To keep the browser path from quietly rotting, a `portability` job in CI compiles
+the simulator to `wasm32-unknown-unknown` on every change, runs the no-explorer
+test suite, and fails the build if the lean production tree ever pulls the
+simulator back in. The browser is not a one-time stunt. It is a gate.

--- a/flake.nix
+++ b/flake.nix
@@ -46,6 +46,9 @@
             cargo-nextest
 	    cargo-edit
 
+	    # wasm demo: generate JS/TS bindings for the cdylib
+	    wasm-bindgen-cli
+
 	    # mdbook
 	    mdbook
             mdbook-toc

--- a/flake.nix
+++ b/flake.nix
@@ -22,10 +22,12 @@
         toolchainFile = builtins.fromTOML (builtins.readFile ./rust-toolchain.toml);
         rustVersion = toolchainFile.toolchain.channel;
         rustComponents = toolchainFile.toolchain.components or [];
-        
-        # Create rust toolchain with specified version and components
+        rustTargets = toolchainFile.toolchain.targets or [];
+
+        # Create rust toolchain with specified version, components, and targets
         rust-toolchain = pkgs.rust-bin.stable.${rustVersion}.default.override {
           extensions = rustComponents;
+          targets = rustTargets;
         };
         
       in

--- a/moonpool-assertions/Cargo.toml
+++ b/moonpool-assertions/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "moonpool-assertions"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Portable assertion accounting (Antithesis-style) for the moonpool framework"
+documentation = "https://docs.rs/moonpool-assertions"
+
+# Pure std, zero dependencies — compiles on wasm32-unknown-unknown, macOS, and Linux.
+# Assertion counts live in a heap-allocated table by default; moonpool-explorer
+# overrides the region with MAP_SHARED memory and installs a discovery hook so the
+# same accounting drives fork-based exploration.
+[dependencies]
+
+[lints]
+workspace = true

--- a/moonpool-assertions/src/buckets.rs
+++ b/moonpool-assertions/src/buckets.rs
@@ -1,8 +1,11 @@
-//! Per-value bucketed exploration infrastructure for `assert_sometimes_each!`.
+//! Per-value bucketed accounting for `assert_sometimes_each!`.
 //!
-//! Each unique combination of identity key values creates one bucket in shared
-//! memory. On first discovery, a fork is triggered. Optional quality watermarks
-//! allow re-forking when the packed quality score improves.
+//! Each unique combination of identity key values creates one bucket. On first
+//! discovery the accounting calls [`crate::hooks::on_bucket_split`]; on every
+//! call it calls [`crate::hooks::on_bucket_mark`]. With no hook installed both
+//! are no-ops (pure accounting); the exploration backend wires them to coverage
+//! marking and fork dispatch. Optional quality watermarks allow re-signalling
+//! when the packed quality score improves.
 //!
 //! # Memory Layout
 //!
@@ -15,7 +18,7 @@
 
 use std::sync::atomic::{AtomicI64, AtomicU8, AtomicU32, Ordering};
 
-/// Maximum number of `EachBucket` slots in shared memory.
+/// Maximum number of `EachBucket` slots.
 pub const MAX_EACH_BUCKETS: usize = 256;
 
 /// Maximum number of identity keys per bucket.
@@ -24,13 +27,13 @@ pub const MAX_EACH_KEYS: usize = 6;
 /// Maximum length of the assertion message stored in a bucket.
 const EACH_MSG_LEN: usize = 32;
 
-/// Total shared memory size for the `EachBucket` region.
+/// Total memory size for the `EachBucket` region.
 pub const EACH_BUCKET_MEM_SIZE: usize = 8 + MAX_EACH_BUCKETS * std::mem::size_of::<EachBucket>();
 
-/// One bucket's state in `MAP_SHARED` memory for per-value bucketed assertions.
+/// One bucket's state for per-value bucketed assertions.
 ///
 /// Each unique combination of identity key values creates one bucket.
-/// Optional quality watermark (`has_quality != 0`): re-forks when `best_score` improves.
+/// Optional quality watermark (`has_quality != 0`): re-signals when `best_score` improves.
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct EachBucket {
@@ -69,7 +72,7 @@ impl EachBucket {
     }
 }
 
-use crate::assertion_slots::msg_hash;
+use crate::slots::msg_hash;
 
 /// Find an existing bucket or allocate a new one by (`site_hash`, `bucket_hash`).
 ///
@@ -77,7 +80,7 @@ use crate::assertion_slots::msg_hash;
 ///
 /// # Safety
 ///
-/// `ptr` must point to a valid `EachBucket` shared memory region of at least
+/// `ptr` must point to a valid `EachBucket` memory region of at least
 /// `EACH_BUCKET_MEM_SIZE` bytes.
 unsafe fn find_or_alloc_each_bucket(
     ptr: *mut u8,
@@ -178,12 +181,12 @@ pub fn unpack_quality(packed: i64, n: u8) -> Vec<i64> {
 /// Backing function for per-value bucketed assertions.
 ///
 /// Each unique combination of identity key values creates one bucket.
-/// Forks on first discovery. Optional quality keys re-fork when the packed
-/// quality score improves (CAS loop on `best_score`).
+/// Signals discovery on first hit. Optional quality keys re-signal when the
+/// packed quality score improves (CAS loop on `best_score`).
 ///
-/// This is a no-op if `EachBucket` shared memory is not initialized.
+/// This is a no-op if `EachBucket` memory is not initialized.
 pub fn assertion_sometimes_each(msg: &str, keys: &[(&str, i64)], quality: &[(&str, i64)]) {
-    let ptr = crate::context::EACH_BUCKET_PTR.with(std::cell::Cell::get);
+    let ptr = crate::region::each_bucket_ptr();
     if ptr.is_null() {
         return;
     }
@@ -199,16 +202,10 @@ pub fn assertion_sometimes_each(msg: &str, keys: &[(&str, i64)], quality: &[(&st
         }
     }
 
-    // Mark coverage bitmap for adaptive yield detection.
-    // Different identity key combinations produce different bucket_hash values,
-    // so the bitmap distinguishes e.g. floor-1 from floor-2 assertions.
-    let bm_ptr = crate::context::COVERAGE_BITMAP_PTR.with(std::cell::Cell::get);
-    if !bm_ptr.is_null() {
-        // Safety: bm_ptr is non-null (checked above) and was set to a valid
-        // alloc_shared() pointer of COVERAGE_MAP_SIZE bytes during init().
-        let bm = unsafe { crate::coverage::CoverageBitmap::new(bm_ptr) };
-        bm.set_bit(bucket_hash as usize);
-    }
+    // Mark coverage for adaptive yield detection (on every call). Different
+    // identity key combinations produce different bucket_hash values, so the
+    // coverage map distinguishes e.g. floor-1 from floor-2 assertions.
+    crate::hooks::on_bucket_mark(bucket_hash);
 
     // `min(4)` guarantees the value fits in u8, so the cast is lossless.
     let has_quality = u8::try_from(quality.len().min(4)).unwrap_or(4);
@@ -218,22 +215,22 @@ pub fn assertion_sometimes_each(msg: &str, keys: &[(&str, i64)], quality: &[(&st
         0
     };
 
-    // Safety: ptr was allocated during init() with EACH_BUCKET_MEM_SIZE bytes.
+    // Safety: ptr was allocated with EACH_BUCKET_MEM_SIZE bytes.
     let bucket =
         unsafe { find_or_alloc_each_bucket(ptr, site_hash, bucket_hash, keys, msg, has_quality) };
     if bucket.is_null() {
         return;
     }
 
-    // Safety: bucket points to valid MAP_SHARED memory. Atomic operations are used
-    // for cross-fork safety (parent waits on child via waitpid, but atomics ensure
+    // Safety: bucket points to valid memory. Atomic operations are used for
+    // cross-fork safety (parent waits on child via waitpid, but atomics ensure
     // correct visibility for recursive fork scenarios).
     unsafe {
         // Increment pass count.
         let count_atomic = &*(&raw const (*bucket).pass_count).cast::<AtomicU32>();
         count_atomic.fetch_add(1, Ordering::Relaxed);
 
-        // Fork on first discovery: CAS split_triggered from 0 → 1.
+        // Signal discovery on first hit: CAS split_triggered from 0 → 1.
         let ft = &*(&raw const (*bucket).split_triggered).cast::<AtomicU8>();
         let first_discovery = ft
             .compare_exchange(0, 1, Ordering::Relaxed, Ordering::Relaxed)
@@ -247,13 +244,10 @@ pub fn assertion_sometimes_each(msg: &str, keys: &[(&str, i64)], quality: &[(&st
             }
 
             let bucket_index = compute_each_bucket_index(ptr, bucket);
-            crate::split_loop::dispatch_split(
-                msg,
-                bucket_index % crate::assertion_slots::MAX_ASSERTION_SLOTS,
-            );
+            crate::hooks::on_bucket_split(msg, bucket_index % crate::slots::MAX_ASSERTION_SLOTS);
         } else if has_quality > 0 {
             // Not first discovery: check quality watermark improvement.
-            // CAS loop on best_score — re-fork when score improves.
+            // CAS loop on best_score — re-signal when score improves.
             let bs_atomic = &*(&raw const (*bucket).best_score).cast::<AtomicI64>();
             let mut current = bs_atomic.load(Ordering::Relaxed);
             loop {
@@ -268,9 +262,9 @@ pub fn assertion_sometimes_each(msg: &str, keys: &[(&str, i64)], quality: &[(&st
                 ) {
                     Ok(_) => {
                         let bucket_index = compute_each_bucket_index(ptr, bucket);
-                        crate::split_loop::dispatch_split(
+                        crate::hooks::on_bucket_split(
                             msg,
-                            bucket_index % crate::assertion_slots::MAX_ASSERTION_SLOTS,
+                            bucket_index % crate::slots::MAX_ASSERTION_SLOTS,
                         );
                         break;
                     }
@@ -281,16 +275,16 @@ pub fn assertion_sometimes_each(msg: &str, keys: &[(&str, i64)], quality: &[(&st
     }
 }
 
-/// Read all recorded `EachBucket` entries from shared memory.
+/// Read all recorded `EachBucket` entries.
 ///
-/// Returns an empty vector if `EachBucket` shared memory is not initialized.
+/// Returns an empty vector if `EachBucket` memory is not initialized.
 #[must_use]
 pub fn each_bucket_read_all() -> Vec<EachBucket> {
-    let ptr = crate::context::EACH_BUCKET_PTR.with(std::cell::Cell::get);
+    let ptr = crate::region::each_bucket_ptr();
     if ptr.is_null() {
         return Vec::new();
     }
-    // Safety: ptr was allocated during init() with EACH_BUCKET_MEM_SIZE bytes.
+    // Safety: ptr was allocated with EACH_BUCKET_MEM_SIZE bytes.
     // - The first 4 bytes hold the bucket count (u32), capped at MAX_EACH_BUCKETS.
     // - base = ptr + 8 is the start of the EachBucket array.
     // - Loop bound 0..count ensures base.add(i) stays within the allocated region.

--- a/moonpool-assertions/src/hooks.rs
+++ b/moonpool-assertions/src/hooks.rs
@@ -1,0 +1,80 @@
+//! Discovery hook: the one-way coupling surface to an exploration backend.
+//!
+//! The accounting layer ([`crate::slots`], [`crate::buckets`]) calls these hooks
+//! at the exact points where something "new" happens — a first Sometimes/Reachable
+//! pass, a numeric watermark improvement, a frontier advance, or an each-bucket
+//! hit. With no hook installed (the default — wasm, macOS, plain native runs) the
+//! calls are no-ops and accounting is pure. An exploration backend
+//! (`moonpool-explorer`) installs hooks that mark coverage and dispatch forks.
+//!
+//! This mirrors `moonpool-explorer`'s own `set_rng_hooks` pattern, inverted: there
+//! the sim hands the explorer RNG hooks; here the explorer hands this crate its
+//! discovery hooks. The function pointers are stored in a thread-local `Cell` set
+//! before forking, so forked children inherit them.
+
+use std::cell::Cell;
+
+/// Discovery callbacks installed by an exploration backend.
+///
+/// Each field is a plain function pointer (defaults are no-ops). The accounting
+/// layer never knows what these do — coverage bitmaps and fork dispatch live
+/// entirely behind these pointers.
+#[derive(Clone, Copy)]
+pub struct DiscoveryHooks {
+    /// A slot assertion (bool Sometimes/Reachable first pass, numeric watermark
+    /// improvement, or frontier advance) made a discovery. Receives the slot
+    /// index and the message hash.
+    pub on_slot_discovery: fn(slot_idx: usize, hash: u32),
+    /// An each-bucket assertion was hit (called on every invocation). Receives
+    /// the bucket hash for coverage marking.
+    pub on_bucket_mark: fn(hash: u32),
+    /// An each-bucket assertion made a first discovery or quality improvement.
+    /// Receives the message label and a slot index.
+    pub on_bucket_split: fn(label: &str, slot_idx: usize),
+}
+
+fn noop_slot(_: usize, _: u32) {}
+fn noop_mark(_: u32) {}
+fn noop_split(_: &str, _: usize) {}
+
+impl DiscoveryHooks {
+    /// Hooks that do nothing — pure accounting, no exploration.
+    pub const NOOP: Self = Self {
+        on_slot_discovery: noop_slot,
+        on_bucket_mark: noop_mark,
+        on_bucket_split: noop_split,
+    };
+}
+
+impl Default for DiscoveryHooks {
+    fn default() -> Self {
+        Self::NOOP
+    }
+}
+
+thread_local! {
+    static HOOKS: Cell<DiscoveryHooks> = const { Cell::new(DiscoveryHooks::NOOP) };
+}
+
+/// Install the discovery hooks. Must be called before forking; children inherit
+/// the hooks via thread-local storage.
+pub fn set_discovery_hooks(hooks: DiscoveryHooks) {
+    HOOKS.with(|h| h.set(hooks));
+}
+
+/// Remove any installed hooks, reverting to pure accounting.
+pub fn clear_discovery_hooks() {
+    HOOKS.with(|h| h.set(DiscoveryHooks::NOOP));
+}
+
+pub(crate) fn on_slot_discovery(slot_idx: usize, hash: u32) {
+    HOOKS.with(|h| (h.get().on_slot_discovery)(slot_idx, hash));
+}
+
+pub(crate) fn on_bucket_mark(hash: u32) {
+    HOOKS.with(|h| (h.get().on_bucket_mark)(hash));
+}
+
+pub(crate) fn on_bucket_split(label: &str, slot_idx: usize) {
+    HOOKS.with(|h| (h.get().on_bucket_split)(label, slot_idx));
+}

--- a/moonpool-assertions/src/lib.rs
+++ b/moonpool-assertions/src/lib.rs
@@ -1,0 +1,42 @@
+//! Portable assertion accounting for the moonpool framework.
+//!
+//! This is the Antithesis-style assertion suite — boolean (always / sometimes /
+//! reachable / unreachable), numeric guidance with watermarks, compound
+//! sometimes-all with frontier tracking, and per-value `sometimes_each` buckets —
+//! factored out of `moonpool-explorer` so it has **zero dependencies** and
+//! compiles on `wasm32-unknown-unknown`, macOS, and Linux.
+//!
+//! # How it relates to exploration
+//!
+//! The counts live in a region of memory. By default [`init`] allocates that
+//! region on the heap (single process — wasm, macOS, plain native test runs).
+//! `moonpool-explorer` instead allocates a `MAP_SHARED` region and hands it to
+//! [`install_region`], so the same accounting is visible across `fork`ed
+//! children, and installs a [`DiscoveryHooks`] that turns "a new assertion state
+//! was reached" into coverage marking and fork dispatch. With no hooks installed
+//! the accounting is pure: assertions still record pass/fail/watermark/frontier,
+//! which is all `UntilAllSometimesReached` and contract validation need.
+//!
+//! See [`hooks`] for the coupling surface and [`region`] for the storage model.
+
+#![deny(missing_docs)]
+
+pub mod buckets;
+pub mod hooks;
+pub mod region;
+pub mod slots;
+
+pub use buckets::{
+    EACH_BUCKET_MEM_SIZE, EachBucket, MAX_EACH_BUCKETS, assertion_sometimes_each,
+    each_bucket_read_all, unpack_quality,
+};
+pub use hooks::{DiscoveryHooks, clear_discovery_hooks, set_discovery_hooks};
+pub use region::{
+    assertion_table_ptr, clear, each_bucket_ptr, init, install_region, prepare_next_seed_reset,
+    reset,
+};
+pub use slots::{
+    ASSERTION_TABLE_MEM_SIZE, AssertCmp, AssertKind, AssertionSlot, AssertionSlotSnapshot,
+    MAX_ASSERTION_SLOTS, assertion_bool, assertion_numeric, assertion_read_all,
+    assertion_sometimes_all, msg_hash,
+};

--- a/moonpool-assertions/src/region.rs
+++ b/moonpool-assertions/src/region.rs
@@ -1,0 +1,227 @@
+//! Storage for the assertion + each-bucket regions.
+//!
+//! By default the regions are heap-allocated by [`init`] — portable everywhere
+//! (wasm, macOS, Linux), single process, no sharing. An exploration backend that
+//! needs cross-`fork` sharing calls [`install_region`] with `MAP_SHARED` pointers
+//! it owns; this crate then accounts into that memory and [`clear`]s its view when
+//! the backend frees it.
+//!
+//! Pointers are thread-locals set before forking, so forked children inherit them
+//! (the `MAP_SHARED` region is the same physical memory in parent and child).
+
+use std::alloc::{Layout, alloc_zeroed, dealloc};
+use std::cell::Cell;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use crate::buckets::{EACH_BUCKET_MEM_SIZE, EachBucket, MAX_EACH_BUCKETS};
+use crate::slots::{ASSERTION_TABLE_MEM_SIZE, AssertionSlot, MAX_ASSERTION_SLOTS};
+
+/// Alignment for both regions. `AssertionSlot`/`EachBucket` contain `u64`/`i64`
+/// fields and the layout places the slot array at offset 8, so 8-byte alignment
+/// satisfies every field access.
+const REGION_ALIGN: usize = 8;
+
+thread_local! {
+    static ASSERTION_TABLE: Cell<*mut u8> = const { Cell::new(std::ptr::null_mut()) };
+    static EACH_BUCKET_PTR: Cell<*mut u8> = const { Cell::new(std::ptr::null_mut()) };
+    /// True when the current pointers are heap regions this crate allocated (and
+    /// must free); false when an external backend installed them (it frees).
+    static HEAP_OWNED: Cell<bool> = const { Cell::new(false) };
+}
+
+fn table_layout() -> Layout {
+    // Infallible: size is a compile-time constant and align is a power of two.
+    Layout::from_size_align(ASSERTION_TABLE_MEM_SIZE, REGION_ALIGN)
+        .expect("assertion table layout: const size, power-of-two align")
+}
+
+fn bucket_layout() -> Layout {
+    // Infallible: size is a compile-time constant and align is a power of two.
+    Layout::from_size_align(EACH_BUCKET_MEM_SIZE, REGION_ALIGN)
+        .expect("each-bucket layout: const size, power-of-two align")
+}
+
+/// Get the raw pointer to the assertion table region (null if uninitialized).
+#[must_use]
+pub fn assertion_table_ptr() -> *mut u8 {
+    ASSERTION_TABLE.with(Cell::get)
+}
+
+/// Get the raw pointer to the each-bucket region (null if uninitialized).
+#[must_use]
+pub fn each_bucket_ptr() -> *mut u8 {
+    EACH_BUCKET_PTR.with(Cell::get)
+}
+
+/// Allocate the regions on the heap (zeroed). Idempotent: a no-op if a region is
+/// already present (whether heap-owned or installed by a backend).
+pub fn init() {
+    if !assertion_table_ptr().is_null() {
+        return;
+    }
+    // Safety: layouts have non-zero size; alloc_zeroed returns zeroed memory of the
+    // requested size/alignment, matching the `[count: u32, _pad, slots..]` layout.
+    let table = unsafe { alloc_zeroed(table_layout()) };
+    if table.is_null() {
+        std::alloc::handle_alloc_error(table_layout());
+    }
+    let buckets = unsafe { alloc_zeroed(bucket_layout()) };
+    if buckets.is_null() {
+        std::alloc::handle_alloc_error(bucket_layout());
+    }
+    ASSERTION_TABLE.with(|c| c.set(table));
+    EACH_BUCKET_PTR.with(|c| c.set(buckets));
+    HEAP_OWNED.with(|c| c.set(true));
+}
+
+/// Point accounting at caller-owned regions (e.g. `MAP_SHARED` memory from an
+/// exploration backend). The caller owns the memory and is responsible for
+/// freeing it after calling [`clear`]. Frees any heap regions this crate
+/// previously allocated.
+///
+/// Both pointers must reference at least [`crate::ASSERTION_TABLE_MEM_SIZE`] /
+/// [`crate::EACH_BUCKET_MEM_SIZE`] bytes respectively, and stay valid until
+/// [`clear`] is called.
+pub fn install_region(table: *mut u8, buckets: *mut u8) {
+    free_heap_regions();
+    ASSERTION_TABLE.with(|c| c.set(table));
+    EACH_BUCKET_PTR.with(|c| c.set(buckets));
+    HEAP_OWNED.with(|c| c.set(false));
+}
+
+/// Drop this crate's view of the regions. Frees heap regions it owns; for
+/// installed (external) regions it only nulls the pointers — the backend frees
+/// its own memory.
+pub fn clear() {
+    free_heap_regions();
+    ASSERTION_TABLE.with(|c| c.set(std::ptr::null_mut()));
+    EACH_BUCKET_PTR.with(|c| c.set(std::ptr::null_mut()));
+}
+
+fn free_heap_regions() {
+    if !HEAP_OWNED.with(Cell::get) {
+        return;
+    }
+    let table = assertion_table_ptr();
+    if !table.is_null() {
+        // Safety: heap-owned table was allocated by init() with table_layout().
+        unsafe { dealloc(table, table_layout()) };
+    }
+    let buckets = each_bucket_ptr();
+    if !buckets.is_null() {
+        // Safety: heap-owned buckets were allocated by init() with bucket_layout().
+        unsafe { dealloc(buckets, bucket_layout()) };
+    }
+    HEAP_OWNED.with(|c| c.set(false));
+}
+
+/// Zero both regions for a between-run reset. No-op if not initialized.
+pub fn reset() {
+    let table = assertion_table_ptr();
+    if !table.is_null() {
+        // Safety: region is ASSERTION_TABLE_MEM_SIZE bytes (heap or installed).
+        unsafe { std::ptr::write_bytes(table, 0, ASSERTION_TABLE_MEM_SIZE) };
+    }
+    let buckets = each_bucket_ptr();
+    if !buckets.is_null() {
+        // Safety: region is EACH_BUCKET_MEM_SIZE bytes (heap or installed).
+        unsafe { std::ptr::write_bytes(buckets, 0, EACH_BUCKET_MEM_SIZE) };
+    }
+}
+
+/// Reset only the per-seed split triggers, preserving pass/fail counts and
+/// watermarks/frontiers across seeds (coverage-preserving multi-seed reset).
+///
+/// `pass_count`/`fail_count` accumulate across seeds so contract validation never
+/// reports a false "was never reached" when a seed doesn't reach a guarded
+/// assertion. Forking uses `split_triggered`, not counts. No-op if uninitialized.
+pub fn prepare_next_seed_reset() {
+    let table = assertion_table_ptr();
+    if !table.is_null() {
+        // Safety: region is the assertion table laid out as
+        // `[count: u32, _pad, slots: [AssertionSlot; MAX_ASSERTION_SLOTS]]`.
+        unsafe {
+            let count_ptr = table.cast::<()>().cast::<AtomicU32>();
+            // MAX_ASSERTION_SLOTS is a small const (128), so the cast is lossless.
+            let max_slots = u32::try_from(MAX_ASSERTION_SLOTS).unwrap_or(u32::MAX);
+            let count = (*count_ptr).load(Ordering::Relaxed).min(max_slots) as usize;
+            let base = table.add(8).cast::<()>().cast::<AssertionSlot>();
+            for i in 0..count {
+                let slot = &mut *base.add(i);
+                // Skip tombstones (msg_hash == 0) left by the duplicate-slot race fix.
+                if slot.msg_hash == 0 {
+                    continue;
+                }
+                slot.split_triggered = 0;
+            }
+        }
+    }
+
+    let buckets = each_bucket_ptr();
+    if !buckets.is_null() {
+        // Safety: region is the each-bucket table laid out as
+        // `[count: u32, _pad, buckets: [EachBucket; MAX_EACH_BUCKETS]]`.
+        unsafe {
+            let count_ptr = buckets.cast::<()>().cast::<AtomicU32>();
+            // MAX_EACH_BUCKETS is a small const (256), so the cast is lossless.
+            let max_buckets = u32::try_from(MAX_EACH_BUCKETS).unwrap_or(u32::MAX);
+            let count = (*count_ptr).load(Ordering::Relaxed).min(max_buckets) as usize;
+            let base = buckets.add(8).cast::<()>().cast::<EachBucket>();
+            for i in 0..count {
+                (*base.add(i)).split_triggered = 0;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::slots::{AssertCmp, AssertKind, assertion_bool, assertion_read_all};
+
+    #[test]
+    fn heap_init_enables_accounting_and_reset() {
+        // Each nextest test runs in its own process, so this thread starts with
+        // null regions.
+        assert!(assertion_table_ptr().is_null());
+        init();
+        assert!(!assertion_table_ptr().is_null());
+
+        // Accounting works on the heap region.
+        assertion_bool(AssertKind::Sometimes, true, true, "site_a");
+        let slots = assertion_read_all();
+        assert_eq!(slots.len(), 1);
+        assert_eq!(slots[0].pass_count, 1);
+
+        // reset() zeroes counts.
+        reset();
+        assert!(assertion_read_all().is_empty());
+
+        clear();
+        assert!(assertion_table_ptr().is_null());
+    }
+
+    #[test]
+    fn prepare_next_seed_preserves_counts_resets_triggers() {
+        init();
+        crate::slots::assertion_numeric(
+            AssertKind::NumericSometimes,
+            AssertCmp::Gt,
+            true,
+            5,
+            0,
+            "n",
+        );
+        assertion_bool(AssertKind::Sometimes, true, true, "s");
+        let before = assertion_read_all();
+        let pass_total: u64 = before.iter().map(|s| s.pass_count).sum();
+        assert!(pass_total >= 2);
+
+        prepare_next_seed_reset();
+        let after = assertion_read_all();
+        // Counts preserved across the seed boundary.
+        let pass_after: u64 = after.iter().map(|s| s.pass_count).sum();
+        assert_eq!(pass_total, pass_after);
+        clear();
+    }
+}

--- a/moonpool-assertions/src/slots.rs
+++ b/moonpool-assertions/src/slots.rs
@@ -1,14 +1,20 @@
 //! Rich assertion slot tracking for the Antithesis-style assertion suite.
 //!
-//! Maintains a fixed-size table of assertion slots in shared memory.
-//! Supports boolean assertions (always/sometimes/reachable/unreachable),
-//! numeric guidance assertions (with watermark tracking), and compound
-//! boolean assertions (sometimes-all with frontier tracking).
+//! Maintains a fixed-size table of assertion slots. Supports boolean assertions
+//! (always/sometimes/reachable/unreachable), numeric guidance assertions (with
+//! watermark tracking), and compound boolean assertions (sometimes-all with
+//! frontier tracking).
 //!
-//! Each slot is accessed via raw pointer arithmetic on `MAP_SHARED` memory.
-//! With `Parallelism::Cores(N)`, multiple fork children run concurrently,
-//! so `find_or_alloc_slot` claims slots by atomically writing `msg_hash`
-//! before re-scanning, ensuring concurrent allocators see each other.
+//! Each slot is accessed via raw pointer arithmetic on the assertion region
+//! (heap by default, or `MAP_SHARED` memory when an exploration backend installs
+//! one). With multiple fork children running concurrently, `find_or_alloc_slot`
+//! claims slots by atomically writing `msg_hash` before re-scanning, ensuring
+//! concurrent allocators see each other.
+//!
+//! On a "discovery" (first Sometimes/Reachable pass, numeric watermark
+//! improvement, or frontier advance) the accounting calls
+//! [`crate::hooks::on_slot_discovery`]. With no hook installed this is a no-op
+//! (pure accounting); the exploration backend wires it to coverage + forking.
 
 use std::sync::atomic::{AtomicI64, AtomicU8, AtomicU32, Ordering};
 
@@ -78,9 +84,9 @@ pub enum AssertCmp {
     Le = 3,
 }
 
-/// A single assertion tracking slot in shared memory.
+/// A single assertion tracking slot.
 ///
-/// All fields are accessed via raw pointer arithmetic on `MAP_SHARED` memory.
+/// All fields are accessed via raw pointer arithmetic on the assertion region.
 #[repr(C)]
 pub struct AssertionSlot {
     /// FNV-1a hash of the assertion message (u32).
@@ -211,39 +217,15 @@ unsafe fn find_or_alloc_slot(
     }
 }
 
-/// Trigger forking for a slot that discovered something new.
-///
-/// Writes to coverage bitmap and explored map (if pointers are non-null),
-/// then calls `dispatch_split()` if exploration is active.
-fn assertion_split(slot_idx: usize, hash: u32) {
-    let bm_ptr = crate::context::COVERAGE_BITMAP_PTR.with(std::cell::Cell::get);
-    let vm_ptr = crate::context::EXPLORED_MAP_PTR.with(std::cell::Cell::get);
-
-    if !bm_ptr.is_null() {
-        // Safety: bm_ptr points to COVERAGE_MAP_SIZE bytes of shared memory set during init().
-        let bm = unsafe { crate::coverage::CoverageBitmap::new(bm_ptr) };
-        bm.set_bit(hash as usize);
-        if !vm_ptr.is_null() {
-            // Safety: vm_ptr points to COVERAGE_MAP_SIZE bytes of shared memory set during init().
-            let vm = unsafe { crate::coverage::ExploredMap::new(vm_ptr) };
-            vm.merge_from(&bm);
-        }
-    }
-
-    if crate::context::explorer_is_active() {
-        crate::split_loop::dispatch_split("", slot_idx % MAX_ASSERTION_SLOTS);
-    }
-}
-
 /// Boolean assertion backing function.
 ///
 /// Handles Always, `AlwaysOrUnreachable`, Sometimes, Reachable, and Unreachable.
-/// Gets or allocates a slot, increments pass/fail counts, and triggers forking
+/// Gets or allocates a slot, increments pass/fail counts, and signals a discovery
 /// for Sometimes/Reachable assertions on first success.
 ///
 /// This is a no-op if the assertion table is not initialized.
 pub fn assertion_bool(kind: AssertKind, must_hit: bool, condition: bool, msg: &str) {
-    let table_ptr = crate::context::assertion_table_ptr();
+    let table_ptr = crate::region::assertion_table_ptr();
     if table_ptr.is_null() {
         return;
     }
@@ -251,14 +233,14 @@ pub fn assertion_bool(kind: AssertKind, must_hit: bool, condition: bool, msg: &s
     let hash = msg_hash(msg);
     let must_hit_u8 = u8::from(must_hit);
 
-    // Safety: table_ptr points to ASSERTION_TABLE_MEM_SIZE bytes of shared memory.
+    // Safety: table_ptr points to ASSERTION_TABLE_MEM_SIZE bytes.
     let (slot, slot_idx) =
         unsafe { find_or_alloc_slot(table_ptr, hash, kind, must_hit_u8, 0, msg) };
     if slot.is_null() {
         return;
     }
 
-    // Safety: slot points to valid shared memory.
+    // Safety: slot points to valid memory.
     unsafe {
         match kind {
             AssertKind::Always | AssertKind::AlwaysOrUnreachable | AssertKind::NumericAlways => {
@@ -284,7 +266,7 @@ pub fn assertion_bool(kind: AssertKind, must_hit: bool, condition: bool, msg: &s
                         .compare_exchange(0, 1, Ordering::Relaxed, Ordering::Relaxed)
                         .is_ok()
                     {
-                        assertion_split(slot_idx, hash);
+                        crate::hooks::on_slot_discovery(slot_idx, hash);
                     }
                 } else {
                     let fc = &*(&raw const (*slot).fail_count).cast::<AtomicI64>();
@@ -309,8 +291,8 @@ pub fn assertion_bool(kind: AssertKind, must_hit: bool, condition: bool, msg: &s
 ///
 /// Evaluates a comparison (left `cmp` right), tracks pass/fail counts,
 /// and maintains a watermark of the best observed value of `left`.
-/// For `NumericSometimes`, forks when the watermark improves past the
-/// last fork watermark.
+/// For `NumericSometimes`, signals a discovery when the watermark improves past
+/// the last fork watermark.
 ///
 /// `maximize` determines whether improving means getting larger (true) or smaller (false).
 ///
@@ -323,7 +305,7 @@ pub fn assertion_numeric(
     right: i64,
     msg: &str,
 ) {
-    let table_ptr = crate::context::assertion_table_ptr();
+    let table_ptr = crate::region::assertion_table_ptr();
     if table_ptr.is_null() {
         return;
     }
@@ -346,7 +328,7 @@ pub fn assertion_numeric(
         AssertCmp::Le => left <= right,
     };
 
-    // Safety: slot points to valid shared memory.
+    // Safety: slot points to valid memory.
     unsafe {
         if passes {
             let pc = &*(&raw const (*slot).pass_count).cast::<AtomicI64>();
@@ -379,7 +361,7 @@ pub fn assertion_numeric(
             }
         }
 
-        // For NumericSometimes: fork when watermark improves past split_watermark
+        // For NumericSometimes: signal discovery when watermark improves past split_watermark
         if kind == AssertKind::NumericSometimes {
             let fw = &*(&raw const (*slot).split_watermark).cast::<AtomicI64>();
             let mut fork_current = fw.load(Ordering::Relaxed);
@@ -399,7 +381,7 @@ pub fn assertion_numeric(
                     Ordering::Relaxed,
                 ) {
                     Ok(_) => {
-                        assertion_split(slot_idx, hash);
+                        crate::hooks::on_slot_discovery(slot_idx, hash);
                         break;
                     }
                     Err(actual) => fork_current = actual,
@@ -412,11 +394,12 @@ pub fn assertion_numeric(
 /// Compound boolean assertion backing function (sometimes-all).
 ///
 /// Counts how many of the named booleans are simultaneously true.
-/// Maintains a frontier (max count seen). Forks when the frontier advances.
+/// Maintains a frontier (max count seen). Signals a discovery when the frontier
+/// advances.
 ///
 /// This is a no-op if the assertion table is not initialized.
 pub fn assertion_sometimes_all(msg: &str, named_bools: &[(&str, bool)]) {
-    let table_ptr = crate::context::assertion_table_ptr();
+    let table_ptr = crate::region::assertion_table_ptr();
     if table_ptr.is_null() {
         return;
     }
@@ -436,13 +419,13 @@ pub fn assertion_sometimes_all(msg: &str, named_bools: &[(&str, bool)]) {
     let true_count =
         u8::try_from(named_bools.iter().filter(|(_, v)| *v).count()).unwrap_or(u8::MAX);
 
-    // Safety: slot points to valid shared memory.
+    // Safety: slot points to valid memory.
     unsafe {
         // Increment pass_count (always, for statistics)
         let pc = &*(&raw const (*slot).pass_count).cast::<AtomicI64>();
         pc.fetch_add(1, Ordering::Relaxed);
 
-        // CAS loop on frontier — fork when it advances
+        // CAS loop on frontier — signal discovery when it advances
         let fr = &*(&raw const (*slot).frontier).cast::<AtomicU8>();
         let mut current = fr.load(Ordering::Relaxed);
         loop {
@@ -456,7 +439,7 @@ pub fn assertion_sometimes_all(msg: &str, named_bools: &[(&str, bool)]) {
                 Ordering::Relaxed,
             ) {
                 Ok(_) => {
-                    assertion_split(slot_idx, hash);
+                    crate::hooks::on_slot_discovery(slot_idx, hash);
                     break;
                 }
                 Err(actual) => current = actual,
@@ -465,17 +448,17 @@ pub fn assertion_sometimes_all(msg: &str, named_bools: &[(&str, bool)]) {
     }
 }
 
-/// Read all allocated assertion slots from shared memory.
+/// Read all allocated assertion slots from the region.
 ///
 /// Returns an empty vector if the assertion table is not initialized.
 #[must_use]
 pub fn assertion_read_all() -> Vec<AssertionSlotSnapshot> {
-    let table_ptr = crate::context::assertion_table_ptr();
+    let table_ptr = crate::region::assertion_table_ptr();
     if table_ptr.is_null() {
         return Vec::new();
     }
 
-    // Safety: table_ptr was allocated during init() with ASSERTION_TABLE_MEM_SIZE bytes.
+    // Safety: table_ptr was allocated with ASSERTION_TABLE_MEM_SIZE bytes.
     // - The first 4 bytes hold the slot count (u32), capped at MAX_ASSERTION_SLOTS.
     // - base = table_ptr + 8 is the start of the AssertionSlot array.
     // - Loop bound 0..count ensures base.add(i) stays within the allocated region.
@@ -579,13 +562,6 @@ mod tests {
             5,
             "test",
         );
-    }
-
-    #[test]
-    fn test_assertion_read_all_when_inactive() {
-        // Should return empty when not initialized.
-        let slots = assertion_read_all();
-        assert!(slots.is_empty());
     }
 
     #[test]

--- a/moonpool-core/Cargo.toml
+++ b/moonpool-core/Cargo.toml
@@ -15,7 +15,18 @@ rustc-args = ["--cfg", "tokio_unstable"]
 
 [features]
 default = ["tokio-providers"]
-tokio-providers = ["dep:tokio", "dep:tokio-util", "rand/thread_rng"]
+# Umbrella: the full production bundle (TokioProviders needs all five slots).
+tokio-providers = ["tokio-task", "tokio-time", "tokio-net", "tokio-fs", "tokio-random"]
+# Granular per-provider features. A consumer that only needs one provider (e.g.
+# moonpool-sim bundles the real TokioTaskProvider) enables just that one and stays
+# free of net/fs/time — keeping the crate wasm-clean where those aren't used.
+# tokio::task::Builder (named spawn) is behind cfg_trace! → needs tokio/tracing.
+tokio-task = ["dep:tokio", "tokio/rt", "tokio/tracing"]
+tokio-time = ["dep:tokio", "tokio/time"]
+tokio-net = ["dep:tokio", "tokio/net", "tokio/io-util", "dep:tokio-util"]
+tokio-fs = ["dep:tokio", "tokio/fs", "tokio/io-util", "dep:tokio-util"]
+# TokioRandomProvider uses rand's ThreadRng; no tokio involved.
+tokio-random = ["rand/thread_rng"]
 
 [dependencies]
 futures = "0.3"
@@ -23,7 +34,7 @@ rand = { version = "0.10", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2.0"
-tokio = { version = "1", features = ["fs", "io-util", "net", "rt", "time", "tracing"], optional = true }
+tokio = { version = "1", default-features = false, optional = true }
 tokio-util = { version = "0.7", features = ["compat"], optional = true }
 tracing = "0.1"
 

--- a/moonpool-core/src/lib.rs
+++ b/moonpool-core/src/lib.rs
@@ -75,24 +75,43 @@ pub use error::{SimulationError, SimulationResult};
 
 // Provider trait exports
 pub use network::{NetworkProvider, TcpListenerTrait};
-#[cfg(feature = "tokio-providers")]
+#[cfg(feature = "tokio-net")]
 pub use network::{TokioNetworkProvider, TokioTcpListener};
 pub use providers::Providers;
 #[cfg(feature = "tokio-providers")]
 pub use providers::TokioProviders;
 pub use random::RandomProvider;
-#[cfg(feature = "tokio-providers")]
+#[cfg(feature = "tokio-random")]
 pub use random::TokioRandomProvider;
 pub use storage::{OpenOptions, StorageFile, StorageProvider};
-#[cfg(feature = "tokio-providers")]
+#[cfg(feature = "tokio-fs")]
 pub use storage::{TokioStorageFile, TokioStorageProvider};
 pub use task::{JoinError, TaskProvider};
-#[cfg(feature = "tokio-providers")]
+#[cfg(feature = "tokio-task")]
 pub use task::{TokioJoinHandle, TokioTaskProvider};
-#[cfg(feature = "tokio-providers")]
+#[cfg(feature = "tokio-time")]
 pub use time::TokioTimeProvider;
 pub use time::{TimeError, TimeProvider};
 
 // Core type exports
 pub use types::{Endpoint, NetworkAddress, NetworkAddressParseError, UID, flags};
 pub use well_known::{WELL_KNOWN_RESERVED_COUNT, WellKnownToken};
+
+/// Common imports for writing code against the provider traits.
+///
+/// Bringing the provider traits into scope is the usual ergonomic need — their
+/// `async fn`s (RPIT) are only callable with the trait in scope. Glob-import this
+/// in production code:
+///
+/// ```
+/// use moonpool_core::prelude::*;
+/// ```
+pub mod prelude {
+    pub use crate::{
+        NetworkProvider, Providers, RandomProvider, StorageProvider, TaskProvider,
+        TcpListenerTrait, TimeProvider,
+    };
+
+    #[cfg(feature = "tokio-providers")]
+    pub use crate::TokioProviders;
+}

--- a/moonpool-core/src/network.rs
+++ b/moonpool-core/src/network.rs
@@ -5,7 +5,7 @@
 
 use futures::io::{AsyncRead, AsyncWrite};
 use std::io;
-#[cfg(feature = "tokio-providers")]
+#[cfg(feature = "tokio-net")]
 use tokio_util::compat::{Compat, TokioAsyncReadCompatExt};
 
 /// Provider trait for creating network connections and listeners.
@@ -54,11 +54,11 @@ pub trait TcpListenerTrait: Send + Sync + 'static {
 /// Wraps `tokio::net::TcpStream` with `tokio_util::compat::Compat` so it
 /// implements the runtime-agnostic `futures::io::AsyncRead + AsyncWrite` traits
 /// required by [`NetworkProvider`].
-#[cfg(feature = "tokio-providers")]
+#[cfg(feature = "tokio-net")]
 #[derive(Debug, Clone, Default)]
 pub struct TokioNetworkProvider;
 
-#[cfg(feature = "tokio-providers")]
+#[cfg(feature = "tokio-net")]
 impl TokioNetworkProvider {
     /// Create a new Tokio network provider.
     #[must_use]
@@ -67,7 +67,7 @@ impl TokioNetworkProvider {
     }
 }
 
-#[cfg(feature = "tokio-providers")]
+#[cfg(feature = "tokio-net")]
 impl NetworkProvider for TokioNetworkProvider {
     type TcpStream = Compat<tokio::net::TcpStream>;
     type TcpListener = TokioTcpListener;
@@ -83,13 +83,13 @@ impl NetworkProvider for TokioNetworkProvider {
 }
 
 /// Wrapper for Tokio `TcpListener` to implement our trait.
-#[cfg(feature = "tokio-providers")]
+#[cfg(feature = "tokio-net")]
 #[derive(Debug)]
 pub struct TokioTcpListener {
     inner: tokio::net::TcpListener,
 }
 
-#[cfg(feature = "tokio-providers")]
+#[cfg(feature = "tokio-net")]
 impl TcpListenerTrait for TokioTcpListener {
     type TcpStream = Compat<tokio::net::TcpStream>;
 

--- a/moonpool-core/src/random.rs
+++ b/moonpool-core/src/random.rs
@@ -5,9 +5,9 @@
 //! like `TimeProvider`, `NetworkProvider`, and `TaskProvider`.
 
 use rand::distr::{Distribution, StandardUniform, uniform::SampleUniform};
-#[cfg(feature = "tokio-providers")]
+#[cfg(feature = "tokio-random")]
 use rand::prelude::*;
-#[cfg(feature = "tokio-providers")]
+#[cfg(feature = "tokio-random")]
 use std::cell::RefCell;
 use std::ops::Range;
 
@@ -57,11 +57,11 @@ pub trait RandomProvider: Clone + Send + Sync + 'static {
 /// let value: u64 = random.random();
 /// let in_range = random.random_range(1..100);
 /// ```
-#[cfg(feature = "tokio-providers")]
+#[cfg(feature = "tokio-random")]
 #[derive(Clone, Default)]
 pub struct TokioRandomProvider;
 
-#[cfg(feature = "tokio-providers")]
+#[cfg(feature = "tokio-random")]
 impl TokioRandomProvider {
     /// Create a new production random provider.
     #[must_use]
@@ -71,12 +71,12 @@ impl TokioRandomProvider {
 }
 
 // Thread-local RNG for TokioRandomProvider
-#[cfg(feature = "tokio-providers")]
+#[cfg(feature = "tokio-random")]
 thread_local! {
     static RNG: RefCell<rand::rngs::ThreadRng> = RefCell::new(rand::rng());
 }
 
-#[cfg(feature = "tokio-providers")]
+#[cfg(feature = "tokio-random")]
 impl RandomProvider for TokioRandomProvider {
     fn random<T>(&self) -> T
     where

--- a/moonpool-core/src/storage.rs
+++ b/moonpool-core/src/storage.rs
@@ -5,13 +5,13 @@
 
 use futures::io::{AsyncRead, AsyncSeek, AsyncWrite};
 use std::io;
-#[cfg(feature = "tokio-providers")]
+#[cfg(feature = "tokio-fs")]
 use std::io::SeekFrom;
-#[cfg(feature = "tokio-providers")]
+#[cfg(feature = "tokio-fs")]
 use std::pin::Pin;
-#[cfg(feature = "tokio-providers")]
+#[cfg(feature = "tokio-fs")]
 use std::task::{Context, Poll};
-#[cfg(feature = "tokio-providers")]
+#[cfg(feature = "tokio-fs")]
 use tokio_util::compat::{Compat, TokioAsyncReadCompatExt};
 
 /// Options for opening a file.
@@ -178,11 +178,11 @@ pub trait StorageFile: AsyncRead + AsyncWrite + AsyncSeek + Unpin + Send + Sync 
 }
 
 /// Real Tokio storage implementation.
-#[cfg(feature = "tokio-providers")]
+#[cfg(feature = "tokio-fs")]
 #[derive(Debug, Clone, Default)]
 pub struct TokioStorageProvider;
 
-#[cfg(feature = "tokio-providers")]
+#[cfg(feature = "tokio-fs")]
 impl TokioStorageProvider {
     /// Create a new Tokio storage provider.
     #[must_use]
@@ -191,7 +191,7 @@ impl TokioStorageProvider {
     }
 }
 
-#[cfg(feature = "tokio-providers")]
+#[cfg(feature = "tokio-fs")]
 impl StorageProvider for TokioStorageProvider {
     type File = TokioStorageFile;
 
@@ -235,13 +235,13 @@ impl StorageProvider for TokioStorageProvider {
 /// [`Compat::get_ref`] / [`Compat::get_mut`] to call tokio-specific APIs
 /// (`sync_all`, `sync_data`, `metadata`, `set_len`) that `Compat` itself
 /// does not expose.
-#[cfg(feature = "tokio-providers")]
+#[cfg(feature = "tokio-fs")]
 #[derive(Debug)]
 pub struct TokioStorageFile {
     inner: Compat<tokio::fs::File>,
 }
 
-#[cfg(feature = "tokio-providers")]
+#[cfg(feature = "tokio-fs")]
 impl StorageFile for TokioStorageFile {
     async fn sync_all(&self) -> io::Result<()> {
         self.inner.get_ref().sync_all().await
@@ -261,7 +261,7 @@ impl StorageFile for TokioStorageFile {
     }
 }
 
-#[cfg(feature = "tokio-providers")]
+#[cfg(feature = "tokio-fs")]
 impl AsyncRead for TokioStorageFile {
     fn poll_read(
         mut self: Pin<&mut Self>,
@@ -272,7 +272,7 @@ impl AsyncRead for TokioStorageFile {
     }
 }
 
-#[cfg(feature = "tokio-providers")]
+#[cfg(feature = "tokio-fs")]
 impl AsyncWrite for TokioStorageFile {
     fn poll_write(
         mut self: Pin<&mut Self>,
@@ -291,7 +291,7 @@ impl AsyncWrite for TokioStorageFile {
     }
 }
 
-#[cfg(feature = "tokio-providers")]
+#[cfg(feature = "tokio-fs")]
 impl AsyncSeek for TokioStorageFile {
     fn poll_seek(
         mut self: Pin<&mut Self>,

--- a/moonpool-core/src/task.rs
+++ b/moonpool-core/src/task.rs
@@ -53,7 +53,7 @@ pub trait TaskProvider: Clone + Send + Sync + 'static {
 /// inside the sim runtime (`new_current_thread().build()`) the runtime runs
 /// every task on a single OS thread, preserving determinism while still
 /// requiring `Send + 'static` futures.
-#[cfg(feature = "tokio-providers")]
+#[cfg(feature = "tokio-task")]
 #[derive(Clone, Debug)]
 pub struct TokioTaskProvider;
 
@@ -62,11 +62,11 @@ pub struct TokioTaskProvider;
 /// Wraps tokio's `JoinHandle<()>` and converts the runtime-specific
 /// `tokio::task::JoinError` into the runtime-agnostic [`JoinError`] variants
 /// when polled.
-#[cfg(feature = "tokio-providers")]
+#[cfg(feature = "tokio-task")]
 #[derive(Debug)]
 pub struct TokioJoinHandle(tokio::task::JoinHandle<()>);
 
-#[cfg(feature = "tokio-providers")]
+#[cfg(feature = "tokio-task")]
 impl Future for TokioJoinHandle {
     type Output = Result<(), JoinError>;
 
@@ -84,7 +84,7 @@ impl Future for TokioJoinHandle {
     }
 }
 
-#[cfg(feature = "tokio-providers")]
+#[cfg(feature = "tokio-task")]
 impl TaskProvider for TokioTaskProvider {
     type JoinHandle = TokioJoinHandle;
 

--- a/moonpool-core/src/time.rs
+++ b/moonpool-core/src/time.rs
@@ -76,14 +76,14 @@ pub trait TimeProvider: Clone + Send + Sync + 'static {
 }
 
 /// Real time provider using Tokio's time facilities.
-#[cfg(feature = "tokio-providers")]
+#[cfg(feature = "tokio-time")]
 #[derive(Debug, Clone)]
 pub struct TokioTimeProvider {
     /// Start time for calculating elapsed duration
     start_time: std::time::Instant,
 }
 
-#[cfg(feature = "tokio-providers")]
+#[cfg(feature = "tokio-time")]
 impl TokioTimeProvider {
     /// Create a new Tokio time provider.
     #[must_use]
@@ -94,14 +94,14 @@ impl TokioTimeProvider {
     }
 }
 
-#[cfg(feature = "tokio-providers")]
+#[cfg(feature = "tokio-time")]
 impl Default for TokioTimeProvider {
     fn default() -> Self {
         Self::new()
     }
 }
 
-#[cfg(feature = "tokio-providers")]
+#[cfg(feature = "tokio-time")]
 impl TimeProvider for TokioTimeProvider {
     async fn sleep(&self, duration: Duration) -> Result<(), TimeError> {
         tokio::time::sleep(duration).await;

--- a/moonpool-explorer/Cargo.toml
+++ b/moonpool-explorer/Cargo.toml
@@ -13,6 +13,7 @@ name = "sim-adaptive-explore"
 path = "src/bin/sim/adaptive_explore.rs"
 
 [dependencies]
+moonpool-assertions = { path = "../moonpool-assertions", version = "0.7.0" }
 libc = "0.2"
 
 [lints]

--- a/moonpool-explorer/src/context.rs
+++ b/moonpool-explorer/src/context.rs
@@ -34,14 +34,8 @@ thread_local! {
     /// Pointer to per-child coverage bitmap.
     pub(crate) static COVERAGE_BITMAP_PTR: Cell<*mut u8> = const { Cell::new(std::ptr::null_mut()) };
 
-    /// Pointer to shared assertion slot table (raw bytes, counter-based layout).
-    pub(crate) static ASSERTION_TABLE: Cell<*mut u8> = const { Cell::new(std::ptr::null_mut()) };
-
     /// Pointer to shared energy budget (null when adaptive forking is disabled).
     pub(crate) static ENERGY_BUDGET_PTR: Cell<*mut EnergyBudget> = const { Cell::new(std::ptr::null_mut()) };
-
-    /// Pointer to shared EachBucket memory (null when not initialized).
-    pub(crate) static EACH_BUCKET_PTR: Cell<*mut u8> = const { Cell::new(std::ptr::null_mut()) };
 
     /// Base pointer for per-process bitmap pool (null until first parallel split).
     pub(crate) static BITMAP_POOL: Cell<*mut u8> = const { Cell::new(std::ptr::null_mut()) };
@@ -135,14 +129,6 @@ pub fn explorer_is_active() -> bool {
 #[must_use]
 pub fn explorer_is_child() -> bool {
     with_ctx(|ctx| ctx.is_child)
-}
-
-/// Get the raw pointer to the assertion table shared memory.
-///
-/// Returns null if the table is not initialized.
-#[must_use]
-pub fn assertion_table_ptr() -> *mut u8 {
-    ASSERTION_TABLE.with(std::cell::Cell::get)
 }
 
 #[cfg(test)]

--- a/moonpool-explorer/src/energy.rs
+++ b/moonpool-explorer/src/energy.rs
@@ -11,8 +11,8 @@
 use std::io;
 use std::sync::atomic::{AtomicI64, Ordering};
 
-use crate::assertion_slots::MAX_ASSERTION_SLOTS;
 use crate::shared_mem;
+use moonpool_assertions::MAX_ASSERTION_SLOTS;
 
 /// 3-level energy budget in shared memory.
 ///

--- a/moonpool-explorer/src/lib.rs
+++ b/moonpool-explorer/src/lib.rs
@@ -558,10 +558,8 @@
 #![deny(missing_docs)]
 #![deny(clippy::unwrap_used)]
 
-pub mod assertion_slots;
 pub mod context;
 pub mod coverage;
-pub mod each_buckets;
 pub mod energy;
 pub mod replay;
 pub mod sancov;
@@ -570,14 +568,15 @@ pub mod shared_stats;
 pub mod simulations;
 pub mod split_loop;
 
-// Re-exports for the public API
-pub use assertion_slots::{
+// The assertion + each-bucket accounting now lives in the dependency-free,
+// wasm-able `moonpool-assertions` crate. Re-export its public surface so
+// `moonpool_explorer::assertion_bool` (and friends) keep resolving for callers.
+pub use context::{explorer_is_child, set_rng_hooks};
+pub use moonpool_assertions::{
     ASSERTION_TABLE_MEM_SIZE, AssertCmp, AssertKind, AssertionSlot, AssertionSlotSnapshot,
-    assertion_bool, assertion_numeric, assertion_read_all, assertion_sometimes_all, msg_hash,
-};
-pub use context::{assertion_table_ptr, explorer_is_child, set_rng_hooks};
-pub use each_buckets::{
-    EachBucket, assertion_sometimes_each, each_bucket_read_all, unpack_quality,
+    EACH_BUCKET_MEM_SIZE, EachBucket, MAX_ASSERTION_SLOTS, MAX_EACH_BUCKETS, assertion_bool,
+    assertion_numeric, assertion_read_all, assertion_sometimes_all, assertion_sometimes_each,
+    assertion_table_ptr, each_bucket_read_all, msg_hash, unpack_quality,
 };
 pub use replay::{ParseTimelineError, format_timeline, parse_timeline};
 pub use sancov::{sancov_edge_count, sancov_edges_covered, sancov_is_available};
@@ -585,9 +584,54 @@ pub use shared_stats::{ExplorationStats, bug_recipe, exploration_stats};
 pub use split_loop::{AdaptiveConfig, Parallelism, exit_child};
 
 use context::{
-    ASSERTION_TABLE, COVERAGE_BITMAP_PTR, EACH_BUCKET_PTR, ENERGY_BUDGET_PTR, EXPLORED_MAP_PTR,
-    SHARED_RECIPE, SHARED_STATS,
+    COVERAGE_BITMAP_PTR, ENERGY_BUDGET_PTR, EXPLORED_MAP_PTR, SHARED_RECIPE, SHARED_STATS,
 };
+
+/// Discovery hooks that wire `moonpool-assertions` accounting to this crate's
+/// coverage bitmap and fork dispatch. Installed by [`init_assertions`].
+///
+/// These reproduce exactly what the inline `assertion_split` / each-bucket code
+/// used to do: slot discoveries mark the bitmap, merge into the explored map, and
+/// dispatch a fork; each-bucket marks the bitmap on every call and dispatches a
+/// fork on discovery/improvement.
+fn install_discovery_hooks() {
+    fn on_slot_discovery(slot_idx: usize, hash: u32) {
+        let bm_ptr = COVERAGE_BITMAP_PTR.with(std::cell::Cell::get);
+        let vm_ptr = EXPLORED_MAP_PTR.with(std::cell::Cell::get);
+        if !bm_ptr.is_null() {
+            // Safety: bm_ptr is a COVERAGE_MAP_SIZE region set during init().
+            let bm = unsafe { coverage::CoverageBitmap::new(bm_ptr) };
+            bm.set_bit(hash as usize);
+            if !vm_ptr.is_null() {
+                // Safety: vm_ptr is a COVERAGE_MAP_SIZE region set during init().
+                let vm = unsafe { coverage::ExploredMap::new(vm_ptr) };
+                vm.merge_from(&bm);
+            }
+        }
+        if context::explorer_is_active() {
+            split_loop::dispatch_split("", slot_idx % MAX_ASSERTION_SLOTS);
+        }
+    }
+
+    fn on_bucket_mark(hash: u32) {
+        let bm_ptr = COVERAGE_BITMAP_PTR.with(std::cell::Cell::get);
+        if !bm_ptr.is_null() {
+            // Safety: bm_ptr is a COVERAGE_MAP_SIZE region set during init().
+            let bm = unsafe { coverage::CoverageBitmap::new(bm_ptr) };
+            bm.set_bit(hash as usize);
+        }
+    }
+
+    fn on_bucket_split(label: &str, slot_idx: usize) {
+        split_loop::dispatch_split(label, slot_idx);
+    }
+
+    moonpool_assertions::set_discovery_hooks(moonpool_assertions::DiscoveryHooks {
+        on_slot_discovery,
+        on_bucket_mark,
+        on_bucket_split,
+    });
+}
 
 /// Configuration for exploration.
 #[derive(Debug, Clone)]
@@ -618,16 +662,17 @@ pub struct ExplorationConfig {
 ///
 /// Returns an error if shared memory allocation fails.
 pub fn init_assertions() -> Result<(), std::io::Error> {
-    let current = ASSERTION_TABLE.with(std::cell::Cell::get);
-    if !current.is_null() {
+    if !assertion_table_ptr().is_null() {
         return Ok(()); // Already initialized
     }
 
-    let table_ptr = shared_mem::alloc_shared(assertion_slots::ASSERTION_TABLE_MEM_SIZE)?;
-    let each_bucket_ptr = shared_mem::alloc_shared(each_buckets::EACH_BUCKET_MEM_SIZE)?;
+    // Allocate the regions in MAP_SHARED so forked children share the counts,
+    // then hand them to moonpool-assertions and install the fork/coverage hooks.
+    let table_ptr = shared_mem::alloc_shared(ASSERTION_TABLE_MEM_SIZE)?;
+    let each_bucket_ptr = shared_mem::alloc_shared(EACH_BUCKET_MEM_SIZE)?;
 
-    ASSERTION_TABLE.with(|c| c.set(table_ptr));
-    EACH_BUCKET_PTR.with(|c| c.set(each_bucket_ptr));
+    moonpool_assertions::install_region(table_ptr, each_bucket_ptr);
+    install_discovery_hooks();
 
     Ok(())
 }
@@ -636,17 +681,17 @@ pub fn init_assertions() -> Result<(), std::io::Error> {
 ///
 /// Nulls the pointers after freeing. No-op if not initialized.
 pub fn cleanup_assertions() {
+    // Read the installed pointers, drop moonpool-assertions' view, then free the
+    // MAP_SHARED regions this crate allocated.
+    let table_ptr = assertion_table_ptr();
+    let each_bucket_ptr = moonpool_assertions::each_bucket_ptr();
+    moonpool_assertions::clear();
     unsafe {
-        let table_ptr = ASSERTION_TABLE.with(std::cell::Cell::get);
         if !table_ptr.is_null() {
-            shared_mem::free_shared(table_ptr, assertion_slots::ASSERTION_TABLE_MEM_SIZE);
-            ASSERTION_TABLE.with(|c| c.set(std::ptr::null_mut()));
+            shared_mem::free_shared(table_ptr, ASSERTION_TABLE_MEM_SIZE);
         }
-
-        let each_bucket_ptr = EACH_BUCKET_PTR.with(std::cell::Cell::get);
         if !each_bucket_ptr.is_null() {
-            shared_mem::free_shared(each_bucket_ptr, each_buckets::EACH_BUCKET_MEM_SIZE);
-            EACH_BUCKET_PTR.with(|c| c.set(std::ptr::null_mut()));
+            shared_mem::free_shared(each_bucket_ptr, EACH_BUCKET_MEM_SIZE);
         }
     }
 }
@@ -655,19 +700,7 @@ pub fn cleanup_assertions() {
 ///
 /// No-op if not initialized.
 pub fn reset_assertions() {
-    let table_ptr = ASSERTION_TABLE.with(std::cell::Cell::get);
-    if !table_ptr.is_null() {
-        unsafe {
-            std::ptr::write_bytes(table_ptr, 0, assertion_slots::ASSERTION_TABLE_MEM_SIZE);
-        }
-    }
-
-    let each_bucket_ptr = EACH_BUCKET_PTR.with(std::cell::Cell::get);
-    if !each_bucket_ptr.is_null() {
-        unsafe {
-            std::ptr::write_bytes(each_bucket_ptr, 0, each_buckets::EACH_BUCKET_MEM_SIZE);
-        }
-    }
+    moonpool_assertions::reset();
 }
 
 /// Prepare the exploration framework for the next seed in multi-seed exploration.
@@ -680,54 +713,10 @@ pub fn reset_assertions() {
 /// Call this between seeds instead of [`reset_assertions`] when you want
 /// coverage-preserving multi-seed exploration.
 pub fn prepare_next_seed(per_seed_energy: i64) {
-    // pass_count/fail_count accumulate across seeds — needed by
-    // validate_assertion_contracts() to avoid false "was never reached" when
-    // a seed doesn't reach a guarded assertion. Forking uses split_triggered,
-    // not counts. Same rationale for each-bucket pass_count.
-    let table_ptr = ASSERTION_TABLE.with(std::cell::Cell::get);
-    if !table_ptr.is_null() {
-        unsafe {
-            let count_ptr = table_ptr
-                .cast::<()>()
-                .cast::<std::sync::atomic::AtomicU32>();
-            // MAX_ASSERTION_SLOTS is a small const (128), so the cast is lossless.
-            let max_slots = u32::try_from(assertion_slots::MAX_ASSERTION_SLOTS).unwrap_or(u32::MAX);
-            let count = (*count_ptr)
-                .load(std::sync::atomic::Ordering::Relaxed)
-                .min(max_slots) as usize;
-            let base = table_ptr
-                .add(8)
-                .cast::<()>()
-                .cast::<assertion_slots::AssertionSlot>();
-            for i in 0..count {
-                let slot = &mut *base.add(i);
-                // Skip tombstones (msg_hash == 0) left by the duplicate-slot race fix.
-                if slot.msg_hash == 0 {
-                    continue;
-                }
-                slot.split_triggered = 0;
-            }
-        }
-    }
-
-    let each_ptr = EACH_BUCKET_PTR.with(std::cell::Cell::get);
-    if !each_ptr.is_null() {
-        unsafe {
-            let count_ptr = each_ptr.cast::<()>().cast::<std::sync::atomic::AtomicU32>();
-            // MAX_EACH_BUCKETS is a small const (256), so the cast is lossless.
-            let max_buckets = u32::try_from(each_buckets::MAX_EACH_BUCKETS).unwrap_or(u32::MAX);
-            let count = (*count_ptr)
-                .load(std::sync::atomic::Ordering::Relaxed)
-                .min(max_buckets) as usize;
-            let base = each_ptr
-                .add(8)
-                .cast::<()>()
-                .cast::<each_buckets::EachBucket>();
-            for i in 0..count {
-                (*base.add(i)).split_triggered = 0;
-            }
-        }
-    }
+    // Reset per-seed split triggers while preserving pass/fail counts and
+    // watermarks/frontiers (needed by validate_assertion_contracts to avoid a
+    // false "was never reached" when a seed doesn't reach a guarded assertion).
+    moonpool_assertions::prepare_next_seed_reset();
 
     // Per-timeline coverage bitmap (NOT the explored map, which is preserved).
     let bm_ptr = COVERAGE_BITMAP_PTR.with(std::cell::Cell::get);
@@ -941,7 +930,7 @@ mod tests {
         init_assertions().expect("init_assertions failed");
 
         // Table pointer should be set
-        let ptr = context::assertion_table_ptr();
+        let ptr = assertion_table_ptr();
         assert!(!ptr.is_null());
 
         // Idempotent — second call should be no-op
@@ -950,7 +939,7 @@ mod tests {
         cleanup_assertions();
 
         // Should be null after cleanup
-        let ptr = context::assertion_table_ptr();
+        let ptr = assertion_table_ptr();
         assert!(ptr.is_null());
     }
 

--- a/moonpool-sim/Cargo.toml
+++ b/moonpool-sim/Cargo.toml
@@ -13,26 +13,50 @@ readme = "README.md"
 rustdoc-args = ["--cfg", "tokio_unstable"]
 rustc-args = ["--cfg", "tokio_unstable"]
 
+[features]
+# tokio-providers re-exports core's production provider bundle (TokioProviders,
+# TokioNetworkProvider, TokioTimeProvider) for examples/tests that drive the same
+# code under prod + sim. Default-on; disable for a wasm-able sim
+# (`--no-default-features`), which still keeps TokioTaskProvider via core/tokio-task.
+default = ["tokio-providers", "exploration"]
+tokio-providers = ["moonpool-core/tokio-providers"]
+# Fork-based multiverse exploration (libc/mmap — never wasm). When off, assertion
+# accounting still works via the in-process heap table from moonpool-assertions, so
+# UntilAllSometimesReached / CoveragePlateau / contract validation are unaffected.
+exploration = ["dep:moonpool-explorer"]
+
 [dependencies]
-moonpool-core = { path = "../moonpool-core", version = "0.7.0" }
-moonpool-explorer = { path = "../moonpool-explorer", version = "0.7.0" }
+# SimProviders always bundles the real TokioTaskProvider (single-thread executor),
+# so tokio-task is mandatory; net/fs/time come in only via the tokio-providers feature.
+moonpool-core = { path = "../moonpool-core", version = "0.7.0", default-features = false, features = ["tokio-task"] }
+# Assertion accounting (pure std, wasm-able) — always present. The fork-based
+# exploration backend below is optional and layers on top of it.
+moonpool-assertions = { path = "../moonpool-assertions", version = "0.7.0" }
+moonpool-explorer = { path = "../moonpool-explorer", version = "0.7.0", optional = true }
 
 async-trait = "0.1"
 crc32c = "0.6"
 futures = "0.3"
-rand = "0.10"
-rand_chacha = "0.10"
+# Seeded ChaCha8 only — no OS entropy, so no getrandom (keeps the sim wasm-clean).
+rand = { version = "0.10", default-features = false }
+rand_chacha = { version = "0.10", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2.0"
 parking_lot = "0.12"
-tokio = { version = "1", features = ["full", "tracing"] }
+# Library code uses tokio::spawn / task::JoinHandle / yield_now (rt),
+# Notify / mpsc (sync), select! (macros), and the named-task instrumentation
+# that TokioTaskProvider relies on (tracing + tokio_unstable). The per-seed
+# runtime uses runtime::Builder + RngSeed (rt). No net/fs/time in lib code.
+# Tests pull "full" via dev-dependencies.
+tokio = { version = "1", features = ["rt", "sync", "macros", "tracing"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 tracing = "0.1"
 
 tracing-subscriber = { version = "0.3", features = ["registry"] }
 
 [dev-dependencies]
+tokio = { version = "1", features = ["full", "tracing"] }
 bytes = "1"
 http-body-util = "0.1"
 hyper = { version = "1", features = ["http1", "server", "client"] }

--- a/moonpool-sim/src/chaos/assertions.rs
+++ b/moonpool-sim/src/chaos/assertions.rs
@@ -1,8 +1,10 @@
 //! Antithesis-style assertion macros and result tracking for simulation testing.
 //!
 //! This module provides 15 assertion macros for testing distributed system
-//! properties. Assertions are tracked in shared memory via moonpool-explorer,
-//! enabling cross-process tracking across forked exploration timelines.
+//! properties. Assertions are tracked by `moonpool-assertions` (a dependency-free
+//! accounting layer). When the `exploration` feature is on, that table lives in
+//! `MAP_SHARED` memory so counts are visible across forked exploration timelines;
+//! otherwise it is a plain heap table — the macros behave identically either way.
 //!
 //! Following the Antithesis principle: **assertions never crash your program**.
 //! Always-type assertions log violations at ERROR level and record them via a
@@ -40,9 +42,9 @@ use std::collections::HashMap;
 thread_local! {
     static ALWAYS_VIOLATION_COUNT: Cell<u64> = const { Cell::new(0) };
     /// When set, the next call to [`reset_assertion_results`] is skipped.
-    /// Used by multi-seed exploration to prevent `SimWorld::create` from
-    /// zeroing assertion state that [`moonpool_explorer::prepare_next_seed`]
-    /// already selectively reset.
+    /// Used by multi-seed runs to prevent `SimWorld::create` from zeroing
+    /// assertion state that the between-seed reset already handled (a selective
+    /// reset under exploration, or accumulation without it).
     static SKIP_NEXT_ASSERTION_RESET: Cell<bool> = const { Cell::new(false) };
 }
 
@@ -155,37 +157,37 @@ pub fn format_details(pairs: &[(&str, &dyn std::fmt::Display)]) -> String {
 
 /// Boolean assertion backing wrapper.
 ///
-/// Delegates to `moonpool_explorer::assertion_bool`.
+/// Delegates to `moonpool_assertions::assertion_bool`.
 /// Accepts both `&str` and `String` message arguments.
 pub fn on_assertion_bool(
     msg: impl AsRef<str>,
     condition: bool,
-    kind: moonpool_explorer::AssertKind,
+    kind: moonpool_assertions::AssertKind,
     must_hit: bool,
 ) {
-    moonpool_explorer::assertion_bool(kind, must_hit, condition, msg.as_ref());
+    moonpool_assertions::assertion_bool(kind, must_hit, condition, msg.as_ref());
 }
 
 /// Numeric assertion backing wrapper.
 ///
-/// Delegates to `moonpool_explorer::assertion_numeric`.
+/// Delegates to `moonpool_assertions::assertion_numeric`.
 /// Accepts both `&str` and `String` message arguments.
 pub fn on_assertion_numeric(
     msg: impl AsRef<str>,
     value: i64,
-    cmp: moonpool_explorer::AssertCmp,
+    cmp: moonpool_assertions::AssertCmp,
     threshold: i64,
-    kind: moonpool_explorer::AssertKind,
+    kind: moonpool_assertions::AssertKind,
     maximize: bool,
 ) {
-    moonpool_explorer::assertion_numeric(kind, cmp, maximize, value, threshold, msg.as_ref());
+    moonpool_assertions::assertion_numeric(kind, cmp, maximize, value, threshold, msg.as_ref());
 }
 
 /// Compound boolean assertion backing wrapper.
 ///
-/// Delegates to `moonpool_explorer::assertion_sometimes_all`.
+/// Delegates to `moonpool_assertions::assertion_sometimes_all`.
 pub fn on_assertion_sometimes_all(msg: impl AsRef<str>, named_bools: &[(&str, bool)]) {
-    moonpool_explorer::assertion_sometimes_all(msg.as_ref(), named_bools);
+    moonpool_assertions::assertion_sometimes_all(msg.as_ref(), named_bools);
 }
 
 /// Notify the exploration framework of a per-value bucketed assertion.
@@ -193,7 +195,7 @@ pub fn on_assertion_sometimes_all(msg: impl AsRef<str>, named_bools: &[(&str, bo
 /// This delegates to moonpool-explorer's `EachBucket` infrastructure for
 /// fork-based exploration with identity keys and quality watermarks.
 pub fn on_sometimes_each(msg: &str, keys: &[(&str, i64)], quality: &[(&str, i64)]) {
-    moonpool_explorer::assertion_sometimes_each(msg, keys, quality);
+    moonpool_assertions::assertion_sometimes_each(msg, keys, quality);
 }
 
 // =============================================================================
@@ -206,7 +208,7 @@ pub fn on_sometimes_each(msg: &str, keys: &[(&str, i64)], quality: &[(&str, i64)
 /// results for reporting and validation.
 #[must_use]
 pub fn assertion_results() -> HashMap<String, AssertionStats> {
-    let slots = moonpool_explorer::assertion_read_all();
+    let slots = moonpool_assertions::assertion_read_all();
     let mut results = HashMap::new();
 
     for slot in &slots {
@@ -229,9 +231,10 @@ pub fn assertion_results() -> HashMap<String, AssertionStats> {
 
 /// Request that the next call to [`reset_assertion_results`] be skipped.
 ///
-/// Used by multi-seed exploration: [`moonpool_explorer::prepare_next_seed`]
-/// does a selective reset (preserving explored map and watermarks), so the
-/// full zero in `SimWorld::create` must be suppressed.
+/// Used by multi-seed runs: the between-seed reset preserves pass/fail counts
+/// (selectively, under exploration, via the explorer's `prepare_next_seed`; or
+/// by accumulation without it), so the full zero in `SimWorld::create` must be
+/// suppressed.
 pub fn skip_next_assertion_reset() {
     SKIP_NEXT_ASSERTION_RESET.with(|c| c.set(true));
 }
@@ -248,7 +251,7 @@ pub fn reset_assertion_results() {
         v
     });
     if !skip {
-        moonpool_explorer::reset_assertions();
+        moonpool_assertions::reset();
     }
 }
 
@@ -264,14 +267,14 @@ pub fn reset_assertion_results() {
 pub fn validate_assertion_contracts() -> (Vec<String>, Vec<String>) {
     let mut always_violations = Vec::new();
     let mut coverage_violations = Vec::new();
-    let slots = moonpool_explorer::assertion_read_all();
+    let slots = moonpool_assertions::assertion_read_all();
 
     for slot in &slots {
         let total = slot.pass_count.saturating_add(slot.fail_count);
-        let kind = moonpool_explorer::AssertKind::from_u8(slot.kind);
+        let kind = moonpool_assertions::AssertKind::from_u8(slot.kind);
 
         match kind {
-            Some(moonpool_explorer::AssertKind::Always) => {
+            Some(moonpool_assertions::AssertKind::Always) => {
                 if slot.fail_count > 0 {
                     always_violations.push(format!(
                         "assert_always!('{}') failed {} times out of {}",
@@ -283,7 +286,7 @@ pub fn validate_assertion_contracts() -> (Vec<String>, Vec<String>) {
                         .push(format!("assert_always!('{}') was never reached", slot.msg));
                 }
             }
-            Some(moonpool_explorer::AssertKind::AlwaysOrUnreachable) => {
+            Some(moonpool_assertions::AssertKind::AlwaysOrUnreachable) => {
                 if slot.fail_count > 0 {
                     always_violations.push(format!(
                         "assert_always_or_unreachable!('{}') failed {} times out of {}",
@@ -291,7 +294,7 @@ pub fn validate_assertion_contracts() -> (Vec<String>, Vec<String>) {
                     ));
                 }
             }
-            Some(moonpool_explorer::AssertKind::Sometimes) => {
+            Some(moonpool_assertions::AssertKind::Sometimes) => {
                 if total > 0 && slot.pass_count == 0 {
                     coverage_violations.push(format!(
                         "assert_sometimes!('{}') has 0% success rate ({} checks)",
@@ -299,7 +302,7 @@ pub fn validate_assertion_contracts() -> (Vec<String>, Vec<String>) {
                     ));
                 }
             }
-            Some(moonpool_explorer::AssertKind::Reachable) => {
+            Some(moonpool_assertions::AssertKind::Reachable) => {
                 if slot.pass_count == 0 {
                     coverage_violations.push(format!(
                         "assert_reachable!('{}') was never reached",
@@ -307,7 +310,7 @@ pub fn validate_assertion_contracts() -> (Vec<String>, Vec<String>) {
                     ));
                 }
             }
-            Some(moonpool_explorer::AssertKind::Unreachable) => {
+            Some(moonpool_assertions::AssertKind::Unreachable) => {
                 if slot.pass_count > 0 {
                     always_violations.push(format!(
                         "assert_unreachable!('{}') was reached {} times",
@@ -315,7 +318,7 @@ pub fn validate_assertion_contracts() -> (Vec<String>, Vec<String>) {
                     ));
                 }
             }
-            Some(moonpool_explorer::AssertKind::NumericAlways) => {
+            Some(moonpool_assertions::AssertKind::NumericAlways) => {
                 if slot.fail_count > 0 {
                     always_violations.push(format!(
                         "numeric assert_always ('{}') failed {} times out of {}",
@@ -323,7 +326,7 @@ pub fn validate_assertion_contracts() -> (Vec<String>, Vec<String>) {
                     ));
                 }
             }
-            Some(moonpool_explorer::AssertKind::NumericSometimes) => {
+            Some(moonpool_assertions::AssertKind::NumericSometimes) => {
                 if total > 0 && slot.pass_count == 0 {
                     coverage_violations.push(format!(
                         "numeric assert_sometimes ('{}') has 0% success rate ({} checks)",
@@ -331,7 +334,7 @@ pub fn validate_assertion_contracts() -> (Vec<String>, Vec<String>) {
                     ));
                 }
             }
-            Some(moonpool_explorer::AssertKind::BooleanSometimesAll) | None => {
+            Some(moonpool_assertions::AssertKind::BooleanSometimesAll) | None => {
                 // BooleanSometimesAll: no simple pass/fail violation contract
                 // (the frontier tracking is the guidance mechanism)
             }
@@ -800,7 +803,7 @@ macro_rules! assert_sometimes_each {
 
 /// Re-exports for macro hygiene (`$crate::chaos::assertions::_re_export::*`).
 pub mod _re_export {
-    pub use moonpool_explorer::{AssertCmp, AssertKind};
+    pub use moonpool_assertions::{AssertCmp, AssertKind};
 }
 
 #[cfg(test)]

--- a/moonpool-sim/src/chaos/exploration_glue.rs
+++ b/moonpool-sim/src/chaos/exploration_glue.rs
@@ -1,0 +1,78 @@
+//! Thin shim over the optional `moonpool-explorer` backend (feature `exploration`).
+//!
+//! Keeps the rest of the runner free of `#[cfg]` for the common lifecycle calls:
+//! assertion-region init/cleanup, the forked-child checks, and the explored
+//! coverage count. The exploration-only entry points (full `init`, RNG hooks,
+//! per-seed energy reset, stats, recipes) stay behind `#[cfg(feature =
+//! "exploration")]` at their call sites since they have no meaning without the
+//! backend.
+
+/// Configuration for exploration. Re-exported from the backend when present; an
+/// uninhabited stand-in otherwise so `SimulationBuilder`'s
+/// `Option<ExplorationConfig>` field (always `None`) still type-checks.
+#[cfg(feature = "exploration")]
+pub use moonpool_explorer::ExplorationConfig;
+
+/// Uninhabited stand-in (see [`ExplorationConfig`] above).
+#[cfg(not(feature = "exploration"))]
+#[derive(Debug, Clone)]
+pub enum ExplorationConfig {}
+
+/// Initialise the assertion region: `MAP_SHARED` + discovery hooks under the
+/// explorer, or a plain heap table without it.
+pub fn init_assertion_region() {
+    #[cfg(feature = "exploration")]
+    if let Err(e) = moonpool_explorer::init_assertions() {
+        tracing::error!("Failed to initialize assertion table: {e}");
+    }
+    #[cfg(not(feature = "exploration"))]
+    moonpool_assertions::init();
+}
+
+/// Tear down the assertion region.
+pub fn cleanup_assertion_region() {
+    #[cfg(feature = "exploration")]
+    moonpool_explorer::cleanup_assertions();
+    #[cfg(not(feature = "exploration"))]
+    moonpool_assertions::clear();
+}
+
+/// Number of bits set in the explored coverage map (0 without exploration).
+#[must_use]
+pub fn explored_coverage_bits() -> u32 {
+    #[cfg(feature = "exploration")]
+    {
+        moonpool_explorer::explored_map_bits_set().unwrap_or(0)
+    }
+    #[cfg(not(feature = "exploration"))]
+    {
+        0
+    }
+}
+
+/// Whether this process is a forked exploration child (always false without it).
+#[must_use]
+pub fn explorer_is_child() -> bool {
+    #[cfg(feature = "exploration")]
+    {
+        moonpool_explorer::explorer_is_child()
+    }
+    #[cfg(not(feature = "exploration"))]
+    {
+        false
+    }
+}
+
+/// Exit a forked exploration child. Only reachable when [`explorer_is_child`]
+/// returned true, which never happens without the backend.
+pub fn exit_child(code: i32) -> ! {
+    #[cfg(feature = "exploration")]
+    {
+        moonpool_explorer::exit_child(code)
+    }
+    #[cfg(not(feature = "exploration"))]
+    {
+        let _ = code;
+        unreachable!("exit_child called without the `exploration` feature")
+    }
+}

--- a/moonpool-sim/src/chaos/mod.rs
+++ b/moonpool-sim/src/chaos/mod.rs
@@ -129,6 +129,7 @@
 
 pub mod assertions;
 pub mod buggify;
+pub mod exploration_glue;
 pub mod fault_events;
 pub mod state_handle;
 

--- a/moonpool-sim/src/lib.rs
+++ b/moonpool-sim/src/lib.rs
@@ -107,9 +107,13 @@
 pub use moonpool_core::{
     CodecError, Endpoint, JsonCodec, MessageCodec, NetworkAddress, NetworkAddressParseError,
     NetworkProvider, Providers, RandomProvider, SimulationError, SimulationResult, TaskProvider,
-    TcpListenerTrait, TimeError, TimeProvider, TokioNetworkProvider, TokioProviders,
-    TokioTaskProvider, TokioTimeProvider, UID, WELL_KNOWN_RESERVED_COUNT, WellKnownToken,
+    TcpListenerTrait, TimeError, TimeProvider, TokioTaskProvider, UID, WELL_KNOWN_RESERVED_COUNT,
+    WellKnownToken,
 };
+// Production provider bundle — only when the tokio-providers feature pulls core's
+// net/fs/time. A wasm-able sim (`--no-default-features`) omits these.
+#[cfg(feature = "tokio-providers")]
+pub use moonpool_core::{TokioNetworkProvider, TokioProviders, TokioTimeProvider};
 
 // =============================================================================
 // Core Modules
@@ -186,10 +190,12 @@ pub use storage::{
 // Provider exports
 pub use providers::{SimProviders, SimRandomProvider, SimTimeProvider};
 
-// Explorer re-exports
+// Assertion vocabulary — always available (dependency-free accounting layer).
+pub use moonpool_assertions::{AssertCmp, AssertKind};
+// Exploration-only re-exports (fork-based multiverse engine).
+#[cfg(feature = "exploration")]
 pub use moonpool_explorer::{
-    AdaptiveConfig, AssertCmp, AssertKind, ExplorationConfig, Parallelism, format_timeline,
-    parse_timeline,
+    AdaptiveConfig, ExplorationConfig, Parallelism, format_timeline, parse_timeline,
 };
 pub use runner::report::{BugRecipe, ExplorationReport};
 

--- a/moonpool-sim/src/runner/builder.rs
+++ b/moonpool-sim/src/runner/builder.rs
@@ -5,7 +5,9 @@
 
 use std::collections::HashMap;
 use std::ops::{Range, RangeInclusive};
-use std::time::{Duration, Instant};
+use std::time::Duration;
+
+use super::wall_clock::Instant;
 use tracing::instrument;
 
 use crate::SimulationError;
@@ -49,11 +51,16 @@ type OrchestrationOutcome = Result<OrchestrateOutput, (Vec<u64>, usize)>;
 
 /// Per-run accumulators passed into the final-report builder.
 struct FinalReportInputs {
-    total_exploration_timelines: u64,
-    total_exploration_fork_points: u64,
-    total_exploration_bugs: u64,
-    bug_recipes: Vec<super::report::BugRecipe>,
     converged: bool,
+    #[cfg(feature = "exploration")]
+    total_exploration_timelines: u64,
+    #[cfg(feature = "exploration")]
+    total_exploration_fork_points: u64,
+    #[cfg(feature = "exploration")]
+    total_exploration_bugs: u64,
+    #[cfg(feature = "exploration")]
+    bug_recipes: Vec<super::report::BugRecipe>,
+    #[cfg(feature = "exploration")]
     per_seed_timelines: Vec<u64>,
 }
 
@@ -82,10 +89,15 @@ impl RunState {
             metrics_collector: MetricsCollector::new(),
             progress_milestone,
             pending_return_map: Vec::new(),
+            #[cfg(feature = "exploration")]
             total_exploration_timelines: 0,
+            #[cfg(feature = "exploration")]
             total_exploration_fork_points: 0,
+            #[cfg(feature = "exploration")]
             total_exploration_bugs: 0,
+            #[cfg(feature = "exploration")]
             bug_recipes: Vec::new(),
+            #[cfg(feature = "exploration")]
             per_seed_timelines: Vec::new(),
             reached_sometimes: std::collections::HashSet::new(),
             prev_coverage_bits: 0,
@@ -106,11 +118,16 @@ struct RunState {
     /// stashed between [`SimulationBuilder::run_orchestrator_for_iteration`]
     /// and [`SimulationBuilder::handle_orchestration_result`].
     pending_return_map: Vec<Option<usize>>,
-    // Exploration accumulators.
+    // Exploration accumulators (only populated/read with the `exploration` feature).
+    #[cfg(feature = "exploration")]
     total_exploration_timelines: u64,
+    #[cfg(feature = "exploration")]
     total_exploration_fork_points: u64,
+    #[cfg(feature = "exploration")]
     total_exploration_bugs: u64,
+    #[cfg(feature = "exploration")]
     bug_recipes: Vec<super::report::BugRecipe>,
+    #[cfg(feature = "exploration")]
     per_seed_timelines: Vec<u64>,
     // Convergence + plateau tracking.
     reached_sometimes: std::collections::HashSet<String>,
@@ -324,7 +341,7 @@ pub struct SimulationBuilder {
     invariants: Vec<Box<dyn Invariant + Send>>,
     fault_injectors: Vec<Box<dyn FaultInjector>>,
     chaos_duration: Option<Duration>,
-    exploration_config: Option<moonpool_explorer::ExplorationConfig>,
+    exploration_config: Option<crate::chaos::exploration_glue::ExplorationConfig>,
     before_iteration_hooks: Vec<Box<dyn FnMut()>>,
     seed_warning_timeout: Option<Duration>,
     run_time_budget: Duration,
@@ -569,8 +586,9 @@ impl SimulationBuilder {
     /// Run until exploration has converged: all `assert_sometimes!` assertions
     /// have been reached and no new coverage was found on the last seed.
     ///
-    /// Requires `.enable_exploration()` to be configured.
-    /// `max_iterations` is a safety cap to prevent infinite loops.
+    /// Requires `.enable_exploration()` to be configured (and the `exploration`
+    /// feature). `max_iterations` is a safety cap to prevent infinite loops.
+    #[cfg(feature = "exploration")]
     #[must_use]
     pub fn until_converged(mut self, max_iterations: usize) -> Self {
         self.iteration_control = IterationControl::UntilConverged { max_iterations };
@@ -639,8 +657,13 @@ impl SimulationBuilder {
     ///
     /// When enabled, the simulation will fork child processes at assertion
     /// discovery points to explore alternate timelines with different seeds.
+    /// Requires the `exploration` feature.
+    #[cfg(feature = "exploration")]
     #[must_use]
-    pub fn enable_exploration(mut self, config: moonpool_explorer::ExplorationConfig) -> Self {
+    pub fn enable_exploration(
+        mut self,
+        config: crate::chaos::exploration_glue::ExplorationConfig,
+    ) -> Self {
         self.exploration_config = Some(config);
         self
     }
@@ -812,7 +835,7 @@ impl SimulationBuilder {
                 }
                 let all_reached =
                     all_sometimes_count > 0 && reached_sometimes.len() >= all_sometimes_count;
-                let current_bits = moonpool_explorer::explored_map_bits_set().unwrap_or(0);
+                let current_bits = crate::chaos::exploration_glue::explored_coverage_bits();
                 let no_new_coverage = current_bits == *prev_coverage_bits;
                 tracing::warn!(
                     "convergence: seed={} reached={}/{} coverage={}->{} delta={}",
@@ -918,8 +941,10 @@ impl SimulationBuilder {
         let mut seed_bytes = [0u8; 32];
         seed_bytes[..8].copy_from_slice(&seed.to_le_bytes());
         let rng_seed = tokio::runtime::RngSeed::from_bytes(&seed_bytes);
+        // No .enable_time(): the sim drives logical time via the event queue, not
+        // tokio's timer wheel. enable_time() also constructs a std::time::Instant
+        // at startup, which panics on wasm32-unknown-unknown.
         tokio::runtime::Builder::new_current_thread()
-            .enable_time()
             .rng_seed(rng_seed)
             .build()
             .expect("per-iteration runtime")
@@ -964,13 +989,14 @@ impl SimulationBuilder {
         }
     }
 
-    /// Initialise shared-memory state (assertion table, optionally explorer).
+    /// Initialise the assertion region (heap, or `MAP_SHARED` + explorer), and
+    /// activate exploration when a config is present.
     fn init_assertions_and_exploration(
-        exploration_config: Option<&moonpool_explorer::ExplorationConfig>,
+        exploration_config: Option<&crate::chaos::exploration_glue::ExplorationConfig>,
     ) {
-        if let Err(e) = moonpool_explorer::init_assertions() {
-            tracing::error!("Failed to initialize assertion table: {}", e);
-        }
+        crate::chaos::exploration_glue::init_assertion_region();
+        let _ = exploration_config;
+        #[cfg(feature = "exploration")]
         if let Some(config) = exploration_config {
             moonpool_explorer::set_rng_hooks(crate::sim::rng_call_count, |seed| {
                 crate::sim::set_sim_seed(seed);
@@ -984,6 +1010,7 @@ impl SimulationBuilder {
 
     /// Build the final `ExplorationReport` from the running totals collected
     /// across iterations.
+    #[cfg(feature = "exploration")]
     fn build_exploration_report(
         total_timelines: u64,
         total_fork_points: u64,
@@ -1014,6 +1041,7 @@ impl SimulationBuilder {
     /// Read the explorer's per-seed exploration stats and accumulate into
     /// the totals + per-seed timelines arrays. Captures any new bug recipe
     /// produced this seed.
+    #[cfg(feature = "exploration")]
     fn accumulate_exploration_stats(
         seed: u64,
         per_seed_timelines: &mut Vec<u64>,
@@ -1040,13 +1068,13 @@ impl SimulationBuilder {
     /// warning for every still-unreached slot, and return the count of
     /// unique Sometimes/Reachable message strings observed.
     fn scan_assertion_slots(reached: &mut std::collections::HashSet<String>) -> usize {
-        let slots = moonpool_explorer::assertion_read_all();
+        let slots = moonpool_assertions::assertion_read_all();
         for slot in &slots {
-            if let Some(kind) = moonpool_explorer::AssertKind::from_u8(slot.kind)
+            if let Some(kind) = moonpool_assertions::AssertKind::from_u8(slot.kind)
                 && matches!(
                     kind,
-                    moonpool_explorer::AssertKind::Sometimes
-                        | moonpool_explorer::AssertKind::Reachable
+                    moonpool_assertions::AssertKind::Sometimes
+                        | moonpool_assertions::AssertKind::Reachable
                 )
             {
                 if slot.pass_count > 0 {
@@ -1065,11 +1093,11 @@ impl SimulationBuilder {
         slots
             .iter()
             .filter(|s| {
-                moonpool_explorer::AssertKind::from_u8(s.kind).is_some_and(|k| {
+                moonpool_assertions::AssertKind::from_u8(s.kind).is_some_and(|k| {
                     matches!(
                         k,
-                        moonpool_explorer::AssertKind::Sometimes
-                            | moonpool_explorer::AssertKind::Reachable
+                        moonpool_assertions::AssertKind::Sometimes
+                            | moonpool_assertions::AssertKind::Reachable
                     )
                 })
             })
@@ -1147,12 +1175,17 @@ impl SimulationBuilder {
             &state.iteration_manager,
             self.exploration_config.as_ref(),
             &self.iteration_control,
-            FinalReportInputs {
-                total_exploration_timelines: state.total_exploration_timelines,
-                total_exploration_fork_points: state.total_exploration_fork_points,
-                total_exploration_bugs: state.total_exploration_bugs,
-                bug_recipes: state.bug_recipes,
+            &FinalReportInputs {
                 converged: state.converged,
+                #[cfg(feature = "exploration")]
+                total_exploration_timelines: state.total_exploration_timelines,
+                #[cfg(feature = "exploration")]
+                total_exploration_fork_points: state.total_exploration_fork_points,
+                #[cfg(feature = "exploration")]
+                total_exploration_bugs: state.total_exploration_bugs,
+                #[cfg(feature = "exploration")]
+                bug_recipes: state.bug_recipes,
+                #[cfg(feature = "exploration")]
                 per_seed_timelines: state.per_seed_timelines,
             },
         )
@@ -1200,6 +1233,7 @@ impl SimulationBuilder {
         // reflects all seeds, not just the last one. For exploration runs,
         // prepare_next_seed() also does a selective reset of coverage state.
         if iteration_count > 1 {
+            #[cfg(feature = "exploration")]
             if let Some(ref config) = self.exploration_config {
                 moonpool_explorer::prepare_next_seed(config.global_energy);
             }
@@ -1216,7 +1250,7 @@ impl SimulationBuilder {
             self.iteration_control,
             IterationControl::UntilConverged { .. }
         ) {
-            state.prev_coverage_bits = moonpool_explorer::explored_map_bits_set().unwrap_or(0);
+            state.prev_coverage_bits = crate::chaos::exploration_glue::explored_coverage_bits();
         }
     }
 
@@ -1330,6 +1364,10 @@ impl SimulationBuilder {
     /// Run all per-iteration cleanup steps after the orchestrator finished:
     /// accumulate exploration stats, run the convergence scan, reset buggify.
     fn finish_iteration(&self, state: &mut RunState, seed: u64, iteration_count: usize) {
+        // `seed` is only consumed by the exploration stats accumulation below.
+        #[cfg(not(feature = "exploration"))]
+        let _ = seed;
+        #[cfg(feature = "exploration")]
         if self.exploration_config.is_some() {
             Self::accumulate_exploration_stats(
                 seed,
@@ -1366,45 +1404,60 @@ impl SimulationBuilder {
     fn build_final_report(
         metrics_collector: MetricsCollector,
         iteration_manager: &IterationManager,
-        exploration_config: Option<&moonpool_explorer::ExplorationConfig>,
+        exploration_config: Option<&crate::chaos::exploration_glue::ExplorationConfig>,
         iteration_control: &IterationControl,
-        inputs: FinalReportInputs,
+        inputs: &FinalReportInputs,
     ) -> SimulationReport {
-        let FinalReportInputs {
-            total_exploration_timelines,
-            total_exploration_fork_points,
-            total_exploration_bugs,
-            bug_recipes,
-            converged,
-            per_seed_timelines,
-        } = inputs;
+        let converged = inputs.converged;
 
-        // 1. Read exploration-specific data (freed by cleanup).
+        // 1. Read exploration-specific data (freed by cleanup). Without the
+        // `exploration` feature there is none — the report's `exploration` field
+        // is simply `None`, keeping the public report shape identical. The two
+        // accumulator Vecs are cloned once here (report time only).
+        #[cfg(feature = "exploration")]
         let exploration_report = if exploration_config.is_some() {
             Some(Self::build_exploration_report(
-                total_exploration_timelines,
-                total_exploration_fork_points,
-                total_exploration_bugs,
-                bug_recipes,
+                inputs.total_exploration_timelines,
+                inputs.total_exploration_fork_points,
+                inputs.total_exploration_bugs,
+                inputs.bug_recipes.clone(),
                 converged,
-                per_seed_timelines,
+                inputs.per_seed_timelines.clone(),
             ))
         } else {
             None
         };
+        #[cfg(not(feature = "exploration"))]
+        let exploration_report: Option<super::report::ExplorationReport> = None;
 
         // 2. Read assertion + bucket data (freed by cleanup/cleanup_assertions).
         let assertion_results = crate::chaos::assertion_results();
         let (assertion_violations, coverage_violations) =
             crate::chaos::validate_assertion_contracts();
-        let raw_assertion_slots = moonpool_explorer::assertion_read_all();
-        let raw_each_buckets = moonpool_explorer::each_bucket_read_all();
+        let raw_assertion_slots = moonpool_assertions::assertion_read_all();
+        let raw_each_buckets = moonpool_assertions::each_bucket_read_all();
 
-        // 3. Now safe to free all shared memory.
-        if exploration_config.is_some() {
-            moonpool_explorer::cleanup();
-        } else {
-            moonpool_explorer::cleanup_assertions();
+        // 3. Now safe to free all shared memory. Under exploration `cleanup()`
+        // frees the exploration regions (the assertion table persists, as before);
+        // otherwise free the assertion region directly.
+        let did_exploration_cleanup = {
+            #[cfg(feature = "exploration")]
+            {
+                if exploration_config.is_some() {
+                    moonpool_explorer::cleanup();
+                    true
+                } else {
+                    false
+                }
+            }
+            #[cfg(not(feature = "exploration"))]
+            {
+                let _ = exploration_config;
+                false
+            }
+        };
+        if !did_exploration_cleanup {
+            crate::chaos::exploration_glue::cleanup_assertion_region();
         }
 
         let assertion_details = build_assertion_details(&raw_assertion_slots);
@@ -1435,10 +1488,10 @@ impl SimulationBuilder {
 
 /// Build [`AssertionDetail`] vec from raw assertion slot snapshots.
 fn build_assertion_details(
-    slots: &[moonpool_explorer::AssertionSlotSnapshot],
+    slots: &[moonpool_assertions::AssertionSlotSnapshot],
 ) -> Vec<super::report::AssertionDetail> {
     use super::report::{AssertionDetail, AssertionStatus};
-    use moonpool_explorer::AssertKind;
+    use moonpool_assertions::AssertKind;
 
     slots
         .iter()
@@ -1499,7 +1552,7 @@ fn build_assertion_details(
 
 /// Build [`BucketSiteSummary`] vec by grouping [`EachBucket`]s by site message.
 fn build_bucket_summaries(
-    buckets: &[moonpool_explorer::EachBucket],
+    buckets: &[moonpool_assertions::EachBucket],
 ) -> Vec<super::report::BucketSiteSummary> {
     use super::report::BucketSiteSummary;
     use std::collections::HashMap;

--- a/moonpool-sim/src/runner/display.rs
+++ b/moonpool-sim/src/runner/display.rs
@@ -5,10 +5,11 @@
 
 use std::io::{IsTerminal, Write};
 
-use moonpool_explorer::AssertKind;
+use moonpool_assertions::AssertKind;
 
 use super::report::{
     AssertionDetail, AssertionStatus, BucketSiteSummary, ExplorationReport, SimulationReport,
+    format_recipe,
 };
 
 // ---------------------------------------------------------------------------
@@ -420,12 +421,7 @@ fn write_exploration(w: &mut impl Write, exp: &ExplorationReport, color: bool) {
             let _ = writeln!(w, "  Bug Recipes");
         }
         for br in &exp.bug_recipes {
-            let _ = writeln!(
-                w,
-                "    seed={}: {}",
-                br.seed,
-                moonpool_explorer::format_timeline(&br.recipe),
-            );
+            let _ = writeln!(w, "    seed={}: {}", br.seed, format_recipe(&br.recipe));
         }
     }
 }

--- a/moonpool-sim/src/runner/mod.rs
+++ b/moonpool-sim/src/runner/mod.rs
@@ -19,6 +19,7 @@ pub mod process;
 pub mod report;
 pub mod tags;
 pub mod topology;
+pub(crate) mod wall_clock;
 pub mod workload;
 
 // Re-export main types at module level

--- a/moonpool-sim/src/runner/orchestrator.rs
+++ b/moonpool-sim/src/runner/orchestrator.rs
@@ -6,7 +6,9 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::time::{Duration, Instant};
+use std::time::Duration;
+
+use super::wall_clock::Instant;
 
 use tracing::Instrument as _;
 
@@ -911,13 +913,13 @@ impl WorkloadOrchestrator {
     /// (all `Ok` results + no `assert_always!` violations) and 42 otherwise.
     /// Returns to the caller when not a forked child.
     fn maybe_exit_child(results: &[SimulationResult<()>]) {
-        if !moonpool_explorer::explorer_is_child() {
+        if !crate::chaos::exploration_glue::explorer_is_child() {
             return;
         }
         let success = results.iter().all(std::result::Result::is_ok)
             && !crate::chaos::has_always_violations();
         let code = if success { 0 } else { 42 };
-        moonpool_explorer::exit_child(code);
+        crate::chaos::exploration_glue::exit_child(code);
     }
 
     /// Run the entire check phase: build per-workload contexts, spawn
@@ -1850,9 +1852,7 @@ pub(crate) struct IterationManager {
 impl IterationManager {
     /// Create a new iteration manager with the given control strategy and initial seeds.
     pub(crate) fn new(control: super::builder::IterationControl, initial_seeds: Vec<u64>) -> Self {
-        let base_seed = std::time::SystemTime::now()
-            .duration_since(std::time::SystemTime::UNIX_EPOCH)
-            .map_or(12345, |d| u64::try_from(d.as_nanos()).unwrap_or(u64::MAX));
+        let base_seed = super::wall_clock::default_base_seed();
 
         Self {
             control,

--- a/moonpool-sim/src/runner/report.rs
+++ b/moonpool-sim/src/runner/report.rs
@@ -6,10 +6,21 @@ use std::collections::HashMap;
 use std::fmt;
 use std::time::Duration;
 
-use moonpool_explorer::AssertKind;
+use moonpool_assertions::AssertKind;
 
 use crate::SimulationResult;
 use crate::chaos::AssertionStats;
+
+/// Format a fork-recipe (`(rng_call_count, seed)` pairs) as a human-readable
+/// timeline: each segment `count@seed`, joined by ` -> ` (matches
+/// `moonpool_explorer::format_timeline`, but available without the backend).
+pub(crate) fn format_recipe(recipe: &[(u64, u64)]) -> String {
+    recipe
+        .iter()
+        .map(|(count, seed)| format!("{count}@{seed}"))
+        .collect::<Vec<_>>()
+        .join(" -> ")
+}
 
 /// Core metrics collected during a simulation run.
 #[derive(Debug, Clone, PartialEq)]
@@ -370,7 +381,7 @@ fn fmt_exploration(f: &mut fmt::Formatter<'_>, exp: &ExplorationReport) -> fmt::
             f,
             "  Bug recipe (seed={}): {}",
             br.seed,
-            moonpool_explorer::format_timeline(&br.recipe)
+            format_recipe(&br.recipe)
         )?;
     }
     Ok(())

--- a/moonpool-sim/src/runner/wall_clock.rs
+++ b/moonpool-sim/src/runner/wall_clock.rs
@@ -1,0 +1,52 @@
+//! Wall-clock helpers that degrade gracefully on `wasm32-unknown-unknown`.
+//!
+//! On that target `std::time::Instant::now()` and `SystemTime::now()` compile
+//! but **panic at runtime** ("time not implemented on this platform"). The sim
+//! drives logical time through its own event queue, so these are only used for
+//! harness bookkeeping (report elapsed, `TimeLimit`, the default base seed).
+//! Native builds use `std::time` directly with zero overhead; wasm builds get a
+//! zero-duration stub so a single-seed run executes instead of aborting.
+
+#[cfg(target_family = "wasm")]
+use std::time::Duration;
+
+/// Monotonic instant for harness timing. Native: re-exported `std::time::Instant`.
+#[cfg(not(target_family = "wasm"))]
+pub(crate) use std::time::Instant;
+
+/// wasm stand-in: never advances (`elapsed()` is always `Duration::ZERO`), which
+/// makes `TimeLimit` behave as a single pass and report timings show `0ms`.
+#[cfg(target_family = "wasm")]
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct Instant(Duration);
+
+#[cfg(target_family = "wasm")]
+impl Instant {
+    pub(crate) fn now() -> Self {
+        Self(Duration::ZERO)
+    }
+
+    pub(crate) fn elapsed(&self) -> Duration {
+        self.0
+    }
+}
+
+/// Entropy for the default base seed when the caller did not set one explicitly.
+///
+/// Native: wall-clock nanoseconds (falling back to a fixed value if the clock is
+/// before the epoch). wasm: a fixed seed plus a warning — deterministic runs on
+/// wasm should always set a seed explicitly.
+#[cfg(not(target_family = "wasm"))]
+pub(crate) fn default_base_seed() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .map_or(12345, |d| u64::try_from(d.as_nanos()).unwrap_or(u64::MAX))
+}
+
+#[cfg(target_family = "wasm")]
+pub(crate) fn default_base_seed() -> u64 {
+    tracing::warn!(
+        "no base seed set on wasm; using fixed seed 0 (set a seed explicitly for determinism)"
+    );
+    0
+}

--- a/moonpool-sim/tests/coverage_plateau.rs
+++ b/moonpool-sim/tests/coverage_plateau.rs
@@ -5,9 +5,9 @@
 //! both with and without fork-based exploration enabled.
 
 use async_trait::async_trait;
-use moonpool_sim::{
-    ExplorationConfig, SimContext, SimulationBuilder, SimulationReport, SimulationResult, Workload,
-};
+#[cfg(feature = "exploration")]
+use moonpool_sim::ExplorationConfig;
+use moonpool_sim::{SimContext, SimulationBuilder, SimulationReport, SimulationResult, Workload};
 
 fn run_simulation(builder: SimulationBuilder) -> SimulationReport {
     builder.run()
@@ -79,6 +79,7 @@ fn test_plateau_no_exploration() {
 
 /// Same condition with exploration enabled — children write into the shared
 /// assertion table, so the plateau accumulator sees the full coverage too.
+#[cfg(feature = "exploration")]
 #[test]
 fn test_plateau_with_exploration() {
     let report = run_simulation(

--- a/moonpool-sim/tests/exploration.rs
+++ b/moonpool-sim/tests/exploration.rs
@@ -1,4 +1,5 @@
 //! Fork-based multiverse exploration tests.
+#![cfg(feature = "exploration")]
 
 #[path = "exploration/tests.rs"]
 mod tests;

--- a/moonpool-sim/tests/network.rs
+++ b/moonpool-sim/tests/network.rs
@@ -6,6 +6,8 @@
 mod latency;
 #[path = "network/partition.rs"]
 mod partition;
+// Exercises TokioNetworkProvider — only available with the tokio-providers feature.
+#[cfg(feature = "tokio-providers")]
 #[path = "network/traits.rs"]
 mod traits;
 #[path = "network/vectored.rs"]

--- a/moonpool-sim/tests/storage.rs
+++ b/moonpool-sim/tests/storage.rs
@@ -20,5 +20,7 @@ mod latency;
 mod performance;
 #[path = "storage/recovery.rs"]
 mod recovery;
+// Exercises TokioStorageProvider — only available with the tokio-providers feature.
+#[cfg(feature = "tokio-providers")]
 #[path = "storage/tokio_provider.rs"]
 mod tokio_provider;

--- a/moonpool-transport/Cargo.toml
+++ b/moonpool-transport/Cargo.toml
@@ -13,8 +13,17 @@ readme = "README.md"
 rustdoc-args = ["--cfg", "tokio_unstable"]
 rustc-args = ["--cfg", "tokio_unstable"]
 
+[features]
+# Production convenience: the TokioTransport alias + NetTransportBuilder::tokio()
+# shortcut, which need core's TokioProviders. Default-on so examples/tests build;
+# a generic consumer that brings its own Providers can use default-features=false.
+default = ["tokio"]
+tokio = ["moonpool-core/tokio-providers"]
+
 [dependencies]
-moonpool-core = { path = "../moonpool-core", version = "0.7.0" }
+# Transport is generic over `P: Providers`; it doesn't need core's production
+# providers unless the `tokio` feature is on (TokioTransport / Builder::tokio()).
+moonpool-core = { path = "../moonpool-core", version = "0.7.0", default-features = false }
 moonpool-transport-derive = { path = "../moonpool-transport-derive", version = "0.7.0" }
 
 async-trait = "0.1"
@@ -23,10 +32,13 @@ futures = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2.0"
-tokio = { version = "1", features = ["full", "tracing"] }
+# Library code only uses tokio::sync (Notify/mpsc/watch) and the select!/pin! macros.
+# spawn/runtime/time live in #[cfg(test)] mods and pull "full" via dev-dependencies.
+tokio = { version = "1", features = ["sync", "macros"] }
 tracing = "0.1"
 
 [dev-dependencies]
+tokio = { version = "1", features = ["full", "tracing"] }
 
 [[example]]
 name = "well_known_endpoint"

--- a/moonpool-transport/src/lib.rs
+++ b/moonpool-transport/src/lib.rs
@@ -56,10 +56,14 @@
 pub use moonpool_core::{
     CodecError, Endpoint, JsonCodec, MessageCodec, NetworkAddress, NetworkAddressParseError,
     NetworkProvider, OpenOptions, Providers, RandomProvider, SimulationError, SimulationResult,
-    StorageFile, StorageProvider, TaskProvider, TcpListenerTrait, TimeError, TimeProvider,
+    StorageFile, StorageProvider, TaskProvider, TcpListenerTrait, TimeError, TimeProvider, UID,
+    WELL_KNOWN_RESERVED_COUNT, WellKnownToken,
+};
+// Production provider bundle — only with the `tokio` feature (core/tokio-providers).
+#[cfg(feature = "tokio")]
+pub use moonpool_core::{
     TokioNetworkProvider, TokioProviders, TokioRandomProvider, TokioStorageFile,
-    TokioStorageProvider, TokioTaskProvider, TokioTimeProvider, UID, WELL_KNOWN_RESERVED_COUNT,
-    WellKnownToken,
+    TokioStorageProvider, TokioTaskProvider, TokioTimeProvider,
 };
 
 // =============================================================================
@@ -102,6 +106,10 @@ pub use rpc::{
     TransportHandle, get_reply, get_reply_unless_failed_for, make_decode_fn, make_encode_fn, send,
     send_request, try_get_reply,
 };
+
+// Production transport alias (TokioProviders + JsonCodec).
+#[cfg(feature = "tokio")]
+pub use rpc::TokioTransport;
 
 // Attribute macros
 pub use moonpool_transport_derive::service;

--- a/moonpool-transport/src/rpc/mod.rs
+++ b/moonpool-transport/src/rpc/mod.rs
@@ -37,6 +37,8 @@ pub use interface_method::InterfaceMethod;
 pub use net_notified_queue::{
     NetNotifiedQueue, RecvFuture, ReplyQueueCloser, SharedNetNotifiedQueue,
 };
+#[cfg(feature = "tokio")]
+pub use net_transport::TokioTransport;
 pub use net_transport::{NetTransport, NetTransportBuilder};
 pub use reply_error::ReplyError;
 pub use reply_future::ReplyFuture;

--- a/moonpool-transport/src/rpc/net_transport.rs
+++ b/moonpool-transport/src/rpc/net_transport.rs
@@ -1073,6 +1073,25 @@ impl<P: Providers> NetTransportBuilder<P, crate::JsonCodec> {
     }
 }
 
+/// A [`NetTransport`] backed by the production [`TokioProviders`](moonpool_core::TokioProviders)
+/// bundle (and the default [`JsonCodec`](crate::JsonCodec)) — the typical
+/// production transport type.
+#[cfg(feature = "tokio")]
+pub type TokioTransport = NetTransport<moonpool_core::TokioProviders>;
+
+#[cfg(feature = "tokio")]
+impl NetTransportBuilder<moonpool_core::TokioProviders, crate::JsonCodec> {
+    /// Create a builder backed by the production
+    /// [`TokioProviders`](moonpool_core::TokioProviders) bundle.
+    ///
+    /// Shorthand for `NetTransportBuilder::new(TokioProviders::new())` — the
+    /// usual production entry point.
+    #[must_use]
+    pub fn tokio() -> Self {
+        Self::new(moonpool_core::TokioProviders::new())
+    }
+}
+
 impl<P: Providers + Send + Sync, C: MessageCodec> NetTransportBuilder<P, C> {
     /// Set the message codec for this transport.
     ///

--- a/moonpool-wasm-demo/.gitignore
+++ b/moonpool-wasm-demo/.gitignore
@@ -1,0 +1,2 @@
+# wasm-bindgen output — a build artifact, regenerate with the steps in README.md
+/web/pkg/

--- a/moonpool-wasm-demo/Cargo.toml
+++ b/moonpool-wasm-demo/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "moonpool-wasm-demo"
+version.workspace = true
+publish = false
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Browser/wasm demo: animate a deterministic ping-pong simulation and the impact of chaos"
+
+[lib]
+# cdylib for the wasm32 build (wasm-bindgen), rlib for the native bin + tests.
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+# Sim + transport, both without their production (tokio net/fs) features: the
+# wasm-able configuration. The real RPC stack runs over the simulated network.
+moonpool-sim = { path = "../moonpool-sim", version = "0.7.0", default-features = false }
+moonpool-transport = { path = "../moonpool-transport", version = "0.7.0", default-features = false }
+async-trait = "0.1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+# The workload emits standard `client_*` observability events; the generic
+# recorder reconstructs the timeline from them.
+tracing = "0.1"
+# `macros` for `tokio::select!` in the workload/server loops. The runtime itself
+# comes from moonpool-sim.
+tokio = { version = "1", features = ["macros"] }
+
+# wasm-only glue. Pinned to the flake's wasm-bindgen-cli (0.2.117) — a version
+# mismatch between the crate and the CLI is the #1 wasm-bindgen footgun.
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = "=0.2.117"
+console_error_panic_hook = "0.1"
+
+[lints]
+workspace = true

--- a/moonpool-wasm-demo/README.md
+++ b/moonpool-wasm-demo/README.md
@@ -1,0 +1,92 @@
+# moonpool-wasm-demo
+
+A KISS browser demo: run **one deterministic seed** of a ping-pong simulation —
+over moonpool's **real transport stack**, driven by the **simulated network** —
+as wasm, and watch the message exchange and the impact of chaos animate in a
+browser tab.
+
+Two nodes take part, both speaking the actual RPC stack:
+
+- **Node B** is a server [`Process`] (the "ponger") that echoes every request.
+- **Node A** is a client [`Workload`] (the "pinger") that sends 12 ping RPCs.
+
+**The visualization sits on top of the workload, not inside it.** The workload is
+a plain transport client — it just emits the standard observability events any
+instrumented client would (`client_issued` / `client_acknowledged` /
+`client_failed`, each carrying a `seq_id`) and contains *zero* visualization
+code. A generic `TimelineRecorder`, registered as an ordinary moonpool
+`Invariant`, observes those `tracing` events from the sim's timeline and
+reconstructs the animated message timeline plus the injected network faults.
+Because it keys off that standard event contract, the *same* recorder visualizes
+any transport workload that emits it — swap in a consensus layer and you'd watch
+its messages and chaos with no recorder changes.
+
+`.random_network()` turns on seeded network chaos — variable latency, reordering,
+connection drops — so a request comes back fast, slowly, or not at all. The
+front-end animates each round trip as a ball flying A→B→A; a dropped request is a
+ball lost at the net (red ✗). Nothing really waits: logical time is driven by the
+sim event queue, which is exactly why the whole transport stack runs in a tab.
+
+**The same seed always produces the same run — byte-for-byte, native and in the
+browser.** That is the whole point of deterministic simulation.
+
+## Run it natively (verify the workload first)
+
+```sh
+nix develop --command cargo run -p moonpool-wasm-demo 42
+```
+
+Prints the message timeline for seed 42 plus the JSON the browser receives. Try
+seeds `7`, `256`, `1000` for heavy chaos; `42` is calm.
+
+## Build & run in the browser
+
+```sh
+# 1. compile the cdylib to wasm (release = ~1 MB; drop --release for a fast dev build)
+nix develop --command cargo build --release --target wasm32-unknown-unknown \
+  -p moonpool-wasm-demo --lib
+
+# 2. generate the JS/wasm bindings into web/pkg/
+#    (wasm-bindgen-cli is pinned in flake.nix; the crate is pinned to match)
+nix develop --command wasm-bindgen --target web --out-dir web/pkg \
+  ../../target/wasm32-unknown-unknown/release/moonpool_wasm_demo.wasm
+
+# 3. serve and open — no bundler, no npm
+cd web && python3 -m http.server 8917
+#   then open http://localhost:8917/
+```
+
+> Run step 2 from the `moonpool-wasm-demo/` directory (so `web/pkg` resolves),
+> or pass absolute paths. `web/pkg/` is a build artifact and is gitignored.
+
+### URL parameters
+
+- `?seed=N` — load and run seed `N` (shareable, reproducible link).
+- `?still=K` — render one frozen frame: the ball mid-flight at shot `K`, with
+  every prior dropped request marked ✗. Deterministic; handy for screenshots.
+- `?dump` — put the raw `runSeed` JSON in a hidden `<pre id="raw">` (used by the
+  native↔browser reproducibility check).
+
+## How it's wired (for the curious)
+
+- `src/lib.rs`
+  - `PongServer` (`Process`) + `PingClient` (`Workload`) — plain transport actors
+    that emit standard `client_*` events; no visualization code.
+  - `TimelineRecorder` (`Invariant`) — the generic, workload-agnostic layer that
+    snapshots those events (and `sim_fault`s) off the trace timeline and rebuilds
+    the `Shot` timeline.
+  - `run_seed` / `run_seed_json` — register the recorder, run one seed, return
+    the timeline. The wasm export `runSeed(seed)` lives behind
+    `#[cfg(target_arch = "wasm32")]` and installs `console_error_panic_hook` so
+    any panic surfaces in the console.
+- `src/main.rs` — the native smoke runner.
+- `web/index.html` — ~280 lines of vanilla JS: a canvas, two nodes, a flying
+  ball, and the seeded chaos animation. No framework.
+
+The crate depends on `moonpool-sim` and `moonpool-transport` with
+`default-features = false` — the wasm-able configuration (no tokio net/fs, no
+fork-based exploration). The single-threaded tokio runtime, the RPC stack, and
+the seeded chaos all compile to and run on `wasm32-unknown-unknown`.
+
+[`Process`]: https://docs.rs/moonpool-sim
+[`Workload`]: https://docs.rs/moonpool-sim

--- a/moonpool-wasm-demo/src/lib.rs
+++ b/moonpool-wasm-demo/src/lib.rs
@@ -1,0 +1,506 @@
+//! Browser/wasm demo of moonpool: run **one deterministic seed** of a ping-pong
+//! simulation over the real `moonpool-transport` RPC layer, driven by the
+//! **simulated network**, and return the message timeline as JSON so a browser
+//! can animate the exchange and the impact of chaos.
+//!
+//! The visualization is built **on top of the workload**, not inside it. The
+//! workload ([`PingClient`]) is a plain transport client: it sends ping RPCs and
+//! emits the *standard* observability events any well-instrumented client would
+//! — `client_issued`, `client_acknowledged`, `client_failed` (each carrying a
+//! `seq_id`). It contains zero visualization code.
+//!
+//! A generic [`TimelineRecorder`] — registered as an ordinary
+//! [`moonpool_sim::Invariant`] — observes those `tracing` events from the sim's
+//! timeline and reconstructs the message timeline ([`Shot`]s) plus the injected
+//! network faults. Because it keys off the standard event contract, the *same*
+//! recorder visualizes any transport workload that emits it (e.g. the
+//! hash-chain workload in `moonpool-transport-sim`) with no changes.
+//!
+//! `.random_network()` turns on seeded network chaos — variable latency,
+//! reordering, connection drops — so a request comes back fast, slowly, or not
+//! at all. Each acknowledged request becomes two [`Shot`] legs (A→B then B→A)
+//! split over the observed round-trip time; a failed request becomes a single
+//! dropped A→B leg. Nothing really waits: logical time is driven by the sim
+//! event queue, which is why the whole transport stack runs in a browser tab.
+//!
+//! Public entry points:
+//! - [`run_seed`] — run a seed, get the structured [`RunResult`].
+//! - [`run_seed_json`] — same, serialized to JSON (used by the native bin and,
+//!   under `wasm32`, exported to JavaScript as `runSeed`).
+
+use async_trait::async_trait;
+use moonpool_sim::runner::builder::{ProcessCount, WorkloadCount};
+use moonpool_sim::{
+    Invariant, Process, SIM_FAULT_EVENT_NAME, SimContext, SimulationBuilder, SimulationError,
+    SimulationResult, TimeProvider, TraceQuery, Workload, assert_always, assert_reachable,
+    assert_sometimes,
+};
+use moonpool_transport::{
+    Endpoint, JsonCodec, NetTransport, NetTransportBuilder, NetworkAddress, ReplyError,
+    RequestEnvelope, UID, get_reply, make_decode_fn, make_encode_fn,
+};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::prelude::wasm_bindgen;
+
+// --- Tuning knobs ------------------------------------------------------------
+
+/// Number of ping requests the client sends.
+const REQUESTS: u32 = 12;
+/// Per-request client deadline, in simulated milliseconds: past this, the
+/// request is recorded as failed and the client moves on. Kept tight so a
+/// slow/partitioned network produces visible drops, not just slow balls.
+const TIMEOUT_MS: u64 = 700;
+/// A round trip at least this slow (simulated ms) counts as "slowed by chaos".
+const SLOW_RTT_MS: u64 = 100;
+/// Minimum displayed flight time for a dropped leg, so it is always visible.
+const MIN_DROP_SPAN_MS: u64 = 50;
+/// How long the network-fault phase runs alongside the workload.
+const CHAOS_SECS: u64 = 10;
+
+/// Node A — the client (pinger).
+const NODE_A: u8 = 0;
+/// Node B — the server (ponger).
+const NODE_B: u8 = 1;
+
+/// RPC interface id for the ping service.
+const PING_INTERFACE: u64 = 0xF00D_0001;
+/// Method index for `ping` on [`PING_INTERFACE`].
+const METHOD_PING: u64 = 1;
+
+// Standard transport-client observability events the recorder consumes. Same
+// names/field as `moonpool-transport-sim`, so the recorder is workload-agnostic.
+const EV_ISSUED: &str = "client_issued";
+const EV_ACKED: &str = "client_acknowledged";
+const EV_FAILED: &str = "client_failed";
+const EV_AMBIGUOUS: &str = "client_ambiguous";
+
+/// A ping request: just a sequence number the server echoes back.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Ping {
+    /// Request sequence number.
+    seq: u64,
+}
+
+/// A pong reply: the echoed sequence number.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Pong {
+    /// Echoed sequence number.
+    seq: u64,
+}
+
+/// How a shot (one leg of a round trip) resolved.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Outcome {
+    /// The leg was delivered over the network.
+    Delivered,
+    /// The request was dropped/timed out by chaos and never came back.
+    Dropped,
+}
+
+/// One message crossing the simulated network: who sent it, when it left and
+/// arrived (simulated milliseconds), how long it was in flight, and whether it
+/// made it.
+#[derive(Debug, Clone, Serialize)]
+pub struct Shot {
+    /// Request sequence number this leg belongs to.
+    pub seq: u64,
+    /// Node that sent this message (0 = A/client, 1 = B/server).
+    pub from: u8,
+    /// Node the message travels to (0 = A/client, 1 = B/server).
+    pub to: u8,
+    /// Simulated time the message left `from`, in milliseconds.
+    pub depart_ms: u64,
+    /// Simulated time the message reached `to`, in milliseconds.
+    pub arrive_ms: u64,
+    /// In-flight latency, in milliseconds (`arrive_ms - depart_ms`).
+    pub latency_ms: u64,
+    /// Whether this leg was delivered or dropped by chaos.
+    pub outcome: Outcome,
+}
+
+/// The full result of one seeded run: every message leg, plus headline counters
+/// the UI shows alongside the animation.
+#[derive(Debug, Clone, Serialize)]
+pub struct RunResult {
+    /// The seed this run used.
+    pub seed: u64,
+    /// Number of ping requests observed.
+    pub requests: u32,
+    /// Every message leg exchanged, in time order.
+    pub shots: Vec<Shot>,
+    /// Round trips that completed successfully.
+    pub delivered: u32,
+    /// Requests dropped / timed out by chaos.
+    pub dropped: u32,
+    /// Network faults the sim injected (connection drops, etc.).
+    pub faults: u32,
+    /// Slowest successful round trip, in simulated milliseconds.
+    pub longest_rtt_ms: u64,
+    /// Total simulated time elapsed, in milliseconds.
+    pub sim_duration_ms: u64,
+}
+
+impl RunResult {
+    /// An empty result, used only if the run produced no observable events.
+    fn empty(seed: u64) -> Self {
+        Self {
+            seed,
+            requests: 0,
+            shots: Vec::new(),
+            delivered: 0,
+            dropped: 0,
+            faults: 0,
+            longest_rtt_ms: 0,
+            sim_duration_ms: 0,
+        }
+    }
+}
+
+/// UID for the ping method.
+fn ping_method_uid() -> UID {
+    UID::new(PING_INTERFACE, METHOD_PING)
+}
+
+/// Parse a sim IP (which may lack a port) into a [`NetworkAddress`], defaulting
+/// to port 4500 (the sim convention).
+fn parse_sim_addr(ip: &str) -> SimulationResult<NetworkAddress> {
+    let addr_str = if ip.contains(':') {
+        ip.to_string()
+    } else {
+        format!("{ip}:4500")
+    };
+    NetworkAddress::parse(&addr_str)
+        .map_err(|e| SimulationError::InvalidState(format!("bad addr: {e}")))
+}
+
+/// Convert a [`Duration`] of simulated time to whole milliseconds.
+fn duration_ms(d: Duration) -> u64 {
+    u64::try_from(d.as_millis()).unwrap_or(u64::MAX)
+}
+
+// ============================================================================
+// Workload + server: plain transport actors. No visualization code lives here —
+// they only do their job and emit standard observability events.
+// ============================================================================
+
+/// Node B: the ponger. Listens on its sim address, registers a ping handler, and
+/// echoes every request's sequence number until shutdown.
+struct PongServer;
+
+#[async_trait]
+impl Process for PongServer {
+    fn name(&self) -> &'static str {
+        "pong-server"
+    }
+
+    async fn run(&mut self, ctx: &SimContext) -> SimulationResult<()> {
+        let addr = parse_sim_addr(ctx.my_ip())?;
+        let transport = NetTransportBuilder::new(ctx.providers().clone())
+            .local_address(addr)
+            .build_listening()
+            .await
+            .map_err(|e| SimulationError::InvalidState(format!("server transport: {e}")))?;
+
+        let (ping_stream, _) = NetTransport::register_handler_at::<Ping, Pong>(
+            &transport,
+            PING_INTERFACE,
+            METHOD_PING,
+        );
+
+        let shutdown = ctx.shutdown().clone();
+        loop {
+            tokio::select! {
+                Some((req, reply)) = ping_stream.recv() => {
+                    reply.send(Pong { seq: req.seq });
+                }
+                () = shutdown.cancelled() => return Ok(()),
+            }
+        }
+    }
+}
+
+/// Node A: the pinger. Sends `REQUESTS` ping RPCs to the server through the
+/// chaotic sim network and emits `client_issued` / `client_acknowledged` /
+/// `client_failed` for each — the standard observability contract the recorder
+/// reconstructs the timeline from. It has no knowledge of the visualization.
+struct PingClient;
+
+#[async_trait]
+impl Workload for PingClient {
+    fn name(&self) -> &'static str {
+        "ping-client"
+    }
+
+    async fn run(&mut self, ctx: &SimContext) -> SimulationResult<()> {
+        let servers = ctx.topology().all_process_ips().to_vec();
+        let Some(server_ip) = servers.first().cloned() else {
+            return Ok(());
+        };
+
+        let my_addr = parse_sim_addr(ctx.my_ip())?;
+        let transport = NetTransportBuilder::new(ctx.providers().clone())
+            .local_address(my_addr)
+            .build_listening()
+            .await
+            .map_err(|e| SimulationError::InvalidState(format!("client transport: {e}")))?;
+
+        let endpoint = Endpoint::new(parse_sim_addr(&server_ip)?, ping_method_uid());
+        let encode = make_encode_fn::<RequestEnvelope<Ping>, _>(JsonCodec);
+        let decode = make_decode_fn::<Result<Pong, ReplyError>, _>(JsonCodec);
+
+        let time = ctx.time().clone();
+        let shutdown = ctx.shutdown().clone();
+
+        for seq in 0..u64::from(REQUESTS) {
+            if shutdown.is_cancelled() {
+                break;
+            }
+
+            let send = time.now();
+            tracing::info!(seq_id = seq, "client_issued");
+
+            // Reliable RPC, abandoned if it doesn't return within the deadline.
+            let result: Option<Result<Pong, ReplyError>> = match get_reply(
+                &*transport,
+                &endpoint,
+                Ping { seq },
+                &encode,
+                decode.clone(),
+            ) {
+                Ok(fut) => tokio::select! {
+                    r = fut => Some(r),
+                    () = shutdown.cancelled() => None,
+                    _ = time.sleep(Duration::from_millis(TIMEOUT_MS)) => None,
+                },
+                Err(_) => None,
+            };
+
+            if let Some(Ok(pong)) = result {
+                assert_always!(pong.seq == seq, "pong echoes the ping it answered");
+                let rtt_ms = duration_ms(time.now().saturating_sub(send));
+                assert_sometimes!(rtt_ms >= SLOW_RTT_MS, "a round trip is slowed by chaos");
+                tracing::info!(seq_id = seq, "client_acknowledged");
+            } else {
+                assert_reachable!("chaos drops a request before any pong returns");
+                tracing::info!(seq_id = seq, "client_failed");
+            }
+        }
+        Ok(())
+    }
+}
+
+// ============================================================================
+// Visualization layer: generic, sits on top of any workload via the timeline.
+// ============================================================================
+
+/// Raw timeline the recorder accumulates from the sim's trace events.
+#[derive(Default)]
+struct RecorderData {
+    /// `(seq_id, sim_time_ms)` for each issued request.
+    issued: Vec<(u64, u64)>,
+    /// `(seq_id, sim_time_ms)` for each acknowledged (delivered) request.
+    acked: Vec<(u64, u64)>,
+    /// `(seq_id, sim_time_ms)` for each failed/ambiguous (dropped) request.
+    failed: Vec<(u64, u64)>,
+    /// `(sim_time_ms, kind)` for each injected network fault.
+    faults: Vec<(u64, String)>,
+}
+
+/// Pull `(seq_id, time_ms)` pairs for every event named `name`.
+fn collect_seq(q: &dyn TraceQuery, name: &str) -> Vec<(u64, u64)> {
+    q.snapshot(name)
+        .into_iter()
+        .filter_map(|e| Some((e.u64("seq_id")?, e.time_ms)))
+        .collect()
+}
+
+/// A workload-agnostic recorder. As an [`Invariant`] it sees the whole trace
+/// timeline after each step; it snapshots the standard client events and the
+/// injected faults into shared state the driver reads once the run completes.
+struct TimelineRecorder {
+    data: Arc<Mutex<RecorderData>>,
+}
+
+impl Invariant for TimelineRecorder {
+    fn name(&self) -> &'static str {
+        "timeline_recorder"
+    }
+
+    fn observe(&self, q: &dyn TraceQuery, _sim_time_ms: u64) {
+        let mut d = self
+            .data
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        d.issued = collect_seq(q, EV_ISSUED);
+        d.acked = collect_seq(q, EV_ACKED);
+        let mut failed = collect_seq(q, EV_FAILED);
+        failed.extend(collect_seq(q, EV_AMBIGUOUS));
+        d.failed = failed;
+        d.faults = q
+            .snapshot(SIM_FAULT_EVENT_NAME)
+            .into_iter()
+            .map(|e| (e.time_ms, e.str("kind").unwrap_or("fault").to_string()))
+            .collect();
+    }
+}
+
+/// Turn the recorded timeline into the animation [`RunResult`]: match each
+/// issued request to its acknowledgement (delivered) or failure (dropped), and
+/// synthesize the two legs of every delivered round trip.
+fn build_result(seed: u64, data: &RecorderData) -> RunResult {
+    let ack: HashMap<u64, u64> = data.acked.iter().copied().collect();
+    let fail: HashMap<u64, u64> = data.failed.iter().copied().collect();
+    let mut issued = data.issued.clone();
+    issued.sort_by_key(|&(_, t)| t);
+
+    let mut shots = Vec::new();
+    let mut delivered = 0_u32;
+    let mut dropped = 0_u32;
+    let mut longest_rtt_ms = 0_u64;
+
+    for (seq, issue_ms) in issued.iter().copied() {
+        if let Some(&ack_ms) = ack.get(&seq) {
+            delivered += 1;
+            let rtt = ack_ms.saturating_sub(issue_ms);
+            longest_rtt_ms = longest_rtt_ms.max(rtt);
+            let mid_ms = issue_ms.saturating_add(rtt / 2);
+            shots.push(Shot {
+                seq,
+                from: NODE_A,
+                to: NODE_B,
+                depart_ms: issue_ms,
+                arrive_ms: mid_ms,
+                latency_ms: mid_ms.saturating_sub(issue_ms),
+                outcome: Outcome::Delivered,
+            });
+            shots.push(Shot {
+                seq,
+                from: NODE_B,
+                to: NODE_A,
+                depart_ms: mid_ms,
+                arrive_ms: ack_ms,
+                latency_ms: ack_ms.saturating_sub(mid_ms),
+                outcome: Outcome::Delivered,
+            });
+        } else {
+            dropped += 1;
+            let end_ms = fail.get(&seq).copied().unwrap_or(issue_ms);
+            let span = end_ms.saturating_sub(issue_ms).max(MIN_DROP_SPAN_MS);
+            shots.push(Shot {
+                seq,
+                from: NODE_A,
+                to: NODE_B,
+                depart_ms: issue_ms,
+                arrive_ms: issue_ms.saturating_add(span),
+                latency_ms: span,
+                outcome: Outcome::Dropped,
+            });
+        }
+    }
+
+    let mut sim_duration_ms = shots.iter().map(|s| s.arrive_ms).max().unwrap_or(0);
+    for (t, _) in &data.faults {
+        sim_duration_ms = sim_duration_ms.max(*t);
+    }
+
+    RunResult {
+        seed,
+        requests: u32::try_from(issued.len()).unwrap_or(u32::MAX),
+        shots,
+        delivered,
+        dropped,
+        faults: u32::try_from(data.faults.len()).unwrap_or(u32::MAX),
+        longest_rtt_ms,
+        sim_duration_ms,
+    }
+}
+
+/// Run one deterministic seed of the ping-pong transport simulation and return
+/// its full timeline. The same seed always produces the same [`RunResult`].
+#[must_use]
+pub fn run_seed(seed: u64) -> RunResult {
+    let data = Arc::new(Mutex::new(RecorderData::default()));
+    let _report = SimulationBuilder::new()
+        .processes(ProcessCount::Fixed(1), || Box::new(PongServer))
+        .workloads(WorkloadCount::Fixed(1), |_| Box::new(PingClient))
+        .invariant(TimelineRecorder { data: data.clone() })
+        .chaos_duration(Duration::from_secs(CHAOS_SECS))
+        .random_network()
+        .set_iterations(1)
+        .set_debug_seeds(vec![seed])
+        .run();
+
+    let data = data
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if data.issued.is_empty() {
+        return RunResult::empty(seed);
+    }
+    build_result(seed, &data)
+}
+
+/// Run one seed and serialize the [`RunResult`] to a JSON string. Serializing a
+/// plain data struct cannot fail, but on the off chance it does the error is
+/// returned as a small JSON object instead of panicking.
+#[must_use]
+pub fn run_seed_json(seed: u64) -> String {
+    serde_json::to_string(&run_seed(seed))
+        .unwrap_or_else(|e| format!("{{\"error\":\"serialize failed: {e}\"}}"))
+}
+
+/// wasm entry point exported to JavaScript as `runSeed(seed)`. Installs the
+/// panic hook first so any runtime panic (e.g. a `block_on` that parks) surfaces
+/// as a real message in the browser console rather than an opaque trap.
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen(js_name = runSeed)]
+#[must_use]
+pub fn run_seed_wasm(seed: u64) -> String {
+    console_error_panic_hook::set_once();
+    run_seed_json(seed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{REQUESTS, run_seed, run_seed_json};
+
+    #[test]
+    fn runs_and_is_reproducible() {
+        let first = run_seed_json(42);
+        let second = run_seed_json(42);
+        assert_eq!(first, second, "same seed must reproduce the same timeline");
+
+        let result = run_seed(42);
+        assert_eq!(
+            result.requests, REQUESTS,
+            "every request should be observed"
+        );
+        assert!(
+            !result.shots.is_empty(),
+            "a seeded run should exchange messages"
+        );
+        for shot in &result.shots {
+            assert!(
+                shot.arrive_ms >= shot.depart_ms,
+                "a message arrived before it left"
+            );
+        }
+        assert_eq!(
+            result.delivered + result.dropped,
+            REQUESTS,
+            "every request is either delivered or dropped"
+        );
+    }
+
+    #[test]
+    fn distinct_seeds_differ() {
+        // Guards against a constant / no-chaos bug: two seeds producing identical
+        // timelines would be astronomically unlikely with seeded network chaos.
+        assert_ne!(run_seed_json(7), run_seed_json(99));
+    }
+}

--- a/moonpool-wasm-demo/src/main.rs
+++ b/moonpool-wasm-demo/src/main.rs
@@ -1,0 +1,43 @@
+//! Native smoke runner: `cargo run -p moonpool-wasm-demo [seed]` runs one seed
+//! of the ping-pong transport simulation and prints its message timeline, so the
+//! workload is verified on native hardware before any wasm build. The browser
+//! calls the exact same [`moonpool_wasm_demo::run_seed`] under the hood.
+
+use moonpool_wasm_demo::{Outcome, run_seed, run_seed_json};
+
+fn main() {
+    let seed = std::env::args()
+        .nth(1)
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(42);
+
+    let result = run_seed(seed);
+
+    println!(
+        "seed {} — {} requests over the simulated network: {} delivered, {} dropped by chaos, \
+         {} net faults, slowest RTT {} ms, {} ms simulated\n",
+        result.seed,
+        result.requests,
+        result.delivered,
+        result.dropped,
+        result.faults,
+        result.longest_rtt_ms,
+        result.sim_duration_ms,
+    );
+
+    for shot in &result.shots {
+        let arrow = if shot.from == 0 { "A → B" } else { "B → A" };
+        let mark = match shot.outcome {
+            Outcome::Delivered => "delivered",
+            Outcome::Dropped => "✗ DROPPED",
+        };
+        println!(
+            "  req {:>2}  {}  {:>4}ms  (t={:>5}ms)  {}",
+            shot.seq, arrow, shot.latency_ms, shot.arrive_ms, mark,
+        );
+    }
+
+    // Print the JSON the browser would receive, so the wire format is eyeballable.
+    println!("\n--- JSON (what runSeed returns to the browser) ---");
+    println!("{}", run_seed_json(seed));
+}

--- a/moonpool-wasm-demo/web/index.html
+++ b/moonpool-wasm-demo/web/index.html
@@ -1,0 +1,309 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>moonpool · ping-pong in the browser</title>
+<style>
+  :root { color-scheme: dark; }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; font: 15px/1.5 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+    background: #0d1117; color: #c9d1d9; padding: 24px;
+    display: flex; flex-direction: column; align-items: center; gap: 16px;
+  }
+  h1 { margin: 0; font-size: 20px; font-weight: 650; }
+  h1 small { color: #8b949e; font-weight: 400; font-size: 13px; }
+  .sub { color: #8b949e; max-width: 720px; text-align: center; margin: -8px 0 0; }
+  .panel { width: min(840px, 100%); background: #161b22; border: 1px solid #30363d;
+           border-radius: 12px; padding: 16px; }
+  .controls { display: flex; flex-wrap: wrap; align-items: center; gap: 10px; }
+  label { color: #8b949e; }
+  input[type=number] { width: 96px; background: #0d1117; color: #c9d1d9;
+    border: 1px solid #30363d; border-radius: 7px; padding: 7px 9px; font: inherit; }
+  input[type=range] { accent-color: #2f81f7; }
+  button { background: #21262d; color: #c9d1d9; border: 1px solid #30363d;
+    border-radius: 7px; padding: 7px 13px; font: inherit; cursor: pointer; }
+  button:hover { border-color: #8b949e; }
+  button.primary { background: #238636; border-color: #2ea043; color: #fff; font-weight: 600; }
+  button.preset { font-size: 13px; padding: 5px 10px; }
+  canvas { width: 100%; height: 300px; display: block; border-radius: 10px;
+    background: radial-gradient(120% 120% at 50% 0%, #131a24 0%, #0d1117 70%); margin-top: 4px; }
+  .stats { display: flex; flex-wrap: wrap; gap: 18px; margin-top: 12px; font-variant-numeric: tabular-nums; }
+  .stat b { display: block; font-size: 20px; font-weight: 650; }
+  .stat .delivered { color: #3fb950; }
+  .stat .dropped { color: #f85149; }
+  .stat span { color: #8b949e; font-size: 12px; text-transform: uppercase; letter-spacing: .04em; }
+  .status { margin-top: 8px; color: #8b949e; min-height: 1.4em; font-size: 13px; }
+  .legend { display: flex; gap: 16px; font-size: 12px; color: #8b949e; margin-top: 4px; }
+  .dot { display: inline-block; width: 9px; height: 9px; border-radius: 50%; vertical-align: middle; margin-right: 5px; }
+  a { color: #2f81f7; }
+</style>
+</head>
+<body>
+  <h1>moonpool <small>· deterministic ping-pong, in your browser tab</small></h1>
+  <p class="sub">Two nodes exchange ping/pong RPCs over moonpool's <b>real transport stack</b>,
+  driven by a <b>simulated network</b>. The whole simulation — server, client, RPC, seeded
+  chaos — runs as wasm. Same seed ⇒ same run, every time.</p>
+
+  <div class="panel">
+    <div class="controls">
+      <label for="seed">seed</label>
+      <input id="seed" type="number" value="42" min="0" />
+      <button id="run" class="primary">▶ Run</button>
+      <span style="flex:1 1 12px"></span>
+      <label for="speed">speed</label>
+      <input id="speed" type="range" min="0.4" max="6" step="0.2" value="2" />
+      <span id="speedval" style="color:#8b949e;width:2.4em">2×</span>
+    </div>
+    <div class="controls" style="margin-top:10px">
+      <span style="color:#8b949e;font-size:13px">try:</span>
+      <button class="preset" data-seed="42">42 · calm</button>
+      <button class="preset" data-seed="123">123 · some drops</button>
+      <button class="preset" data-seed="256">256 · chaotic</button>
+      <button class="preset" data-seed="7">7 · storm</button>
+      <button class="preset" id="rand">🎲 random</button>
+    </div>
+
+    <canvas id="court" width="808" height="300"></canvas>
+    <div class="legend">
+      <span><i class="dot" style="background:#58a6ff"></i>node A · client</span>
+      <span><i class="dot" style="background:#3fb950"></i>node B · server</span>
+      <span><i class="dot" style="background:#d29922"></i>ball in flight</span>
+      <span><i class="dot" style="background:#f85149"></i>dropped by chaos</span>
+    </div>
+
+    <div class="stats">
+      <div class="stat"><b id="s-req">–</b><span>requests</span></div>
+      <div class="stat"><b id="s-del" class="delivered">–</b><span>delivered</span></div>
+      <div class="stat"><b id="s-drop" class="dropped">–</b><span>dropped</span></div>
+      <div class="stat"><b id="s-fault">–</b><span>net faults</span></div>
+      <div class="stat"><b id="s-rtt">–</b><span>slowest rtt</span></div>
+      <div class="stat"><b id="s-sim">–</b><span>sim time</span></div>
+    </div>
+    <div class="status" id="status">Loading wasm…</div>
+  </div>
+  <pre id="raw" style="display:none"></pre>
+
+<script type="module">
+import init, { runSeed } from './pkg/moonpool_wasm_demo.js';
+
+const $ = (id) => document.getElementById(id);
+const canvas = $('court'), ctx = canvas.getContext('2d');
+const W = canvas.width, H = canvas.height;
+const A = { x: 120, y: H / 2, label: 'A', sub: 'client', color: '#58a6ff' };
+const B = { x: W - 120, y: H / 2, label: 'B', sub: 'server', color: '#3fb950' };
+const nodes = [A, B];
+const NET_X = W / 2;
+
+let run = null;          // current RunResult
+let idx = 0;             // index into run.shots
+let animStart = null;    // ms timestamp the current shot began
+let shotMs = 0;          // wall duration of the current shot
+let live = { delivered: 0, dropped: 0, rtt: 0 };
+let flashes = [];        // active drop bursts
+let crosses = [];        // persistent ✗ marks (freeze-frame mode)
+let playing = false;
+
+// Optional URL params: ?seed=N picks the seed; ?still=K renders one frozen
+// frame (ball mid-flight at shot K, prior drops marked) instead of animating.
+const params = new URLSearchParams(location.search);
+if (params.has('seed')) $('seed').value = params.get('seed');
+const STILL = params.has('still') ? parseInt(params.get('still'), 10) : null;
+const DUMP = params.has('dump'); // ?dump puts raw runSeed JSON in #raw (repro checks)
+if (params.has('embed')) {       // ?embed hides the page title (e.g. inside the book)
+  document.querySelector('h1').style.display = 'none';
+  document.querySelector('.sub').style.display = 'none';
+  document.body.style.padding = '10px';
+}
+
+const lerp = (a, b, t) => a + (b - a) * t;
+const ease = (t) => t * t * (3 - 2 * t); // smoothstep
+const clamp = (v, lo, hi) => Math.max(lo, Math.min(hi, v));
+
+function drawScene(ball) {
+  ctx.clearRect(0, 0, W, H);
+
+  // net
+  ctx.strokeStyle = '#30363d'; ctx.lineWidth = 2; ctx.setLineDash([6, 7]);
+  ctx.beginPath(); ctx.moveTo(NET_X, 26); ctx.lineTo(NET_X, H - 26); ctx.stroke();
+  ctx.setLineDash([]);
+  ctx.fillStyle = '#484f58'; ctx.font = '11px system-ui'; ctx.textAlign = 'center';
+  ctx.fillText('simulated network · chaos', NET_X, H - 12);
+
+  // nodes
+  for (const n of nodes) {
+    ctx.beginPath(); ctx.arc(n.x, n.y, 34, 0, 7); ctx.fillStyle = n.color + '22';
+    ctx.fill(); ctx.lineWidth = 2.5; ctx.strokeStyle = n.color; ctx.stroke();
+    ctx.fillStyle = n.color; ctx.font = '600 22px system-ui'; ctx.textAlign = 'center';
+    ctx.fillText(n.label, n.x, n.y + 7);
+    ctx.fillStyle = '#8b949e'; ctx.font = '12px system-ui';
+    ctx.fillText(n.sub, n.x, n.y + 54);
+  }
+
+  // drop bursts
+  const now = performance.now();
+  flashes = flashes.filter(f => now < f.until);
+  for (const f of flashes) {
+    const k = 1 - (f.until - now) / 600;
+    ctx.globalAlpha = 1 - k;
+    ctx.strokeStyle = '#f85149'; ctx.lineWidth = 3;
+    const r = 10 + k * 22;
+    ctx.beginPath(); ctx.moveTo(f.x - r, f.y - r); ctx.lineTo(f.x + r, f.y + r);
+    ctx.moveTo(f.x + r, f.y - r); ctx.lineTo(f.x - r, f.y + r); ctx.stroke();
+    ctx.globalAlpha = 1;
+  }
+
+  // persistent ✗ marks (freeze-frame mode)
+  ctx.strokeStyle = '#f85149'; ctx.lineWidth = 3;
+  for (const c of crosses) {
+    ctx.beginPath(); ctx.moveTo(c.x - 11, c.y - 11); ctx.lineTo(c.x + 11, c.y + 11);
+    ctx.moveTo(c.x + 11, c.y - 11); ctx.lineTo(c.x - 11, c.y + 11); ctx.stroke();
+  }
+
+  // ball
+  if (ball) {
+    ctx.shadowColor = ball.color; ctx.shadowBlur = 14;
+    ctx.beginPath(); ctx.arc(ball.x, ball.y, 9, 0, 7); ctx.fillStyle = ball.color; ctx.fill();
+    ctx.shadowBlur = 0;
+  }
+}
+
+// Render a single static frame: ball at the midpoint of shot K, with every
+// prior dropped shot marked ✗. Deterministic — used for screenshots and
+// ?still= links, no animation timing involved.
+function drawStill(k) {
+  k = clamp(k, 0, run.shots.length - 1);
+  crosses = [];
+  for (let i = 0; i < k; i++) {
+    const s = run.shots[i];
+    if (s.outcome === 'dropped') {
+      // Scatter deterministically by seq so multiple drops don't stack.
+      const f = 0.48 + ((s.seq * 17) % 30) / 100;            // 0.48..0.77 along the path
+      crosses.push({ x: lerp(nodes[s.from].x, nodes[s.to].x, f),
+                     y: nodes[s.from].y - 64 * Math.sin(Math.PI * f) + ((s.seq * 29) % 70 - 35) });
+    }
+  }
+  const shot = run.shots[k];
+  const reach = shot.outcome === 'dropped' ? 0.5 : 0.5;
+  const x = lerp(nodes[shot.from].x, nodes[shot.to].x, ease(reach));
+  const y = nodes[shot.from].y - 64 * Math.sin(Math.PI * reach);
+  drawScene({ x, y, color: shot.outcome === 'dropped' ? '#f85149' : '#d29922' });
+  setStats(run, false);
+  $('status').textContent =
+    `seed ${run.seed} · frame at request ${shot.seq} · ${run.delivered} delivered, ${run.dropped} dropped by chaos`;
+}
+
+function setStats(r, useLive) {
+  $('s-req').textContent = r.requests;
+  $('s-del').textContent = useLive ? live.delivered : r.delivered;
+  $('s-drop').textContent = useLive ? live.dropped : r.dropped;
+  $('s-fault').textContent = r.faults;
+  $('s-rtt').textContent = (useLive ? live.rtt : r.longest_rtt_ms) + ' ms';
+  $('s-sim').textContent = r.sim_duration_ms + ' ms';
+}
+
+function frame(ts) {
+  if (!playing) return;
+
+  if (idx >= run.shots.length) {
+    playing = false;
+    setStats(run, false);
+    $('status').textContent =
+      `done · seed ${run.seed} · ${run.delivered} delivered, ${run.dropped} dropped by chaos`;
+    drawScene(null);
+    return;
+  }
+
+  const shot = run.shots[idx];
+  if (animStart === null) {
+    animStart = ts;
+    const speed = parseFloat($('speed').value);
+    shotMs = clamp(shot.latency_ms / speed * 6 + 140, 150, 1700);
+    const dir = shot.from === 0 ? 'A → B' : 'B → A';
+    const kind = shot.outcome === 'dropped' ? 'request lost in the network ✗' : 'in flight';
+    $('status').textContent =
+      `request ${shot.seq} · ${dir} · ${shot.latency_ms} ms · ${kind}`;
+  }
+
+  const t = clamp((ts - animStart) / shotMs, 0, 1);
+  const from = nodes[shot.from], to = nodes[shot.to];
+  const dropping = shot.outcome === 'dropped';
+  // a dropped ball only travels ~62% of the way before it's lost
+  const reach = dropping ? 0.62 : 1;
+  const tt = t * reach;
+  const x = lerp(from.x, to.x, ease(tt));
+  const y = from.y - 64 * Math.sin(Math.PI * tt); // hop over the net
+  const fade = dropping ? clamp(1 - (t - 0.5) / 0.5, 0.15, 1) : 1;
+  const color = dropping ? '#f85149' : '#d29922';
+
+  ctx.globalAlpha = fade;
+  drawScene({ x, y, color });
+  ctx.globalAlpha = 1;
+
+  if (t >= 1) {
+    // shot resolved
+    if (dropping) {
+      const fx = lerp(from.x, to.x, 0.62), fy = from.y - 64 * Math.sin(Math.PI * 0.62);
+      flashes.push({ x: fx, y: fy, until: performance.now() + 600 });
+      live.dropped++;
+    } else if (shot.to === 0) {
+      // a B → A leg completing means a full round trip landed
+      live.delivered++;
+      live.rtt = Math.max(live.rtt, run.shots[idx - 1].latency_ms + shot.latency_ms);
+    }
+    setStats(run, true);
+    idx++; animStart = null;
+  }
+  requestAnimationFrame(frame);
+}
+
+function start() {
+  const seed = BigInt($('seed').value || '0');
+  $('status').textContent = `running seed ${seed} in wasm…`;
+  let json;
+  try {
+    json = runSeed(seed);          // <-- the whole sim runs here, in the browser
+  } catch (e) {
+    $('status').textContent = 'wasm panicked: ' + e + ' (see console)';
+    throw e;
+  }
+  if (DUMP) {                      // expose raw JSON for native↔browser repro checks
+    document.getElementById('raw').textContent = json;
+    $('status').textContent = `dumped seed ${$('seed').value}`;
+    return;
+  }
+
+  run = JSON.parse(json);
+  idx = 0; animStart = null;
+  live = { delivered: 0, dropped: 0, rtt: 0 };
+  flashes = []; crosses = [];
+
+  if (STILL !== null) {            // deterministic frozen frame (screenshots / links)
+    playing = false;
+    drawStill(STILL);
+    return;
+  }
+  playing = true;
+  setStats(run, true);
+  requestAnimationFrame(frame);
+}
+
+$('run').addEventListener('click', start);
+$('seed').addEventListener('keydown', (e) => { if (e.key === 'Enter') start(); });
+$('speed').addEventListener('input', () => { $('speedval').textContent = $('speed').value + '×'; });
+for (const b of document.querySelectorAll('.preset[data-seed]')) {
+  b.addEventListener('click', () => { $('seed').value = b.dataset.seed; start(); });
+}
+$('rand').addEventListener('click', () => {
+  $('seed').value = Math.floor(Math.random() * 100000); start();
+});
+
+drawScene(null);
+init().then(() => {
+  $('status').textContent = 'ready · press Run (or pick a seed above)';
+  start();
+}).catch((e) => { $('status').textContent = 'failed to load wasm: ' + e; });
+</script>
+</body>
+</html>

--- a/moonpool/Cargo.toml
+++ b/moonpool/Cargo.toml
@@ -9,10 +9,29 @@ repository.workspace = true
 edition.workspace = true
 readme = "README.md"
 
+[features]
+# Default = the full framework (what the crate's audience uses today). Lean
+# production builds opt out of sim/explorer entirely:
+#   moonpool = { version = "0.8", default-features = false, features = ["tokio", "transport"] }
+default = ["sim", "tokio", "transport"]
+sim = ["dep:moonpool-sim"]
+transport = ["dep:moonpool-transport"]
+# Production providers (TokioProviders) on core, and the transport tokio shortcut.
+tokio = ["moonpool-core/tokio-providers", "moonpool-transport?/tokio"]
+
 [dependencies]
-moonpool-core = { path = "../moonpool-core", version = "0.7.0" }
-moonpool-sim = { path = "../moonpool-sim", version = "0.7.0" }
-moonpool-transport = { path = "../moonpool-transport", version = "0.7.0" }
+moonpool-core = { path = "../moonpool-core", version = "0.7.0", default-features = false }
+moonpool-sim = { path = "../moonpool-sim", version = "0.7.0", optional = true }
+moonpool-transport = { path = "../moonpool-transport", version = "0.7.0", optional = true }
+
+[dev-dependencies]
+async-trait = "0.1"
+tokio = { version = "1", features = ["rt", "macros", "time"] }
+
+# Production-usage example, also driven through the simulator by its #[test].
+[[example]]
+name = "retrying_worker"
+test = true
 
 [lints]
 workspace = true

--- a/moonpool/examples/retrying_worker.rs
+++ b/moonpool/examples/retrying_worker.rs
@@ -1,0 +1,85 @@
+//! Write once, run in production, test under simulation.
+//!
+//! `fetch_with_retry` is ordinary application logic written against the
+//! [`Providers`] traits — it never touches tokio directly. `main` runs it on the
+//! real [`TokioProviders`] backend (wall-clock sleeps, OS RNG); the test at the
+//! bottom drives the *same function* through [`SimulationBuilder`], where time is
+//! logical and the RNG is seeded — so 50 deterministic "production days" run in
+//! milliseconds.
+//!
+//! Run the production demo:    `cargo run --example retrying_worker`
+//! Run the simulation test:    `cargo test --example retrying_worker`
+
+use moonpool::prelude::*;
+use std::time::Duration;
+
+/// Retry an operation with exponential backoff + jitter, using only provider
+/// traits. Because it is generic over `P: Providers`, the exact same code runs
+/// on Tokio in production and under deterministic simulation in tests.
+async fn fetch_with_retry<P: Providers>(providers: &P, max_attempts: u32) -> Result<u32, String> {
+    let time = providers.time();
+    let random = providers.random();
+
+    for attempt in 0..max_attempts {
+        // Stand-in for a real fallible operation (network call, etc.): succeeds
+        // ~60% of the time. In sim this draw comes from the seeded RNG.
+        if random.random_bool(0.6) {
+            return Ok(attempt);
+        }
+
+        // Exponential backoff with jitter — every sleep goes through the time
+        // provider, so simulation advances logical time instead of really waiting.
+        let base_ms = 10u64 << attempt;
+        let jitter_ms = random.random_range(0..base_ms.max(1));
+        time.sleep(Duration::from_millis(base_ms + jitter_ms))
+            .await
+            .map_err(|e| e.to_string())?;
+    }
+
+    Err(format!("gave up after {max_attempts} attempts"))
+}
+
+/// Production entry point: drive the worker on the real Tokio backend.
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let providers = TokioProviders::new();
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    let result = runtime.block_on(fetch_with_retry(&providers, 5));
+    println!("production run finished: {result:?}");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+
+    /// Drives `fetch_with_retry` under simulation. The workload pulls the
+    /// `SimProviders` bundle from the context and hands it to the very same
+    /// generic function `main` calls.
+    struct RetryWorkload;
+
+    #[async_trait]
+    impl Workload for RetryWorkload {
+        fn name(&self) -> &'static str {
+            "retry-client"
+        }
+
+        async fn run(&mut self, ctx: &SimContext) -> moonpool::SimulationResult<()> {
+            // Either outcome is fine — we are asserting the worker never panics
+            // or hangs under simulated time + chaos, across many seeds.
+            let _ = fetch_with_retry(ctx.providers(), 5).await;
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn survives_chaos() {
+        let report = SimulationBuilder::new()
+            .set_iterations(50)
+            .workload(RetryWorkload)
+            .run();
+        assert_eq!(report.failed_runs, 0, "worker should survive every seed");
+    }
+}

--- a/moonpool/src/lib.rs
+++ b/moonpool/src/lib.rs
@@ -61,7 +61,34 @@
 #![deny(missing_docs)]
 #![allow(ambiguous_glob_reexports)]
 
-// Re-export all public items from sub-crates
+// Re-export all public items from sub-crates. `moonpool-core` is always present;
+// `sim` and `transport` are feature-gated so a lean production build pulls neither
+// the simulation runtime nor the explorer (no libc/mio in the prod dependency tree).
 pub use moonpool_core::*;
+#[cfg(feature = "sim")]
 pub use moonpool_sim::*;
+#[cfg(feature = "transport")]
 pub use moonpool_transport::*;
+
+/// Common imports for application code.
+///
+/// Production:
+///
+/// ```
+/// use moonpool::prelude::*;
+/// ```
+///
+/// Brings the provider traits into scope (needed to call their async methods),
+/// plus the transport entry points and, when the `sim` feature is on, the
+/// simulation builder/driver types.
+pub mod prelude {
+    pub use moonpool_core::prelude::*;
+
+    #[cfg(all(feature = "transport", feature = "tokio"))]
+    pub use moonpool_transport::TokioTransport;
+    #[cfg(feature = "transport")]
+    pub use moonpool_transport::{NetTransport, NetTransportBuilder, NetworkAddress};
+
+    #[cfg(feature = "sim")]
+    pub use moonpool_sim::{Process, SimContext, SimulationBuilder, Workload, WorkloadTopology};
+}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -31,6 +31,12 @@ name = "moonpool-core"
 changelog_path = "moonpool-core/CHANGELOG.md"
 version_group = "moonpool"
 
+# Leaf accounting crate; moonpool-explorer depends on it, so it must publish first.
+[[package]]
+name = "moonpool-assertions"
+changelog_path = "moonpool-assertions/CHANGELOG.md"
+version_group = "moonpool"
+
 [[package]]
 name = "moonpool-explorer"
 changelog_path = "moonpool-explorer/CHANGELOG.md"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -68,6 +68,11 @@ release = false
 publish = false
 
 [[package]]
+name = "moonpool-wasm-demo"
+release = false
+publish = false
+
+[[package]]
 name = "xtask"
 release = false
 publish = false

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
 channel = "1.95.0"
 components = ["rustc", "cargo", "rustfmt", "clippy", "rust-analyzer", "rust-src"]
+targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
## What

Makes a single-seed moonpool simulation compile **and run** on
`wasm32-unknown-unknown` (widening the margin for macOS too), settles the
provider-dispatch question, right-sizes the crate graph, and ships a lean
production path — capped by a browser demo that proves the whole stack runs in a
tab.

## Highlights

**Dispatch — stay static-generic.** Provider traits aren't object-safe (`Clone`
supertrait, generic `random<T>`, RPIT futures, associated types) and the sim is
test-only, so `enum`/`dyn` dispatch buys nothing. Where generics hurt, erase at a
boundary (the existing `Arc<dyn TransportHandle>` precedent).

**Crate graph.**
- New leaf crate **`moonpool-assertions`** (pure std, zero deps, wasm-able): the
  assertion accounting lifted out of the explorer. Heap table by default; the
  explorer overlays `MAP_SHARED` + a discovery hook.
- **`moonpool-explorer`** (libc/fork/mmap) is now optional behind `moonpool-sim`'s
  `exploration` feature (default ON). Off ⇒ the sim compiles to wasm.
- **`moonpool-core`** granular tokio features (`tokio-task`/`-time`/`-net`/`-fs`/
  `-random`) under an umbrella `tokio-providers`.

**Portability fixes:** explorer gated; three wall-clock sites shimmed
(`Instant::now()`/`SystemTime::now()` panic on wasm); tokio narrowed to
`rt`/`sync`/`macros`; `rand` default-features off (seeded ChaCha8, no getrandom).
**Unknown A resolved at runtime:** current-thread `block_on` never parks under
wasm because the simulation is ready-driven.

**Production DX:** facade `default = ["sim","tokio","transport"]`; the lean prod
stanza (`default-features=false, features=["tokio","transport"]`) pulls no
sim/explorer/assertions. `TokioTransport` alias + `Builder::tokio()`, preludes,
and a `retrying_worker` example that runs on Tokio and under simulation.

**Browser demo (`moonpool-wasm-demo`):** one seed of two nodes trading ping/pong
RPCs over the **real transport stack** on the **simulated** network, animated in
a tab. A generic `TimelineRecorder` invariant rebuilds the message timeline from
standard `client_*` trace events, so the workload carries no visualization code.
The same seed reproduces **byte-identically** native and in-browser.

**Docs:** new book chapter "Simulation in the Browser" (with the demo embedded
live), a production chapter, updated README/architecture, and `release-plz`
includes `moonpool-assertions`.

**CI:** a `portability` job (no-default clippy/tests, wasm `cargo check` for
`moonpool-sim`/`-assertions`, and a lean-prod `cargo tree` guard); the Pages
workflow builds the wasm demo before `mdbook build`.

## Verification

- `cargo fmt` / `clippy --workspace --all-targets -- -D warnings` (pedantic) /
  `nextest --workspace` → **532 pass, 1 skip**.
- `-p moonpool-sim --no-default-features`: clippy + tests; `cargo check --target
  wasm32-unknown-unknown` for `moonpool-sim` and `moonpool-assertions`.
- `moonpool-wasm-demo`: native bin + tests; release wasm runs in chromium;
  native↔browser JSON **byte-identical** for seeds 7 / 42 / 256.
- `mdbook build` clean; the embedded demo runs from the book asset path.
- Lean production `cargo tree` excludes sim/explorer/assertions.

## Notes

- macOS: core/sim/transport/assertions expected to build and run as-is;
  fork-based exploration is best-effort there (documented fallback:
  `moonpool-sim = { default-features = false }`).
- `Cargo.lock` changes are worth a glance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
