### PR TITLE
feat(moonpool-sim): per-pair permanent latency (FDB SimClogging)

### DIFF
--- a/book/src/appendix/03-configuration.md
+++ b/book/src/appendix/03-configuration.md
@@ -139,6 +139,14 @@ All fault injection settings for the simulated network. Part of `NetworkConfigur
 | `clog_probability` | `f64` | 0.0 |
 | `clog_duration` | `Range<Duration>` | 100ms..300ms |
 
+### Per-Pair Permanent Latency
+
+| Field | Type | Default |
+|-------|------|---------|
+| `max_pair_latency` | `Range<Duration>` | `ZERO..ZERO` (off) |
+
+Each ordered IP pair samples one fixed latency from this range at first contact and adds it to every delivery on that pair for the whole run (FoundationDB's `SimClogging`). An all-zero range disables it. FDB's `MAX_CLOGGING_LATENCY * random01()` is the `ZERO..MAX` case.
+
 ### Network Partitions
 
 | Field | Type | Default |

--- a/book/src/appendix/04-fault-reference.md
+++ b/book/src/appendix/04-fault-reference.md
@@ -30,6 +30,7 @@ Configured via `ChaosConfiguration` (nested under `NetworkConfiguration::chaos`)
 | Slow latency spike | `slow_latency_probability` | 0.1% (bimodal mode only) | GC pauses, cross-datacenter hops |
 | Slow latency multiplier | `slow_latency_multiplier` | 10x normal | Magnitude of tail latency spikes |
 | Write clogging | `clog_probability` / `clog_duration` | 0%, 100-300ms | Backpressure handling, flow control |
+| Per-pair permanent latency | `max_pair_latency` | `ZERO..ZERO` (off) | One stably-slow peer blocking quorum, asymmetric link delay |
 | Clock drift | `clock_drift_enabled` / `clock_drift_max` | enabled, 100ms | Lease expiration, distributed consensus, TTL handling |
 | Buggified delay | `buggified_delay_probability` / `buggified_delay_max` | 25%, 100ms | Race conditions, timing-dependent bugs |
 | Handshake delay | `handshake_delay_enabled` / `handshake_delay_max` | enabled, 10ms | TLS negotiation, connection startup overhead |

--- a/book/src/part3-building/10-network-faults.md
+++ b/book/src/part3-building/10-network-faults.md
@@ -18,6 +18,8 @@ Every network operation (bind, accept, connect, read, write) has a configurable 
 
 For tail latency testing, moonpool supports **bimodal latency distribution**, following FoundationDB's `halfLatency()` pattern. In bimodal mode, 99.9% of operations use normal latency, but 0.1% experience latencies multiplied by 5x to 20x. This is how real networks behave: most requests are fast, but a small fraction hit GC pauses, cross-datacenter hops, or congestion.
 
+Re-sampling latency per operation has a blind spot: no single connection ever stays slow. Real clusters break differently. One machine sits behind a degraded switch port and every message to it lags, run after run, while the rest of the fleet is healthy. That **stably-slow peer** is exactly what stalls a quorum or reorders a consensus round, and uniform per-operation jitter never produces it. So moonpool borrows FoundationDB's `SimClogging` trick: set `max_pair_latency` to a range and each ordered IP pair draws **one** fixed latency at first contact, then carries it for the whole run. Off by default (`ZERO..ZERO`), it adds nothing. Turn it on and some pairs are permanently sluggish while others are quick, which is how you find the bug where the slow replica is the one holding the lease.
+
 ### Connection Drops
 
 Random close injects spontaneous connection failures during I/O operations, at a configurable probability (default 0.001%). When triggered, 30% of closes are **explicit** (the caller gets an error) and 70% are **silent** (the connection just stops working). This ratio, taken from FoundationDB, tests both error-handling paths and timeout-based failure detection.

--- a/moonpool-sim/src/network/config.rs
+++ b/moonpool-sim/src/network/config.rs
@@ -208,6 +208,14 @@ pub struct ChaosConfiguration {
     /// Probability of connect failure when Probabilistic mode is enabled (default 50%)
     pub connect_failure_probability: f64,
 
+    /// Permanent per-IP-pair latency range (FDB `SimClogging::MAX_CLOGGING_LATENCY`).
+    /// Each ordered IP pair samples a fixed latency from this range at first contact
+    /// (via [`sample_duration`]), then adds it to every delivery on that pair for the
+    /// whole run — modelling a stably-slow link. An all-zero range (`end` is zero)
+    /// disables it, leaving behavior unchanged. FDB's `MAX * random01()` is the
+    /// `ZERO..MAX` case. FDB ref: `sim2.actor.cpp` ~294-299, 352-354.
+    pub max_pair_latency: Range<Duration>,
+
     /// Network partition strategy.
     /// Controls how nodes are selected for partitioning.
     /// `TigerBeetle` ref: `packet_simulator.zig` partition modes
@@ -242,6 +250,7 @@ impl Default for ChaosConfiguration {
             buggified_delay_probability: 0.25, // FDB: random01() < 0.25
             connect_failure_mode: ConnectFailureMode::Probabilistic, // FDB: SIM_CONNECT_ERROR_MODE = 2
             connect_failure_probability: 0.5,                        // FDB: random01() > 0.5
+            max_pair_latency: Duration::ZERO..Duration::ZERO, // FDB: MAX_CLOGGING_LATENCY default 0
             partition_strategy: PartitionStrategy::default(),
         }
     }
@@ -271,6 +280,7 @@ impl ChaosConfiguration {
             buggified_delay_probability: 0.25,
             connect_failure_mode: ConnectFailureMode::Disabled,
             connect_failure_probability: 0.5,
+            max_pair_latency: Duration::ZERO..Duration::ZERO,
             partition_strategy: PartitionStrategy::Random, // Default strategy
         }
     }
@@ -308,6 +318,10 @@ impl ChaosConfiguration {
                 1 => PartitionStrategy::UniformSize,
                 _ => PartitionStrategy::IsolateSingle,
             },
+            // Permanent per-pair latency, randomized upper bound up to 100ms (FDB
+            // buggifies MAX_CLOGGING_LATENCY to 0.1s). Kept last so existing RNG
+            // draws above are unaffected.
+            max_pair_latency: Duration::ZERO..Duration::from_millis(sim_random_range(0..100)),
         }
     }
 
@@ -329,7 +343,7 @@ impl ChaosConfiguration {
     /// Disable each fault family with ~50% probability using the `CONFIG_RNG`
     /// stream (see [`swarm_for_seed`](Self::swarm_for_seed)).
     ///
-    /// Draws exactly seven `config_random_bool` values (one per family) so the
+    /// Draws exactly eight `config_random_bool` values (one per family) so the
     /// `CONFIG_RNG` call sequence is fixed and reproducible per seed. Durations,
     /// cooldowns, and strategy stay as sampled — they are inert once their family
     /// is off.
@@ -352,6 +366,10 @@ impl ChaosConfiguration {
         }
         self.clock_drift_enabled = config_random_bool(0.5);
         self.buggified_delay_enabled = config_random_bool(0.5);
+        // Appended last: keeps the seven draws above stable across seeds.
+        if !config_random_bool(0.5) {
+            self.max_pair_latency = Duration::ZERO..Duration::ZERO;
+        }
     }
 }
 

--- a/moonpool-sim/src/network/sim/provider.rs
+++ b/moonpool-sim/src/network/sim/provider.rs
@@ -129,6 +129,11 @@ impl NetworkProvider for SimNetworkProvider {
         // Create a connection pair for bidirectional communication
         let (client_id, server_id) = sim.create_connection_pair("client-addr", addr);
 
+        // FDB SimClogging: fix a permanent per-pair latency at first contact, for
+        // both directions. No-op (returns ZERO, no RNG) when max_pair_latency is off.
+        let _ = sim.connection_base_latency(client_id);
+        let _ = sim.connection_base_latency(server_id);
+
         // Store the server side for accept() to pick up later
         sim.store_pending_connection(addr, server_id);
 

--- a/moonpool-sim/src/sim/world.rs
+++ b/moonpool-sim/src/sim/world.rs
@@ -1353,6 +1353,8 @@ impl SimWorld {
         let next_send_time = conn.next_send_time;
         let has_data = !conn.send_buffer.is_empty();
         let is_stable = conn.flags.is_stable(); // For stable connection checks
+        let local_ip = conn.local_ip;
+        let remote_ip = conn.remote_ip;
 
         let recv_delay = paired_id.and_then(|pid| {
             inner
@@ -1361,6 +1363,19 @@ impl SimWorld {
                 .get(&pid)
                 .and_then(|c| c.recv_delay)
         });
+
+        // Permanent per-pair latency, memoized at connect (FDB SimClogging). Pure
+        // map read on a field disjoint from `connections`; ZERO when the feature is
+        // off (map empty) or endpoints are unknown.
+        let pair_extra = match (local_ip, remote_ip) {
+            (Some(src), Some(dst)) => inner
+                .network
+                .pair_latencies
+                .get(&(src, dst))
+                .copied()
+                .unwrap_or(Duration::ZERO),
+            _ => Duration::ZERO,
+        };
 
         if !has_data {
             if let Some(conn) = inner.network.connections.get_mut(&connection_id) {
@@ -1420,7 +1435,7 @@ impl SimWorld {
 
         // Schedule data delivery to paired connection
         if let Some(paired_id) = paired_id {
-            let scheduled_time = earliest_time + recv_delay.unwrap_or(Duration::ZERO);
+            let scheduled_time = earliest_time + recv_delay.unwrap_or(Duration::ZERO) + pair_extra;
             let sequence = inner.next_sequence;
             inner.next_sequence += 1;
 
@@ -1976,39 +1991,46 @@ impl SimWorld {
             })
     }
 
-    /// Get the base latency for a connection based on its IP pair.
-    /// If not set, samples from config and sets it.
+    /// Get the permanent per-pair base latency for a connection, memoizing it on
+    /// first contact (FDB `SimClogging`).
+    ///
+    /// Returns [`Duration::ZERO`] — without drawing from the RNG or touching the
+    /// pair map — when the `max_pair_latency` range is disabled (its `end` is zero)
+    /// or the connection's endpoints are unknown. Otherwise samples a fixed latency
+    /// from `max_pair_latency` once per ordered IP pair and reuses it for the run.
     ///
     /// # Panics
     ///
     /// Panics if the simulation lock is poisoned by a prior task panic.
     #[must_use]
     pub fn connection_base_latency(&self, connection_id: ConnectionId) -> Duration {
+        let range = self.with_network_config(|config| config.chaos.max_pair_latency.clone());
+        if range.end.is_zero() {
+            return Duration::ZERO;
+        }
+
         let inner = self
             .inner
             .read()
             .expect("RwLock poisoned: prior task panicked");
-        let (local_ip, remote_ip) = inner
+        let endpoints = inner
             .network
             .connections
             .get(&connection_id)
-            .and_then(|conn| Some((conn.local_ip?, conn.remote_ip?)))
-            .unwrap_or({
-                (
-                    IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED),
-                    IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED),
-                )
-            });
+            .and_then(|conn| Some((conn.local_ip?, conn.remote_ip?)));
         drop(inner);
+
+        let Some((local_ip, remote_ip)) = endpoints else {
+            return Duration::ZERO;
+        };
 
         // Check if latency is already set
         if let Some(latency) = self.pair_latency(local_ip, remote_ip) {
             return latency;
         }
 
-        // Sample a new latency from config and set it
-        let latency = self
-            .with_network_config(|config| crate::network::sample_duration(&config.write_latency));
+        // Sample a fixed latency for this pair and memoize it for the whole run.
+        let latency = crate::network::sample_duration(&range);
         self.set_pair_latency_if_not_set(local_ip, remote_ip, latency)
     }
 
@@ -3005,6 +3027,59 @@ mod tests {
 
         assert_eq!(sim.current_time(), Duration::from_millis(300));
         assert!(!sim.has_pending_events());
+    }
+
+    #[test]
+    fn pair_latency_deterministic_per_seed() {
+        use crate::network::{ChaosConfiguration, NetworkConfiguration};
+
+        let client_ip = IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 1, 1));
+        let server_ip = IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 1, 2));
+        let range = Duration::from_millis(10)..Duration::from_millis(50);
+
+        // Build a fast-local config that only enables per-pair latency.
+        let on_config = || NetworkConfiguration {
+            chaos: ChaosConfiguration {
+                max_pair_latency: range.clone(),
+                ..ChaosConfiguration::disabled()
+            },
+            ..NetworkConfiguration::fast_local()
+        };
+
+        // Establish one connection pair and memoize both directions.
+        let assign = || {
+            let sim = SimWorld::new_with_network_config_and_seed(on_config(), 42);
+            let (client, server) = sim.create_connection_pair("10.0.1.1:0", "10.0.1.2:0");
+            let _ = sim.connection_base_latency(client);
+            let _ = sim.connection_base_latency(server);
+            (
+                sim.pair_latency(client_ip, server_ip),
+                sim.pair_latency(server_ip, client_ip),
+            )
+        };
+
+        let first = assign();
+        let second = assign();
+
+        // Same seed -> identical, fully-populated assignments.
+        assert_eq!(first, second, "pair latency must be deterministic per seed");
+        let c2s = first.0.expect("client->server pair latency assigned");
+        let s2c = first.1.expect("server->client pair latency assigned");
+        for latency in [c2s, s2c] {
+            assert!(
+                range.contains(&latency),
+                "pair latency {latency:?} must fall in the configured range {range:?}"
+            );
+        }
+
+        // Disabled range (default) -> no map writes at all.
+        let off =
+            SimWorld::new_with_network_config_and_seed(NetworkConfiguration::fast_local(), 42);
+        let (client, server) = off.create_connection_pair("10.0.1.1:0", "10.0.1.2:0");
+        let _ = off.connection_base_latency(client);
+        let _ = off.connection_base_latency(server);
+        assert_eq!(off.pair_latency(client_ip, server_ip), None);
+        assert_eq!(off.pair_latency(server_ip, client_ip), None);
     }
 
     #[test]


### PR DESCRIPTION
Closes #124.

## Motivation

Moonpool re-samples network latency *per operation*, so no connection ever develops a **persistent asymmetric delay** — missing the "one stably-slow peer blocks quorum" class of timeout/ordering bugs. FoundationDB's `SimClogging` fixes a random latency per IP-pair at first contact and reuses it for the whole run. This wires moonpool to do the same.

The scaffolding (`pair_latencies` map + three helper methods) already existed but was connected to nothing — this is mostly wiring.

## What changed

- **Config knob** — `max_pair_latency: Range<Duration>` on `ChaosConfiguration`. Each ordered IP pair samples one fixed latency from this range at first contact and adds it to every delivery on that pair for the whole run. Off by default (`ZERO..ZERO`) ⇒ no RNG draws, no behavior change; `fast_local()` stays off. FDB's `MAX * random01()` is the `ZERO..MAX` case.
- **Wiring** — `connection_base_latency()` memoizes per pair (RNG-free when off or endpoints unknown); `connect()` populates both directions at first contact; `handle_normal_send()` adds the memoized value to `scheduled_time` (a constant shift on the delivery side — does **not** compound through `next_send_time`).
- **Swarm-aware** — randomized in `random_for_seed()` and 50%-masked in `apply_swarm_mask()`, both **appended last** so existing `SIM_RNG`/`CONFIG_RNG` draw order is unchanged. Under `.swarm()` the family is enabled ~half the seeds and fully off the rest (the Groce et al. swarm extremes); the on/off decision uses the independent `CONFIG_RNG` stream.
- **Test** — `pair_latency_deterministic_per_seed`: same seed → identical, in-range, both-directions populated; off ⇒ map stays empty.
- **Book** — config appendix, fault reference, and a narrative paragraph in the network-faults chapter.

## Validation

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` (pedantic, no `#[allow]`)
- `cargo nextest run` (sim + transport + transport-sim): **443 passed**, incl. `swarm_runs_clean_across_seeds`
- Portability: `clippy -p moonpool-sim --no-default-features`, `cargo check --target wasm32-unknown-unknown -p moonpool-sim --no-default-features`
- `mdbook build book/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)