### PR TITLE
feat(moonpool-sim): swarm testing — per-seed fault-family subsets (core)

### DIFF
--- a/book/src/part3-building/04-simulation-builder.md
+++ b/book/src/part3-building/04-simulation-builder.md
@@ -173,6 +173,12 @@ For additional chaos, enable randomized network configuration:
 
 This varies latency, packet delay distributions, and other network parameters per iteration, based on the seed. Without this flag, the network uses default configuration (consistent, low-latency).
 
+For stronger coverage, use `.swarm()` instead. It enables a random **subset** of network fault families per seed, fully disabling the rest, rather than turning every fault slightly on at once. This defeats passive suppression, where active faults crowd each other out and the extreme single-family configs that surface bugs almost never occur. See [Network Faults](10-network-faults.md#swarm-testing-less-is-more) for the full reasoning.
+
+```rust
+.swarm()
+```
+
 ## Putting It All Together
 
 A production-grade simulation configuration looks like this:

--- a/book/src/part3-building/10-network-faults.md
+++ b/book/src/part3-building/10-network-faults.md
@@ -102,3 +102,23 @@ config.chaos.partition_probability = 0.05;
 config.chaos.partition_strategy = PartitionStrategy::IsolateSingle;
 // Everything else at defaults
 ```
+
+## Swarm Testing: Less Is More
+
+There is a subtle trap hiding inside `random_for_seed()`. It sets **every** fault family to a random non-zero probability. Clogging is a little bit on, partitions are a little bit on, bit flips are a little bit on, all at once, on every seed. That sounds thorough. It is actually the opposite.
+
+The problem is called **passive suppression**, and it comes straight from the "Swarm Testing" paper by Groce and colleagues (ISSTA 2012), popularized by Will Wilson's Antithesis talks. When every feature is always slightly active, the features crowd each other out. To find a clogging bug you often need clogging cranked hard, for a sustained stretch, with nothing else interfering. If partitions keep tearing down the connection you were trying to clog, you never drive clogging deep enough to hit its bug. The undirected default explores a narrow band in the middle of the configuration space and never visits the extremes where bugs actually live. In the paper, undirected swarm testing found **42% more distinct compiler crashes** than a heavily hand-tuned default.
+
+The fix is counterintuitive: for each run, turn **off** a random subset of fault families entirely. Each seed enables roughly half the families and fully disables the rest. One seed is clogging-only. Another is partition-plus-bitflip. Another is the all-off no-fault baseline. Across many seeds you cover the single-family extremes that the all-on config can never reach.
+
+```rust
+SimulationBuilder::new()
+    .swarm() // each seed enables a random subset of fault families
+    // ...
+```
+
+`.swarm()` builds on `random_for_seed()`, then masks each of the seven network fault families to off with 50% probability: clog, partition, bit-flip, random-close, connect-failure, clock-drift, and buggified-delay. The all-off subset is allowed on purpose, because a pure no-fault run is a useful, valid config.
+
+The interesting engineering detail is **where the randomness comes from**. Swarm decisions must not perturb the in-run randomness, or they would shift every fault's timing and break fork-explorer replay. So the subset is drawn from a separate `CONFIG_RNG` stream, seeded from the iteration seed but salted to decorrelate it from the main `SIM_RNG`. The config RNG never advances the in-run call counter. Same seed, same subset, every time, with zero effect on the simulation that follows.
+
+You already met a tiny version of this idea earlier in the chapter. Connect failures have always had a one-in-three chance of being fully disabled per seed. Swarm testing simply generalizes that one disabled branch to every fault family at once.

--- a/moonpool-sim/src/network/config.rs
+++ b/moonpool-sim/src/network/config.rs
@@ -79,7 +79,7 @@
 //! - Clock drift: FDB sim2.actor.cpp:1058-1064
 //! - Connect failures: FDB sim2.actor.cpp:1243-1250
 
-use crate::sim::rng::{sim_random_range, sim_random_range_or_default};
+use crate::sim::rng::{config_random_bool, sim_random_range, sim_random_range_or_default};
 use std::ops::Range;
 use std::time::Duration;
 
@@ -310,6 +310,49 @@ impl ChaosConfiguration {
             },
         }
     }
+
+    /// Create a swarm-testing chaos configuration for seed-based testing.
+    ///
+    /// Starts from [`random_for_seed`](Self::random_for_seed), then disables each
+    /// fault family with ~50% probability (drawn from the independent `CONFIG_RNG`
+    /// stream). This implements *swarm testing* (Groce et al., ISSTA 2012): each
+    /// seed exercises a random *subset* of fault families — including the all-off
+    /// subset — instead of every family being slightly on at once (which lets
+    /// families crowd each other out, the passive-suppression anti-pattern).
+    #[must_use]
+    pub fn swarm_for_seed() -> Self {
+        let mut chaos = Self::random_for_seed();
+        chaos.apply_swarm_mask();
+        chaos
+    }
+
+    /// Disable each fault family with ~50% probability using the `CONFIG_RNG`
+    /// stream (see [`swarm_for_seed`](Self::swarm_for_seed)).
+    ///
+    /// Draws exactly seven `config_random_bool` values (one per family) so the
+    /// `CONFIG_RNG` call sequence is fixed and reproducible per seed. Durations,
+    /// cooldowns, and strategy stay as sampled — they are inert once their family
+    /// is off.
+    fn apply_swarm_mask(&mut self) {
+        if !config_random_bool(0.5) {
+            self.clog_probability = 0.0;
+        }
+        if !config_random_bool(0.5) {
+            self.partition_probability = 0.0;
+        }
+        if !config_random_bool(0.5) {
+            self.bit_flip_probability = 0.0;
+        }
+        if !config_random_bool(0.5) {
+            self.random_close_probability = 0.0;
+        }
+        if !config_random_bool(0.5) {
+            self.connect_failure_mode = ConnectFailureMode::Disabled;
+            self.connect_failure_probability = 0.0;
+        }
+        self.clock_drift_enabled = config_random_bool(0.5);
+        self.buggified_delay_enabled = config_random_bool(0.5);
+    }
 }
 
 /// Configuration for network simulation parameters
@@ -377,6 +420,19 @@ impl NetworkConfiguration {
         }
     }
 
+    /// Create a swarm-testing network configuration for seed-based testing.
+    ///
+    /// Identical to [`random_for_seed`](Self::random_for_seed) for the baseline
+    /// latencies, but the embedded [`ChaosConfiguration`] enables only a random
+    /// *subset* of fault families per seed. See
+    /// [`ChaosConfiguration::swarm_for_seed`].
+    #[must_use]
+    pub fn swarm_for_seed() -> Self {
+        let mut config = Self::random_for_seed();
+        config.chaos.apply_swarm_mask();
+        config
+    }
+
     /// Create a configuration optimized for fast local testing
     #[must_use]
     pub fn fast_local() -> Self {
@@ -390,5 +446,97 @@ impl NetworkConfiguration {
             write_latency: one_us..one_us,
             chaos: ChaosConfiguration::disabled(),
         }
+    }
+}
+
+#[cfg(test)]
+mod swarm_tests {
+    use super::{ChaosConfiguration, ConnectFailureMode, NetworkConfiguration};
+    use crate::sim::rng::{reset_sim_rng, set_config_seed, set_sim_seed};
+
+    /// The on/off state of each swarmed fault family, in mask order.
+    fn enabled_families(chaos: &ChaosConfiguration) -> [bool; 7] {
+        [
+            chaos.clog_probability > 0.0,
+            chaos.partition_probability > 0.0,
+            chaos.bit_flip_probability > 0.0,
+            chaos.random_close_probability > 0.0,
+            chaos.connect_failure_mode != ConnectFailureMode::Disabled,
+            chaos.clock_drift_enabled,
+            chaos.buggified_delay_enabled,
+        ]
+    }
+
+    /// Build a swarm config the way the runner does: both streams seeded per iteration.
+    fn swarm_for(seed: u64) -> NetworkConfiguration {
+        reset_sim_rng();
+        set_sim_seed(seed);
+        set_config_seed(seed);
+        NetworkConfiguration::swarm_for_seed()
+    }
+
+    #[test]
+    fn swarm_subset_is_deterministic_per_seed() {
+        for seed in [0_u64, 1, 42, 12_345] {
+            let first = enabled_families(&swarm_for(seed).chaos);
+            let second = enabled_families(&swarm_for(seed).chaos);
+            assert_eq!(
+                first, second,
+                "swarm subset must be reproducible for seed {seed}"
+            );
+        }
+    }
+
+    #[test]
+    fn swarm_reaches_all_off_and_mixed_subsets() {
+        let mut saw_all_off = false;
+        let mut saw_mixed = false;
+
+        for seed in 0..1000_u64 {
+            let families = enabled_families(&swarm_for(seed).chaos);
+            let on = families.iter().filter(|&&e| e).count();
+            if on == 0 {
+                saw_all_off = true;
+            }
+            if on > 0 && on < families.len() {
+                saw_mixed = true;
+            }
+            if saw_all_off && saw_mixed {
+                break;
+            }
+        }
+
+        assert!(
+            saw_all_off,
+            "no seed in 0..1000 produced the all-off subset"
+        );
+        assert!(saw_mixed, "no seed in 0..1000 produced a mixed subset");
+    }
+
+    #[test]
+    fn swarm_all_off_seed_has_zero_fault_probabilities() {
+        // Find a seed whose subset is entirely off, then assert every family is inert.
+        let seed = (0..1000_u64)
+            .find(|&s| enabled_families(&swarm_for(s).chaos).iter().all(|&e| !e))
+            .expect("expected an all-off seed within 0..1000");
+
+        let chaos = swarm_for(seed).chaos;
+        assert_zero(chaos.clog_probability);
+        assert_zero(chaos.partition_probability);
+        assert_zero(chaos.bit_flip_probability);
+        assert_zero(chaos.random_close_probability);
+        assert_eq!(chaos.connect_failure_mode, ConnectFailureMode::Disabled);
+        assert_zero(chaos.connect_failure_probability);
+        assert!(!chaos.clock_drift_enabled);
+        assert!(!chaos.buggified_delay_enabled);
+    }
+
+    /// Assert an f64 is exactly `+0.0` (bit-exact, avoiding the float-cmp lint).
+    fn assert_zero(value: f64) {
+        assert_eq!(
+            value.to_bits(),
+            0.0_f64.to_bits(),
+            "expected 0.0, got {value}"
+        );
     }
 }

--- a/moonpool-sim/src/runner/builder.rs
+++ b/moonpool-sim/src/runner/builder.rs
@@ -338,6 +338,7 @@ pub struct SimulationBuilder {
     attrition: Option<Attrition>,
     seeds: Vec<u64>,
     use_random_config: bool,
+    use_swarm_config: bool,
     invariants: Vec<Box<dyn Invariant + Send>>,
     fault_injectors: Vec<Box<dyn FaultInjector>>,
     chaos_duration: Option<Duration>,
@@ -364,6 +365,7 @@ impl SimulationBuilder {
             attrition: None,
             seeds: Vec::new(),
             use_random_config: false,
+            use_swarm_config: false,
             invariants: Vec::new(),
             fault_injectors: Vec::new(),
             chaos_duration: None,
@@ -653,6 +655,23 @@ impl SimulationBuilder {
         self
     }
 
+    /// Enable swarm testing: each seed enables a random *subset* of network
+    /// fault families (~50% each, the rest fully off), including the all-off
+    /// subset.
+    ///
+    /// This defeats passive suppression — when every fault is always slightly on
+    /// (as with [`random_network`](Self::random_network)) families crowd each
+    /// other out and the extreme single-family configs that surface bugs almost
+    /// never occur. Subset decisions are drawn from a dedicated `CONFIG_RNG`
+    /// stream, so they are reproducible per seed yet never perturb in-run
+    /// randomness or fork-explorer replay. Takes precedence over
+    /// `random_network`.
+    #[must_use]
+    pub fn swarm(mut self) -> Self {
+        self.use_swarm_config = true;
+        self
+    }
+
     /// Enable fork-based multiverse exploration.
     ///
     /// When enabled, the simulation will fork child processes at assertion
@@ -762,10 +781,17 @@ impl SimulationBuilder {
         })
     }
 
-    /// Build a `SimWorld` for the iteration, picking a randomised or default
-    /// network configuration.
-    fn build_sim_for_iteration(use_random: bool, seed: u64) -> crate::sim::SimWorld {
-        let network_config = if use_random {
+    /// Build a `SimWorld` for the iteration, picking a swarm-subset, randomised,
+    /// or default network configuration. `use_swarm` takes precedence over
+    /// `use_random`.
+    fn build_sim_for_iteration(
+        use_random: bool,
+        use_swarm: bool,
+        seed: u64,
+    ) -> crate::sim::SimWorld {
+        let network_config = if use_swarm {
+            crate::NetworkConfiguration::swarm_for_seed()
+        } else if use_random {
             crate::NetworkConfiguration::random_for_seed()
         } else {
             crate::NetworkConfiguration::default()
@@ -955,6 +981,9 @@ impl SimulationBuilder {
         obs_handle.reset_for_seed();
         crate::sim::reset_sim_rng();
         crate::sim::set_sim_seed(seed);
+        // Seed the independent config RNG that drives swarm-subset decisions.
+        // Runs before `build_sim_for_iteration`, so `swarm_for_seed()` sees it.
+        crate::sim::set_config_seed(seed);
         crate::chaos::reset_always_violations();
         // Use moderate probabilities: 50% activation rate, 25% firing rate.
         crate::chaos::buggify_init(0.5, 0.25);
@@ -1284,7 +1313,8 @@ impl SimulationBuilder {
             .as_ref()
             .map(Self::resolve_process_config);
 
-        let sim = Self::build_sim_for_iteration(self.use_random_config, seed);
+        let sim =
+            Self::build_sim_for_iteration(self.use_random_config, self.use_swarm_config, seed);
         let start_time = Instant::now();
         let fault_injectors =
             Self::collect_fault_injectors(&mut self.fault_injectors, self.attrition.as_ref());

--- a/moonpool-sim/src/sim/mod.rs
+++ b/moonpool-sim/src/sim/mod.rs
@@ -25,7 +25,8 @@ pub use events::{
     ConnectionStateChange, Event, EventQueue, NetworkOperation, ScheduledEvent, StorageOperation,
 };
 pub use rng::{
-    clear_rng_breakpoints, current_sim_seed, reset_rng_call_count, reset_sim_rng, rng_call_count,
+    clear_rng_breakpoints, config_random_bool, config_random_f64, current_sim_seed,
+    reset_config_rng, reset_rng_call_count, reset_sim_rng, rng_call_count, set_config_seed,
     set_rng_breakpoints, set_sim_seed, sim_random, sim_random_range, sim_random_range_or_default,
 };
 pub use sleep::SleepFuture;

--- a/moonpool-sim/src/sim/rng.rs
+++ b/moonpool-sim/src/sim/rng.rs
@@ -38,7 +38,21 @@ thread_local! {
     /// Each entry is `(target_count, new_seed)`. When the call count exceeds
     /// `target_count`, the RNG reseeds with `new_seed` and the count resets to 1.
     static RNG_BREAKPOINTS: RefCell<VecDeque<(u64, u64)>> = const { RefCell::new(VecDeque::new()) };
+
+    /// Thread-local configuration RNG, independent of [`SIM_RNG`].
+    ///
+    /// Drives swarm-testing subset decisions (which fault families are enabled
+    /// per seed). It deliberately does NOT go through [`pre_sample`], so it has
+    /// no effect on the [`SIM_RNG`] call count or breakpoint replay — config
+    /// decisions can never perturb in-run randomness or fork-explorer replay.
+    static CONFIG_RNG: RefCell<ChaCha8Rng> = RefCell::new(ChaCha8Rng::seed_from_u64(0));
 }
+
+/// Salt mixed into the iteration seed before seeding [`CONFIG_RNG`].
+///
+/// Decorrelates config (swarm-subset) decisions from the in-run [`SIM_RNG`]
+/// stream while keeping both fully reproducible from the same iteration seed.
+const CONFIG_RNG_SALT: u64 = 0x6D6F_6F6E_7377_726D; // "moonswrm"
 
 /// Increment the RNG call counter and check for breakpoints.
 ///
@@ -244,6 +258,42 @@ pub fn set_rng_breakpoints(breakpoints: Vec<(u64, u64)>) {
 /// Clear all RNG breakpoints.
 pub fn clear_rng_breakpoints() {
     RNG_BREAKPOINTS.with(|bp| bp.borrow_mut().clear());
+}
+
+/// Seed the thread-local configuration RNG from an iteration seed.
+///
+/// The seed is mixed with [`CONFIG_RNG_SALT`] so swarm-subset decisions are
+/// decorrelated from [`SIM_RNG`] yet remain reproducible per iteration seed.
+/// Unlike [`set_sim_seed`], this does not touch the call counter or breakpoints.
+pub fn set_config_seed(seed: u64) {
+    CONFIG_RNG.with(|rng| {
+        *rng.borrow_mut() = ChaCha8Rng::seed_from_u64(seed ^ CONFIG_RNG_SALT);
+    });
+}
+
+/// Reset the configuration RNG to its initial (seed 0) state.
+pub fn reset_config_rng() {
+    CONFIG_RNG.with(|rng| {
+        *rng.borrow_mut() = ChaCha8Rng::seed_from_u64(0);
+    });
+}
+
+/// Generate a random f64 in `[0.0, 1.0)` using the configuration RNG.
+///
+/// Independent of [`SIM_RNG`]: it does not increment the RNG call count and is
+/// invisible to breakpoint replay.
+#[must_use]
+pub fn config_random_f64() -> f64 {
+    CONFIG_RNG.with(|rng| rng.borrow_mut().sample(StandardUniform))
+}
+
+/// Return `true` with probability `p`, drawn from the configuration RNG.
+///
+/// Used for swarm-subset decisions (e.g. "enable this fault family?"). Always
+/// consumes exactly one [`CONFIG_RNG`] draw regardless of the outcome.
+#[must_use]
+pub fn config_random_bool(p: f64) -> bool {
+    config_random_f64() < p
 }
 
 #[cfg(test)]
@@ -500,6 +550,51 @@ mod tests {
 
         assert_f64_eq(post_fork_1, replay_1);
         assert_f64_eq(post_fork_2, replay_2);
+    }
+
+    #[test]
+    fn test_config_rng_does_not_perturb_sim_rng() {
+        // Control: SIM_RNG sequence with no CONFIG_RNG draws interleaved.
+        reset_sim_rng();
+        set_sim_seed(42);
+        let control: Vec<f64> = (0..5).map(|_| sim_random::<f64>()).collect();
+        let control_count = rng_call_count();
+
+        // Experiment: interleave CONFIG_RNG draws between every SIM_RNG draw.
+        reset_sim_rng();
+        set_sim_seed(42);
+        set_config_seed(42);
+        let mut experiment = Vec::new();
+        for _ in 0..5 {
+            let _ = config_random_bool(0.5);
+            let _ = config_random_f64();
+            experiment.push(sim_random::<f64>());
+        }
+
+        // CONFIG_RNG must not perturb the SIM_RNG sequence or its call count.
+        for (c, e) in control.iter().zip(experiment.iter()) {
+            assert_f64_eq(*c, *e);
+        }
+        assert_eq!(rng_call_count(), control_count);
+    }
+
+    #[test]
+    fn test_config_rng_determinism_and_independence_from_seed() {
+        // Same config seed -> same CONFIG_RNG sequence.
+        set_config_seed(7);
+        let a: Vec<f64> = (0..4).map(|_| config_random_f64()).collect();
+        set_config_seed(7);
+        let b: Vec<f64> = (0..4).map(|_| config_random_f64()).collect();
+        for (x, y) in a.iter().zip(b.iter()) {
+            assert_f64_eq(*x, *y);
+        }
+
+        // Salting decorrelates CONFIG_RNG from a same-numbered SIM_RNG seed.
+        set_sim_seed(7);
+        let sim_first: f64 = sim_random();
+        set_config_seed(7);
+        let config_first = config_random_f64();
+        assert_f64_ne(sim_first, config_first);
     }
 
     #[test]

--- a/moonpool-sim/tests/chaos.rs
+++ b/moonpool-sim/tests/chaos.rs
@@ -14,3 +14,5 @@ mod clock_drift;
 mod connect_failure;
 #[path = "chaos/random_close.rs"]
 mod random_close;
+#[path = "chaos/swarm.rs"]
+mod swarm;

--- a/moonpool-sim/tests/chaos/swarm.rs
+++ b/moonpool-sim/tests/chaos/swarm.rs
@@ -1,0 +1,55 @@
+//! End-to-end integration test for swarm testing (`SimulationBuilder::swarm`).
+//!
+//! Verifies that the swarm-subset wiring (per-seed `CONFIG_RNG` seeding plus the
+//! swarm branch in `build_sim_for_iteration`) drives a full run cleanly across
+//! many seeds: every seed builds its own per-seed fault subset and the
+//! orchestrator completes. The per-seed subset logic itself (which families are
+//! enabled, determinism, the all-off case) is unit-tested in
+//! `moonpool-sim/src/network/config.rs`.
+//!
+//! The workload deliberately does not open connections. Under some swarm subsets
+//! `ConnectFailureMode::Probabilistic` makes `connect()` hang forever — correct
+//! chaos behavior, but it would make this plumbing test depend on which subsets
+//! the entropy-seeded iteration happens to draw. `bind()` has no failure mode,
+//! so it exercises the swarm-configured network provider without that coupling.
+
+use async_trait::async_trait;
+use moonpool_sim::{NetworkProvider, SimContext, SimulationBuilder, Workload};
+
+/// Minimal workload: touches the swarm-configured network provider via `bind`
+/// and fires a coverage gate. Always completes, regardless of fault subset.
+struct SwarmSmokeWorkload;
+
+#[async_trait]
+impl Workload for SwarmSmokeWorkload {
+    fn name(&self) -> &'static str {
+        "client"
+    }
+
+    async fn run(&mut self, ctx: &SimContext) -> moonpool_sim::SimulationResult<()> {
+        moonpool_sim::assert_sometimes!(true, "swarm run reached workload");
+        // bind has no failure/hang mode, so this can't deadlock under any subset.
+        if let Ok(listener) = ctx.network().bind("server").await {
+            drop(listener);
+        }
+        Ok(())
+    }
+}
+
+/// A swarm run over many seeds must build a per-seed subset and complete every
+/// seed without deadlocks, panics, or orchestration failures.
+#[test]
+fn swarm_runs_clean_across_seeds() {
+    let report = SimulationBuilder::new()
+        .swarm()
+        .set_iterations(50)
+        .workload(SwarmSmokeWorkload)
+        .run();
+
+    assert_eq!(
+        report.failed_runs, 0,
+        "swarm run had {} failed seeds",
+        report.failed_runs
+    );
+    assert_eq!(report.iterations, 50, "expected all 50 seeds to run");
+}


### PR DESCRIPTION
## What & why

Per-seed network chaos randomization (`ChaosConfiguration::random_for_seed()`) set **every** fault family to a random non-zero probability — nothing was ever fully off. That is the textbook **passive-suppression** anti-pattern from the "Swarm Testing" paper (Groce et al., ISSTA 2012): when every fault is always slightly on, families crowd each other out and the single-family-cranked configs that actually surface bugs almost never occur.

This adds an opt-in `.swarm()` builder method: each seed enables a random **subset** of fault families (~50% each, the rest fully off, all-off allowed) — restoring the extremes the all-on baseline can never reach.

This is the **foundational** piece of the swarm-testing epic (#131); #129 (workload op-alphabet swarm) and #130 (attrition + storage swarm) build on the `CONFIG_RNG` mechanism introduced here.

## Design

- **`CONFIG_RNG` stream** (`sim/rng.rs`): a second ChaCha8 stream that drives swarm-subset decisions. Seeded from the iteration seed but **salted** to decorrelate it from `SIM_RNG`, and it deliberately bypasses `pre_sample()` — so swarm decisions never perturb in-run randomness, the RNG call count, or fork-explorer breakpoint replay. Proven by test.
- **`swarm_for_seed()`** (`network/config.rs`): reuses the existing `random_for_seed()` values, then masks each of the 7 fault families to off with 50% probability (`apply_swarm_mask`, exactly 7 `config_random_bool` draws → deterministic). Generalizes the existing 1/3-`Disabled` `ConnectFailureMode` precedent to every family. `random_for_seed()` is left untouched, so `.random_network()` behavior is unchanged.
- **Builder wiring** (`runner/builder.rs`): `.swarm()` opt-in, `set_config_seed()` per iteration, swarm branch in `build_sim_for_iteration` (takes precedence over `random_network`).

## Acceptance criteria (#128)

- [x] `CONFIG_RNG` stream seeded per iteration, independent of `SIM_RNG` (no perturbation of call counts / breakpoints)
- [x] Each fault family set to `0.0` with ~50% probability, else its existing random value
- [x] `.swarm()` opt-in + determinism test (same seed → identical enabled-family set)
- [x] All-off subset produces zero injected network faults

## Tests

- `CONFIG_RNG` independence (no `SIM_RNG` perturbation) + salt decorrelation
- Per-seed determinism of the enabled-family set
- Subset reachability across seeds 0..1000 (all-off **and** mixed both occur)
- All-off seed → every family probability is exactly zero / `Disabled` / `false`
- End-to-end `.swarm()` builder smoke test over 50 seeds

## Validation

- `cargo fmt`, `cargo clippy --all-targets -- -D warnings` (pedantic), `cargo nextest run` (538 passed)
- Portability gates: `moonpool-sim --no-default-features` clippy + `wasm32-unknown-unknown` check
- `mdbook build book/` (new "Swarm Testing" section in the network-faults chapter)

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)