### PR TITLE
feat(moonpool-sim): swarm testing — workload operation-alphabet subsets

### DIFF
--- a/.claude/skills/writing-a-workload/SKILL.md
+++ b/.claude/skills/writing-a-workload/SKILL.md
@@ -33,6 +33,54 @@ pub trait Workload: 'static {
 - **Reference model**: Track expected state locally, compare on every response
 - **Multiple instances**: `SimulationBuilder::new().workloads(WorkloadCount::Fixed(5), |i| Box::new(...))`
 - **State publishing**: `ctx.state().publish("model", self.model.clone())` after every mutation for invariants
+- **Operation-alphabet swarm**: per-seed subset of the alphabet via `swarm_op_enabled(op_id)` (opt in with `SimulationBuilder::swarm()`)
+
+## Operation-Alphabet Swarm Testing
+
+Picking operations *uniformly over the full alphabet every step* suffers **passive
+suppression**: a bounded queue with 50/50 push/pop is a 1-D random walk that (by
+the Hoeffding bound) needs tens of millions of ops to ever fill, so the
+capacity-overflow bug is never hit. Swarm testing fixes this by enabling a random
+**subset** of the alphabet per seed (the rest fully off), so extreme states
+("only pushes") show up immediately.
+
+`moonpool_sim::swarm_op_enabled(op_id: u8) -> bool` reports whether operation
+`op_id` is in this seed's subset. It is:
+- **Opt-in**: returns `true` for every op unless `SimulationBuilder::swarm()` is
+  set — so default runs use the full alphabet (zero behavior change).
+- **Pure & deterministic**: each op is independently ~50% on, a pure function of
+  `(seed, op_id)`. Query it any number of times in any order — same answer. It
+  consumes **no** RNG (neither `SIM_RNG` nor the fault-family `CONFIG_RNG`), so
+  fork-explorer replay and fault-family swarm are unperturbed.
+
+Pattern — remap a single full-alphabet draw into the enabled subset, preserving
+the per-step `SIM_RNG` call count (critical for deterministic replay — **do not**
+add a resample loop that draws extra RNG):
+
+```rust
+// Cache the enabled subset once per run (idempotent). Empty-mask fallback:
+// if a seed disables everything, fall back to the full alphabet so the
+// workload always has something to do.
+let enabled: Vec<u8> = (0..NUM_OPS).filter(|&i| swarm_op_enabled(i)).collect();
+let enabled = if enabled.is_empty() { (0..NUM_OPS).collect() } else { enabled };
+
+// Per step: one RNG draw, remapped into the subset (== raw % NUM_OPS when full).
+let raw = moonpool_sim::sim_random::<u64>();
+let op = enabled[(raw % enabled.len() as u64) as usize];
+```
+
+Demonstrator: emit a coverage assertion *only on the path where it holds* (so it
+never accrues a 0%-success coverage violation when unreachable):
+
+```rust
+if !enabled.iter().any(|&i| i < NUM_MOVE_OPS) {
+    moonpool_sim::assert_sometimes!(true, "movement suppressed by swarm");
+}
+```
+
+Reference implementation: `moonpool-sim-examples/src/dungeon.rs`
+(`swarm_enabled_actions`, `pick_action_index`). End-to-end test:
+`moonpool-sim/tests/swarm_op_alphabet.rs`.
 
 ## Book Chapters
 

--- a/book/src/part3-building/19-designing-workloads.md
+++ b/book/src/part3-building/19-designing-workloads.md
@@ -54,6 +54,43 @@ match roll {
 
 The percentages are tunable. Start with a heavy normal-operation bias and adjust based on what your `assert_sometimes!` statements tell you about coverage.
 
+## Swarm the Alphabet
+
+A complete alphabet has a hidden failure mode. Picking operations uniformly over the full set on every step means every operation is always slightly active, and they crowd each other out. The classic example is a bounded queue with a 50/50 push/pop mix. That is a one-dimensional random walk, and by the Hoeffding bound it takes tens of millions of operations to drift far enough to ever fill. The capacity-overflow bug is real, reachable, and never hit, because `pop` keeps undoing the progress `push` makes. This is **passive suppression**, the same effect we saw with network faults, now at the level of the workload's own operations.
+
+The fix is the same too. Instead of running every seed with the whole alphabet, enable a random **subset** per seed and turn the rest fully off. Disable `pop` for some runs and the queue fills on the first handful of steps. We call this swarming the alphabet, after the [Swarm Testing](10-network-faults.md#swarm-testing-less-is-more) paper.
+
+`moonpool_sim::swarm_op_enabled(op_id)` tells you whether operation `op_id` is in this seed's subset. Opt in with `SimulationBuilder::swarm()`. Without it, every operation reports enabled, so default runs use the full alphabet and nothing changes.
+
+```rust
+// Cache the subset once per run. Each operation is independently ~50% on,
+// a pure function of (seed, op_id), so this is the same answer every time.
+// Empty-mask fallback: if a seed disables everything, use the full alphabet
+// so the workload always has something to do.
+let enabled: Vec<u8> = (0..NUM_OPS).filter(|&i| swarm_op_enabled(i)).collect();
+let enabled = if enabled.is_empty() { (0..NUM_OPS).collect() } else { enabled };
+
+// Per step: take a single draw and remap it into the enabled subset.
+let raw = moonpool_sim::sim_random::<u64>();
+let op = enabled[(raw % enabled.len() as u64) as usize];
+```
+
+The remap matters. We draw **once** and fold the result into the subset rather than resampling in a loop until we land on an enabled operation. A resample loop would consume a variable number of `SIM_RNG` values per step, and the fork explorer keys its replay on the in-run RNG call count. Keep the per-step draw count fixed and replay stays exact. When the full alphabet is enabled, `enabled[raw % NUM_OPS] == raw % NUM_OPS`, so a non-swarm run is byte-identical to one with no swarm code at all.
+
+Like the fault-family version, these decisions never touch `SIM_RNG`. `swarm_op_enabled` is a pure hash of the seed and the operation id, so it consumes no randomness, the answer is independent of how often or in what order you ask, and the fault-family `CONFIG_RNG` stream is left untouched. The two swarm axes compose: a seed picks both a fault subset and an operation subset, independently.
+
+The payoff is a demonstrator assertion that only the swarm can reach. Emit it on the path where it holds, so it never records a check on the runs where the subset keeps it impossible:
+
+```rust
+// Reachable only when every movement operation was masked off this seed.
+// Under the always-on full alphabet, this can never happen.
+if !enabled.iter().any(|&i| i < NUM_MOVE_OPS) {
+    moonpool_sim::assert_sometimes!(true, "movement suppressed by swarm");
+}
+```
+
+The dungeon example in `moonpool-sim-examples/src/dungeon.rs` is the reference implementation, and `moonpool-sim/tests/swarm_op_alphabet.rs` shows the assertion firing under `.swarm()` and staying unreachable without it.
+
 ## Invariant Patterns
 
 Generating interesting operations is half the problem. The other half is knowing whether the system **behaved correctly** under those operations. Four patterns have proven reliable across many simulation workloads.

--- a/moonpool-sim-examples/src/dungeon.rs
+++ b/moonpool-sim-examples/src/dungeon.rs
@@ -527,6 +527,14 @@ const KEY_FIND_P: f64 = 0.03;
 /// Probability of repeating the previous action (structured rollout).
 const REPEAT_ACTION_P: f64 = 0.70;
 
+/// Size of the action alphabet (see [`dungeon_game::Action::from_index`]):
+/// indices 0..8 are `Move` directions, 8 is `DownStairs`, 9 is `Search`.
+const NUM_ACTIONS: u8 = 10;
+
+/// Number of leading action indices that are `Move` directions. The remaining
+/// actions (`DownStairs`, `Search`) cannot change the player's position.
+const NUM_MOVE_ACTIONS: u8 = 8;
+
 /// Result of a single dungeon step.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StepResult {
@@ -544,6 +552,9 @@ pub struct Dungeon {
     max_steps: u64,
     game: dungeon_game::Game,
     last_action_index: Option<u8>,
+    /// Per-seed enabled subset of the action alphabet (swarm testing). Without
+    /// `.swarm()` this is the full alphabet, so behavior is unchanged.
+    enabled_actions: Vec<u8>,
 }
 
 impl Dungeon {
@@ -556,6 +567,23 @@ impl Dungeon {
             max_steps,
             game: dungeon_game::Game::new(&mut rng, target_level),
             last_action_index: None,
+            enabled_actions: Self::swarm_enabled_actions(),
+        }
+    }
+
+    /// Compute this seed's enabled action subset for operation-alphabet swarm
+    /// testing. Each action is independently enabled ~50% of the time (derived
+    /// from the per-seed swarm state via [`moonpool_sim::swarm_op_enabled`]).
+    /// If a seed would disable every action we fall back to the full alphabet so
+    /// the workload always has something to do (the empty-mask guard).
+    fn swarm_enabled_actions() -> Vec<u8> {
+        let enabled: Vec<u8> = (0..NUM_ACTIONS)
+            .filter(|&i| moonpool_sim::swarm_op_enabled(i))
+            .collect();
+        if enabled.is_empty() {
+            (0..NUM_ACTIONS).collect()
+        } else {
+            enabled
         }
     }
 
@@ -574,10 +602,19 @@ impl Dungeon {
     }
 
     /// Pick the next action index using a structured rollout. Always consumes
-    /// two RNG values per step for deterministic call count.
+    /// exactly two `SIM_RNG` values per step for a deterministic call count
+    /// (preserved across swarm on/off so fork-explorer replay is unperturbed):
+    /// one `u64` for the fresh action, one `f64` for the repeat decision.
+    ///
+    /// The fresh `u64` draw is remapped into the per-seed enabled subset rather
+    /// than the full alphabet. With swarm disabled the subset is the full
+    /// alphabet, so `enabled_actions[raw % 10] == raw % 10` — byte-identical to
+    /// the previous behavior.
     fn pick_action_index(&mut self) -> u8 {
-        let fresh_action_index =
-            u8::try_from(moonpool_sim::sim_random::<u64>() % 10).expect("value < 10 fits in u8");
+        let raw = moonpool_sim::sim_random::<u64>();
+        let span = u64::try_from(self.enabled_actions.len()).expect("alphabet size fits in u64");
+        let idx = usize::try_from(raw % span).expect("modulo result fits in usize");
+        let fresh_action_index = self.enabled_actions[idx];
         let repeat = Self::random_bool(REPEAT_ACTION_P);
         let action_index = match (repeat, self.last_action_index) {
             (true, Some(last)) => last,
@@ -723,6 +760,13 @@ impl Dungeon {
 
     /// Run the dungeon until bug, death, or step limit.
     pub fn run(&mut self) -> StepResult {
+        // Swarm-testing demonstrator: this seed masked off every `Move` action,
+        // so the player can never change position. Reachable only under
+        // operation-alphabet swarm (~(1/2)^8 per seed); under all-on mixing the
+        // full alphabet is always enabled, so it is unreachable.
+        if !self.enabled_actions.iter().any(|&i| i < NUM_MOVE_ACTIONS) {
+            moonpool_sim::assert_sometimes!(true, "movement suppressed by swarm");
+        }
         loop {
             match self.step() {
                 StepResult::Continue => {}
@@ -765,5 +809,68 @@ impl Workload for DungeonWorkload {
         );
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pick_action_consumes_two_sim_rng_draws() {
+        // The two-draw-per-step discipline must hold whether or not swarm masks
+        // the alphabet, so fork-explorer replay (keyed on the SIM_RNG call
+        // count) is never perturbed by operation-alphabet swarm.
+        for swarm in [None, Some(7u64), Some(99u64)] {
+            moonpool_sim::reset_sim_rng();
+            moonpool_sim::set_sim_seed(1234);
+            moonpool_sim::set_swarm_op_seed(swarm);
+            let mut dungeon = Dungeon::new(100, 8);
+            let before = moonpool_sim::rng_call_count();
+            let _ = dungeon.pick_action_index();
+            let after = moonpool_sim::rng_call_count();
+            assert_eq!(
+                after - before,
+                2,
+                "pick_action_index must consume exactly two SIM_RNG draws (swarm={swarm:?})"
+            );
+        }
+        moonpool_sim::set_swarm_op_seed(None);
+    }
+
+    #[test]
+    fn swarm_off_uses_full_action_alphabet() {
+        moonpool_sim::set_swarm_op_seed(None);
+        assert_eq!(
+            Dungeon::swarm_enabled_actions(),
+            (0..NUM_ACTIONS).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn enabled_actions_never_empty() {
+        for seed in 0..2000u64 {
+            moonpool_sim::set_swarm_op_seed(Some(seed));
+            assert!(
+                !Dungeon::swarm_enabled_actions().is_empty(),
+                "empty-mask fallback failed for seed {seed}"
+            );
+        }
+        moonpool_sim::set_swarm_op_seed(None);
+    }
+
+    #[test]
+    fn swarm_can_suppress_all_movement() {
+        // The demonstrator condition: a seed that disables every Move action
+        // while keeping a non-move action enabled. Exists across seeds under
+        // swarm; impossible when the full alphabet is always on.
+        let found = (0..4000u64).any(|seed| {
+            moonpool_sim::set_swarm_op_seed(Some(seed));
+            let actions = Dungeon::swarm_enabled_actions();
+            !actions.iter().any(|&i| i < NUM_MOVE_ACTIONS)
+                && actions.iter().any(|&i| i >= NUM_MOVE_ACTIONS)
+        });
+        assert!(found, "expected a seed that masks off all movement actions");
+        moonpool_sim::set_swarm_op_seed(None);
     }
 }

--- a/moonpool-sim/src/lib.rs
+++ b/moonpool-sim/src/lib.rs
@@ -152,7 +152,7 @@ pub use sim::{
     ConnectionStateChange, Event, EventQueue, NetworkOperation, ScheduledEvent, SimFaultRecord,
     SimWorld, SleepFuture, StorageOperation, WeakSimWorld, clear_rng_breakpoints, current_sim_seed,
     reset_rng_call_count, reset_sim_rng, rng_call_count, set_rng_breakpoints, set_sim_seed,
-    sim_random, sim_random_range, sim_random_range_or_default,
+    set_swarm_op_seed, sim_random, sim_random_range, sim_random_range_or_default, swarm_op_enabled,
 };
 
 // Runner module re-exports

--- a/moonpool-sim/src/runner/builder.rs
+++ b/moonpool-sim/src/runner/builder.rs
@@ -977,13 +977,16 @@ impl SimulationBuilder {
     }
 
     /// Reset per-iteration state: capture buffers, RNG, buggify, and chaos.
-    fn reset_per_iteration_state(seed: u64, obs_handle: &SimulationLayerHandle) {
+    fn reset_per_iteration_state(seed: u64, use_swarm: bool, obs_handle: &SimulationLayerHandle) {
         obs_handle.reset_for_seed();
         crate::sim::reset_sim_rng();
         crate::sim::set_sim_seed(seed);
         // Seed the independent config RNG that drives swarm-subset decisions.
         // Runs before `build_sim_for_iteration`, so `swarm_for_seed()` sees it.
         crate::sim::set_config_seed(seed);
+        // Per-seed base for the workload operation-alphabet swarm mask; `None`
+        // disables masking so workloads see the full alphabet.
+        crate::sim::set_swarm_op_seed(use_swarm.then_some(seed));
         crate::chaos::reset_always_violations();
         // Use moderate probabilities: 50% activation rate, 25% firing rate.
         crate::chaos::buggify_init(0.5, 0.25);
@@ -1273,7 +1276,7 @@ impl SimulationBuilder {
             hook();
         }
 
-        Self::reset_per_iteration_state(seed, obs_handle);
+        Self::reset_per_iteration_state(seed, self.use_swarm_config, obs_handle);
 
         if matches!(
             self.iteration_control,

--- a/moonpool-sim/src/sim/mod.rs
+++ b/moonpool-sim/src/sim/mod.rs
@@ -27,7 +27,8 @@ pub use events::{
 pub use rng::{
     clear_rng_breakpoints, config_random_bool, config_random_f64, current_sim_seed,
     reset_config_rng, reset_rng_call_count, reset_sim_rng, rng_call_count, set_config_seed,
-    set_rng_breakpoints, set_sim_seed, sim_random, sim_random_range, sim_random_range_or_default,
+    set_rng_breakpoints, set_sim_seed, set_swarm_op_seed, sim_random, sim_random_range,
+    sim_random_range_or_default, swarm_op_enabled,
 };
 pub use sleep::SleepFuture;
 pub use world::{SimFaultRecord, SimWorld, WeakSimWorld};

--- a/moonpool-sim/src/sim/rng.rs
+++ b/moonpool-sim/src/sim/rng.rs
@@ -46,6 +46,13 @@ thread_local! {
     /// no effect on the [`SIM_RNG`] call count or breakpoint replay — config
     /// decisions can never perturb in-run randomness or fork-explorer replay.
     static CONFIG_RNG: RefCell<ChaCha8Rng> = RefCell::new(ChaCha8Rng::seed_from_u64(0));
+
+    /// Thread-local per-seed base for workload operation-alphabet swarm masks.
+    ///
+    /// `Some(seed)` when `.swarm()` is enabled for the current iteration,
+    /// `None` otherwise. See [`swarm_op_enabled`] for how it is consumed; like
+    /// [`CONFIG_RNG`] it never touches the [`SIM_RNG`] call count.
+    static SWARM_OP_SEED: Cell<Option<u64>> = const { Cell::new(None) };
 }
 
 /// Salt mixed into the iteration seed before seeding [`CONFIG_RNG`].
@@ -53,6 +60,13 @@ thread_local! {
 /// Decorrelates config (swarm-subset) decisions from the in-run [`SIM_RNG`]
 /// stream while keeping both fully reproducible from the same iteration seed.
 const CONFIG_RNG_SALT: u64 = 0x6D6F_6F6E_7377_726D; // "moonswrm"
+
+/// Salt mixed into the iteration seed when deriving operation-alphabet swarm
+/// masks.
+///
+/// Distinct from [`CONFIG_RNG_SALT`] so per-seed *operation* subset decisions
+/// are decorrelated from the *fault-family* subset decisions of the same seed.
+const SWARM_OP_SALT: u64 = 0x6F70_6D61_736B_7372; // "opmasksr"
 
 /// Increment the RNG call counter and check for breakpoints.
 ///
@@ -294,6 +308,53 @@ pub fn config_random_f64() -> f64 {
 #[must_use]
 pub fn config_random_bool(p: f64) -> bool {
     config_random_f64() < p
+}
+
+/// Set the per-seed base for workload operation-alphabet swarm masks.
+///
+/// Called once per iteration by the runner: `Some(seed)` when `.swarm()` is
+/// enabled, `None` otherwise. With `None`, [`swarm_op_enabled`] reports every
+/// operation as enabled (full alphabet — zero behavior change).
+pub fn set_swarm_op_seed(seed: Option<u64>) {
+    SWARM_OP_SEED.with(|s| s.set(seed));
+}
+
+/// 64-bit `SplitMix64` finalizer — a stateless, dependency-free mixing function.
+///
+/// Used to derive per-`(seed, op_id)` swarm decisions without consuming any RNG
+/// stream, so the result is idempotent and order-independent.
+fn splitmix64(mut x: u64) -> u64 {
+    x = (x ^ (x >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    x = (x ^ (x >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    x ^ (x >> 31)
+}
+
+/// Report whether operation `op_id` is enabled for the current iteration's
+/// operation-alphabet swarm subset.
+///
+/// When swarm is disabled (no [`set_swarm_op_seed`] with `Some`), every
+/// operation is enabled. When enabled, each operation is independently on with
+/// probability 0.5, derived as a **pure function** of `(seed, op_id)` via
+/// [`splitmix64`] — *not* by consuming the [`CONFIG_RNG`] stream. This makes the
+/// decision idempotent and order-independent: a workload may query the mask any
+/// number of times in any order and always sees the same subset, and the
+/// fault-family `CONFIG_RNG` draw sequence is left untouched. Like
+/// [`config_random_bool`], it never touches [`SIM_RNG`], so fork-explorer replay
+/// is unperturbed.
+///
+/// Callers own the empty-subset fallback: if a seed disables every operation in
+/// the alphabet, the workload should fall back to the full alphabet so it always
+/// has something to do.
+#[must_use]
+pub fn swarm_op_enabled(op_id: u8) -> bool {
+    match SWARM_OP_SEED.with(Cell::get) {
+        None => true,
+        Some(seed) => {
+            let mixed = splitmix64(seed ^ SWARM_OP_SALT ^ u64::from(op_id).rotate_left(32));
+            // Top bit gives a clean 50/50 split.
+            mixed & (1 << 63) != 0
+        }
+    }
 }
 
 #[cfg(test)]
@@ -616,5 +677,82 @@ mod tests {
         let _: f64 = sim_random();
         assert_eq!(rng_call_count(), 1);
         assert_eq!(current_sim_seed(), 42); // no breakpoint triggered
+    }
+
+    #[test]
+    fn swarm_op_disabled_enables_full_alphabet() {
+        // No swarm: every operation is enabled (zero behavior change).
+        set_swarm_op_seed(None);
+        for op in 0..32u8 {
+            assert!(
+                swarm_op_enabled(op),
+                "op {op} must be enabled when swarm is off"
+            );
+        }
+    }
+
+    #[test]
+    fn swarm_op_mask_is_idempotent_and_order_independent() {
+        const N: u8 = 16;
+        set_swarm_op_seed(Some(123));
+        let forward: Vec<bool> = (0..N).map(swarm_op_enabled).collect();
+
+        // Re-query in reverse, with repeats: a pure (seed, op) function must
+        // yield the identical mask regardless of call order or count.
+        set_swarm_op_seed(Some(123));
+        let mut reverse = vec![false; usize::from(N)];
+        for op in (0..N).rev() {
+            let _ = swarm_op_enabled(op);
+            reverse[usize::from(op)] = swarm_op_enabled(op);
+        }
+        assert_eq!(
+            forward, reverse,
+            "mask must be idempotent and order-independent"
+        );
+        set_swarm_op_seed(None);
+    }
+
+    #[test]
+    fn swarm_op_varies_across_seeds_and_reaches_extremes() {
+        const N: u8 = 10;
+        let mut min_enabled = usize::MAX;
+        let mut max_enabled = 0usize;
+        for seed in 0..4000u64 {
+            set_swarm_op_seed(Some(seed));
+            let count = (0..N).filter(|&op| swarm_op_enabled(op)).count();
+            min_enabled = min_enabled.min(count);
+            max_enabled = max_enabled.max(count);
+        }
+        // Deterministic across runs (pure hash), but spread across the alphabet:
+        // some seeds yield a near-empty subset, others the full alphabet.
+        assert!(
+            min_enabled <= 1,
+            "expected a near-empty subset; min was {min_enabled}"
+        );
+        assert_eq!(
+            max_enabled,
+            usize::from(N),
+            "expected a full subset; max was {max_enabled}"
+        );
+        set_swarm_op_seed(None);
+    }
+
+    #[test]
+    fn swarm_op_query_does_not_perturb_sim_rng() {
+        reset_sim_rng();
+        set_sim_seed(99);
+        let _: f64 = sim_random();
+        let before = rng_call_count();
+
+        set_swarm_op_seed(Some(5));
+        for op in 0..50u8 {
+            let _ = swarm_op_enabled(op);
+        }
+        assert_eq!(
+            rng_call_count(),
+            before,
+            "swarm_op_enabled must not touch the SIM_RNG call count"
+        );
+        set_swarm_op_seed(None);
     }
 }

--- a/moonpool-sim/tests/swarm_op_alphabet.rs
+++ b/moonpool-sim/tests/swarm_op_alphabet.rs
@@ -1,0 +1,90 @@
+//! Integration test for workload operation-alphabet swarm testing (issue #129).
+//!
+//! Verifies the end-to-end wiring: with `.swarm()`, each seed enables a random
+//! *subset* of a workload's operation alphabet (via [`swarm_op_enabled`]), so a
+//! demonstrator that only triggers when a whole operation sub-group is masked
+//! off becomes reachable across seeds — yet stays unreachable under the
+//! always-on full alphabet (no swarm). This is the canonical swarm-testing win:
+//! defeating passive/active suppression of bug-finding operations.
+
+use async_trait::async_trait;
+use moonpool_sim::{
+    SimContext, SimulationBuilder, SimulationReport, SimulationResult, Workload, swarm_op_enabled,
+};
+
+/// The demonstrator fires when none of the first four operations is enabled.
+const GROUP: u8 = 4;
+
+/// Minimal workload over an operation alphabet. Mirrors the dungeon reference
+/// pattern: emit the demonstrator assertion only on the path where it holds, so
+/// it never accrues a 0%-success coverage violation when unreachable.
+struct OpAlphabetWorkload;
+
+#[async_trait]
+impl Workload for OpAlphabetWorkload {
+    fn name(&self) -> &'static str {
+        "client"
+    }
+
+    async fn run(&mut self, _ctx: &SimContext) -> SimulationResult<()> {
+        // Always reached: proves the workload ran this seed.
+        moonpool_sim::assert_sometimes!(true, "op alphabet workload reached");
+
+        // Reachable only when the whole leading operation group is masked off
+        // (P = (1/2)^GROUP per seed under swarm); impossible when the full
+        // alphabet is always on.
+        let group_suppressed = !(0..GROUP).any(swarm_op_enabled);
+        if group_suppressed {
+            moonpool_sim::assert_sometimes!(true, "operation group suppressed by swarm");
+        }
+
+        Ok(())
+    }
+}
+
+fn group_suppressed_pass_count(report: &SimulationReport) -> u64 {
+    report
+        .assertion_details
+        .iter()
+        .find(|d| d.msg == "operation group suppressed by swarm")
+        .map_or(0, |d| d.pass_count)
+}
+
+/// 400 explicit seeds make the run fully deterministic (independent of the
+/// wall-clock base seed). With `GROUP == 4` the demonstrator fires ~6% of
+/// seeds, so it is hit many times within 400.
+fn seeds() -> Vec<u64> {
+    (0..400u64).collect()
+}
+
+#[test]
+fn swarm_makes_group_suppression_reachable() {
+    let report = SimulationBuilder::new()
+        .swarm()
+        .set_debug_seeds(seeds())
+        .set_iterations(400)
+        .workload(OpAlphabetWorkload)
+        .run();
+
+    assert_eq!(report.failed_runs, 0, "swarm run had failed seeds");
+    assert!(
+        group_suppressed_pass_count(&report) > 0,
+        "the suppressed-group demonstrator must be reachable under swarm"
+    );
+}
+
+#[test]
+fn full_alphabet_never_suppresses_group() {
+    let report = SimulationBuilder::new()
+        .set_debug_seeds(seeds())
+        .set_iterations(400)
+        .workload(OpAlphabetWorkload)
+        .run();
+
+    assert_eq!(report.failed_runs, 0, "baseline run had failed seeds");
+    assert_eq!(
+        group_suppressed_pass_count(&report),
+        0,
+        "without swarm the full alphabet is always on; the demonstrator is unreachable"
+    );
+}

--- a/moonpool-transport-sim/src/bin/sim/transport.rs
+++ b/moonpool-transport-sim/src/bin/sim/transport.rs
@@ -23,7 +23,10 @@ fn main() {
         })
         .invariant(TransportIntegrityInvariant::new())
         .chaos_duration(Duration::from_secs(10))
-        .random_network()
+        // Swarm: each seed runs a random *subset* of both the network fault
+        // families and the workload's operation alphabet (the rest fully off),
+        // defeating passive/active suppression. Supersedes `.random_network()`.
+        .swarm()
         .set_iterations(20)
         .seed_warning_timeout(Duration::from_secs(15))
         .run();

--- a/moonpool-transport-sim/src/workload.rs
+++ b/moonpool-transport-sim/src/workload.rs
@@ -46,7 +46,7 @@ pub const EV_CLIENT_FAILED: &str = "client_failed";
 /// shutdown mid-await). Fields: `seq_id`.
 pub const EV_CLIENT_AMBIGUOUS: &str = "client_ambiguous";
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Op {
     NormalAppend,
     EmptyBlock,
@@ -57,16 +57,64 @@ enum Op {
     SmallDelay,
 }
 
-fn random_op() -> Op {
-    match sim_random_range(0u32..100) {
-        0..70 => Op::NormalAppend,
-        70..78 => Op::EmptyBlock,
-        78..85 => Op::MaxSizeBlock,
-        85..91 => Op::AtMostOnceAppend,
-        91..96 => Op::AppendWithTimeout,
-        96..98 => Op::SendToWrongEndpoint,
-        _ => Op::SmallDelay,
+impl Op {
+    /// True for operations that issue a request the server turns into an
+    /// `append_block` (i.e. that can advance the hash chain).
+    fn is_append(self) -> bool {
+        matches!(
+            self,
+            Op::NormalAppend
+                | Op::EmptyBlock
+                | Op::MaxSizeBlock
+                | Op::AtMostOnceAppend
+                | Op::AppendWithTimeout
+        )
     }
+}
+
+/// The operation alphabet with its baseline weights (summing to 100). The array
+/// index is the stable operation id consulted by [`moonpool_sim::swarm_op_enabled`].
+const OP_ALPHABET: [(Op, u32); 7] = [
+    (Op::NormalAppend, 70),
+    (Op::EmptyBlock, 8),
+    (Op::MaxSizeBlock, 7),
+    (Op::AtMostOnceAppend, 6),
+    (Op::AppendWithTimeout, 5),
+    (Op::SendToWrongEndpoint, 2),
+    (Op::SmallDelay, 2),
+];
+
+/// This seed's enabled operation subset for swarm testing. Each operation is
+/// independently ~50% on (via the per-seed mask); with swarm disabled every
+/// operation is enabled, so the table is byte-identical to [`OP_ALPHABET`].
+/// Empty-mask fallback: if a seed disables everything, use the full alphabet so
+/// the workload always has something to do.
+fn swarm_enabled_ops() -> Vec<(Op, u32)> {
+    let enabled: Vec<(Op, u32)> = (0u8..)
+        .zip(OP_ALPHABET)
+        .filter(|&(id, _)| moonpool_sim::swarm_op_enabled(id))
+        .map(|(_, op)| op)
+        .collect();
+    if enabled.is_empty() {
+        OP_ALPHABET.to_vec()
+    } else {
+        enabled
+    }
+}
+
+/// Pick an operation from the enabled subset, weighted by `table`. Consumes
+/// exactly one `SIM_RNG` draw per call (the remapping into the subset adds no
+/// draws, so fork-explorer replay is unperturbed).
+fn weighted_op(table: &[(Op, u32)]) -> Op {
+    let total: u32 = table.iter().map(|&(_, w)| w).sum();
+    let mut roll = sim_random_range(0u32..total);
+    for &(op, w) in table {
+        if roll < w {
+            return op;
+        }
+        roll -= w;
+    }
+    table.last().expect("enabled op table is never empty").0
 }
 
 fn random_block(min: usize, max: usize) -> Vec<u8> {
@@ -144,6 +192,17 @@ impl Workload for TransportClientWorkload {
         let mut expected_h: u64 = INITIAL_DIGEST;
         let mut stopped_after_ambiguous = false;
 
+        // Per-seed operation-alphabet subset (swarm testing). Computed once;
+        // `swarm_op_enabled` is a pure function of the seed, so this is stable.
+        let op_table = swarm_enabled_ops();
+
+        // Demonstrator: this seed masked off every append-producing op, so the
+        // hash chain can never advance — only delays / wrong-endpoint probes run.
+        // Reachable under swarm (~(1/2)^5 per seed), impossible under all-on.
+        if !op_table.iter().any(|&(op, _)| op.is_append()) {
+            assert_sometimes!(true, "swarm: no append ops, chain cannot advance");
+        }
+
         tracing::info!(client_id, num_ops, "workload starting");
 
         for _ in 0..num_ops {
@@ -151,7 +210,7 @@ impl Workload for TransportClientWorkload {
                 break;
             }
 
-            let op = random_op();
+            let op = weighted_op(&op_table);
             seq_counter += 1;
             let seq_id = (client_id as u64) * 1_000_000 + seq_counter;
 


### PR DESCRIPTION
## What

Per-seed **operation-alphabet swarm testing** (issue #129), building on the just-merged fault-family swarm core (#128). Each seed enables a random *subset* of a workload's operation alphabet (the rest fully off), defeating **passive suppression** — the bounded-cache 1-D-random-walk where a 50/50 op mix never reaches the state that triggers a bug.

Closes #129. Part of the swarm epic #131.

## Core

`moonpool_sim::swarm_op_enabled(op_id: u8) -> bool` (in `sim/rng.rs`):
- Each op is independently ~50% on, a **pure splitmix64 hash of `(seed, op_id)`** — idempotent, order-independent.
- Consumes **no RNG** (neither `SIM_RNG` nor the fault-family `CONFIG_RNG`), so fork-explorer replay and fault-family swarm are unperturbed.
- Opt in via the existing `.swarm()` flag (seeded per iteration in `reset_per_iteration_state`); without it every op is enabled (**zero behavior change**).

## Reference conversions

- **dungeon.rs** — `pick_action_index` remaps its single full-alphabet draw into the per-seed enabled subset, **preserving the 2-draws-per-step discipline** (no resample loop). Empty-mask fallback. Demonstrator `assert_sometimes!("movement suppressed by swarm")`.
- **transport workload** — `random_op` replaced by a swarm-aware weighted selector over the enabled subset (one `SIM_RNG` draw, empty-mask fallback); `sim-transport` switched from `.random_network()` to `.swarm()`. The demonstrator (a seed masking off every append op) **fired on a real run**.

## Tests

- `rng.rs` unit tests: swarm-off all-on, idempotent/order-independent, reaches near-empty & full subsets, no `SIM_RNG` perturbation.
- dungeon tests: 2-draw discipline, full-alphabet default, never-empty, suppression seeds exist.
- `tests/swarm_op_alphabet.rs`: demonstrator reachable under `.swarm()` and unreachable without, over 400 deterministic seeds.

## Docs

`writing-a-workload` skill + book ch.19 *"Swarm the Alphabet"*.

## Validation

`cargo fmt` · `clippy --all-targets -- -D warnings` (pedantic) · `nextest run` (549 passed) · portability (`-p moonpool-sim --no-default-features` clippy + wasm32 check) · `mdbook build` · `cargo xtask sim run dungeon` and `... transport` (both 100% success, no deadlocks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)