### PR TITLE
feat(moonpool-sim): declarative enable_chaos with per-surface swarm/random modes (#130)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,7 +191,9 @@ Strategic placement: error handling, timeouts, retries, resource limits
 **Builder API**:
 - `.processes(count, factory)` — register server processes (IPs: `10.0.1.{1..N}`)
 - `.tags(&[("key", &["val1", "val2"])])` — round-robin tag distribution
-- `.attrition(config)` — built-in chaos reboots (requires `.phases()`)
+- `.enable_chaos([Chaos::Attrition { config, mode }])` — built-in chaos reboots (requires `.chaos_duration()`)
+- `.enable_chaos([Chaos::Network(mode) | Chaos::Storage(mode)])` — network/storage faults per seed (`ChaosMode::Random` all-on, `ChaosMode::Swarm` per-seed subset)
+- `.swarm_operations()` — per-seed swarm of each workload's operation alphabet
 
 **Reboot lifecycle**: Graceful (signal token → grace period → force kill → restart) vs Crash (immediate abort → restart)
 **Key types**: `Process`, `RebootKind`, `Attrition`, `ProcessTags`, `TagRegistry`

--- a/book/src/appendix/03-configuration.md
+++ b/book/src/appendix/03-configuration.md
@@ -25,7 +25,8 @@ The builder pattern for configuring and running simulation experiments. Created 
 | `set_iteration_control(ctrl)` | `IterationControl` | Set the iteration control strategy |
 | `set_time_limit(dur)` | `Duration` | Run for a wall-clock time duration |
 | `set_debug_seeds(seeds)` | `Vec<u64>` | Use specific seeds for deterministic debugging |
-| `random_network()` | -- | Enable randomized `NetworkConfiguration` per iteration |
+| `enable_chaos(surfaces)` | `impl IntoIterator<Item = Chaos>` | Enable network/storage/attrition chaos per seed, each in a `ChaosMode` (`Random` or `Swarm`) |
+| `swarm_operations()` | -- | Enable per-seed swarm of each workload's operation alphabet |
 | `enable_exploration(config)` | `ExplorationConfig` | Enable fork-based multiverse exploration |
 | `replay_recipe(recipe)` | `BugRecipe` | Replay a specific bug recipe |
 | `run()` | -- | Execute the simulation, returns `SimulationReport` |
@@ -35,7 +36,8 @@ The builder pattern for configuring and running simulation experiments. Created 
 A freshly created `SimulationBuilder::new()` has:
 
 - **iteration_control**: `IterationControl::FixedCount(1)`
-- **use_random_config**: `false` (uses `NetworkConfiguration::default()`)
+- **chaos**: all surfaces off (network/storage use `default()`, no attrition)
+- **swarm_operations**: `false` (workloads see the full operation alphabet)
 - **exploration**: disabled
 - **seeds**: empty (auto-generated)
 - No workloads, processes, invariants, or fault injectors

--- a/book/src/part3-building/04-simulation-builder.md
+++ b/book/src/part3-building/04-simulation-builder.md
@@ -132,20 +132,23 @@ Invariants read from the `StateHandle`, which workloads write to via `ctx.state(
 Real distributed systems do not just run cleanly. Servers crash, networks partition, and then things have to recover. The builder models this with `chaos_duration`:
 
 ```rust
-use moonpool_sim::Attrition;
+use moonpool_sim::{Attrition, Chaos, ChaosMode};
 
 SimulationBuilder::new()
     .processes(3, || Box::new(KvServer))
     .workload(KvWorkload::new(200, keys))
     .chaos_duration(Duration::from_secs(30))
-    .attrition(Attrition {
-        max_dead: 1,
-        prob_graceful: 0.3,
-        prob_crash: 0.5,
-        prob_wipe: 0.2,
-        recovery_delay_ms: Some(1000..5000),
-        grace_period_ms: Some(2000..4000),
-    })
+    .enable_chaos([Chaos::Attrition {
+        config: Attrition {
+            max_dead: 1,
+            prob_graceful: 0.3,
+            prob_crash: 0.5,
+            prob_wipe: 0.2,
+            recovery_delay_ms: Some(1000..5000),
+            grace_period_ms: Some(2000..4000),
+        },
+        mode: ChaosMode::Random,
+    }])
     .set_iterations(100)
     .run()
     .await;
@@ -163,21 +166,26 @@ The simulation lifecycle:
 
 `max_dead: 1` means at most one process is down at any time. The probability weights control the mix of graceful shutdowns (shutdown token fired, grace period) versus instant crashes (no warning, connections abort).
 
-## Randomized Network
+## Enabling Chaos
 
-For additional chaos, enable randomized network configuration:
-
-```rust
-.random_network()
-```
-
-This varies latency, packet delay distributions, and other network parameters per iteration, based on the seed. Without this flag, the network uses default configuration (consistent, low-latency).
-
-For stronger coverage, use `.swarm()` instead. It enables a random **subset** of network fault families per seed, fully disabling the rest, rather than turning every fault slightly on at once. This defeats passive suppression, where active faults crowd each other out and the extreme single-family configs that surface bugs almost never occur. See [Network Faults](10-network-faults.md#swarm-testing-less-is-more) for the full reasoning.
+For additional chaos, enable one or more fault surfaces and choose how each is sampled per seed:
 
 ```rust
-.swarm()
+.enable_chaos([Chaos::Network(ChaosMode::Random)])
 ```
+
+`ChaosMode::Random` varies latency, packet delay distributions, and other network parameters per iteration, based on the seed. A surface absent from the list stays off, using its default configuration (consistent, low-latency, no faults).
+
+For stronger coverage, use `ChaosMode::Swarm`. It enables a random **subset** of that surface's fault families per seed, fully disabling the rest, rather than turning every fault slightly on at once. This defeats passive suppression, where active faults crowd each other out and the extreme single-family configs that surface bugs almost never occur. See [Network Faults](10-network-faults.md#swarm-testing-less-is-more) for the full reasoning.
+
+```rust
+.enable_chaos([
+    Chaos::Network(ChaosMode::Swarm),
+    Chaos::Storage(ChaosMode::Swarm),
+])
+```
+
+The same call drives storage faults and the attrition reboot regime, each with its own `ChaosMode`. The workload operation-alphabet swarm is a separate, test-driver concern: opt in with `.swarm_operations()`.
 
 ## Putting It All Together
 
@@ -190,15 +198,21 @@ let report = SimulationBuilder::new()
     .workload(KvWorkload::new(500, keys.clone()))
     .invariant(ConservationLaw)
     .chaos_duration(Duration::from_secs(30))
-    .attrition(Attrition {
-        max_dead: 1,
-        prob_graceful: 0.3,
-        prob_crash: 0.5,
-        prob_wipe: 0.2,
-        recovery_delay_ms: None,
-        grace_period_ms: None,
-    })
-    .random_network()
+    .enable_chaos([
+        Chaos::Attrition {
+            config: Attrition {
+                max_dead: 1,
+                prob_graceful: 0.3,
+                prob_crash: 0.5,
+                prob_wipe: 0.2,
+                recovery_delay_ms: None,
+                grace_period_ms: None,
+            },
+            mode: ChaosMode::Swarm,
+        },
+        Chaos::Network(ChaosMode::Swarm),
+        Chaos::Storage(ChaosMode::Swarm),
+    ])
     .set_iterations(100)
     .run()
     .await;

--- a/book/src/part3-building/05-running.md
+++ b/book/src/part3-building/05-running.md
@@ -35,7 +35,7 @@ fn main() {
             .processes(3, || Box::new(KvServer))
             .workload(KvWorkload::new(200, keys))
             .set_iterations(100)
-            .random_network()
+            .enable_chaos([Chaos::Network(ChaosMode::Random)])
             .run()
             .await
     });

--- a/book/src/part3-building/09-attrition.md
+++ b/book/src/part3-building/09-attrition.md
@@ -58,16 +58,21 @@ Attrition {
 Attrition is configured on the simulation builder and requires a chaos duration:
 
 ```rust
+use moonpool_sim::{Attrition, Chaos, ChaosMode};
+
 SimulationBuilder::new()
     .processes(3, || Box::new(MyProcess::new()))
-    .attrition(Attrition {
-        max_dead: 1,
-        prob_graceful: 0.3,
-        prob_crash: 0.5,
-        prob_wipe: 0.2,
-        recovery_delay_ms: None,  // use defaults
-        grace_period_ms: None,    // use defaults
-    })
+    .enable_chaos([Chaos::Attrition {
+        config: Attrition {
+            max_dead: 1,
+            prob_graceful: 0.3,
+            prob_crash: 0.5,
+            prob_wipe: 0.2,
+            recovery_delay_ms: None,  // use defaults
+            grace_period_ms: None,    // use defaults
+        },
+        mode: ChaosMode::Random,
+    }])
     .chaos_duration(Duration::from_secs(60))
     .workload(MyWorkload::new())
     .run()
@@ -75,6 +80,8 @@ SimulationBuilder::new()
 ```
 
 The `.chaos_duration()` call is required because attrition runs only during the chaos phase. After the chaos duration elapses, fault injectors stop and the system continues until all workloads complete. A settle phase then drains remaining events before checks run, surfacing cleanup bugs rather than hiding them behind an arbitrary timer.
+
+`ChaosMode::Random` uses your configured weights as written every seed. Switch to `ChaosMode::Swarm` to swarm the reboot *regime* itself: each seed draws a random subset of the configuration, including the never-reboot case (which surfaces slow-leak and timer bugs that constant restarting hides) and single-mode cases like always-crash or graceful-only. Same reasoning as [swarming network faults](10-network-faults.md#swarm-testing-less-is-more).
 
 ## The max_dead Constraint
 

--- a/book/src/part3-building/10-network-faults.md
+++ b/book/src/part3-building/10-network-faults.md
@@ -115,11 +115,12 @@ The fix is counterintuitive: for each run, turn **off** a random subset of fault
 
 ```rust
 SimulationBuilder::new()
-    .swarm() // each seed enables a random subset of fault families
+    // each seed enables a random subset of network fault families
+    .enable_chaos([Chaos::Network(ChaosMode::Swarm)])
     // ...
 ```
 
-`.swarm()` builds on `random_for_seed()`, then masks each of the seven network fault families to off with 50% probability: clog, partition, bit-flip, random-close, connect-failure, clock-drift, and buggified-delay. The all-off subset is allowed on purpose, because a pure no-fault run is a useful, valid config.
+`ChaosMode::Swarm` builds on `random_for_seed()`, then masks each of the seven network fault families to off with 50% probability: clog, partition, bit-flip, random-close, connect-failure, clock-drift, and buggified-delay. The all-off subset is allowed on purpose, because a pure no-fault run is a useful, valid config. The same `enable_chaos` call swarms storage faults (`Chaos::Storage`) and the attrition reboot regime (`Chaos::Attrition`) the same way.
 
 The interesting engineering detail is **where the randomness comes from**. Swarm decisions must not perturb the in-run randomness, or they would shift every fault's timing and break fork-explorer replay. So the subset is drawn from a separate `CONFIG_RNG` stream, seeded from the iteration seed but salted to decorrelate it from the main `SIM_RNG`. The config RNG never advances the in-run call counter. Same seed, same subset, every time, with zero effect on the simulation that follows.
 

--- a/book/src/part3-building/19-designing-workloads.md
+++ b/book/src/part3-building/19-designing-workloads.md
@@ -60,7 +60,7 @@ A complete alphabet has a hidden failure mode. Picking operations uniformly over
 
 The fix is the same too. Instead of running every seed with the whole alphabet, enable a random **subset** per seed and turn the rest fully off. Disable `pop` for some runs and the queue fills on the first handful of steps. We call this swarming the alphabet, after the [Swarm Testing](10-network-faults.md#swarm-testing-less-is-more) paper.
 
-`moonpool_sim::swarm_op_enabled(op_id)` tells you whether operation `op_id` is in this seed's subset. Opt in with `SimulationBuilder::swarm()`. Without it, every operation reports enabled, so default runs use the full alphabet and nothing changes.
+`moonpool_sim::swarm_op_enabled(op_id)` tells you whether operation `op_id` is in this seed's subset. Opt in with `SimulationBuilder::swarm_operations()`. Without it, every operation reports enabled, so default runs use the full alphabet and nothing changes.
 
 ```rust
 // Cache the subset once per run. Each operation is independently ~50% on,
@@ -89,7 +89,7 @@ if !enabled.iter().any(|&i| i < NUM_MOVE_OPS) {
 }
 ```
 
-The dungeon example in `moonpool-sim-examples/src/dungeon.rs` is the reference implementation, and `moonpool-sim/tests/swarm_op_alphabet.rs` shows the assertion firing under `.swarm()` and staying unreachable without it.
+The dungeon example in `moonpool-sim-examples/src/dungeon.rs` is the reference implementation, and `moonpool-sim/tests/swarm_op_alphabet.rs` shows the assertion firing under `.swarm_operations()` and staying unreachable without it.
 
 ## Invariant Patterns
 

--- a/book/src/part4-integration/06-wasm.md
+++ b/book/src/part4-integration/06-wasm.md
@@ -85,7 +85,7 @@ The repository ships one:
 It runs a single seed of two nodes trading ping/pong RPCs over the **real
 transport stack**, driven by the **simulated** network, and animates the result.
 The client and server are ordinary `Process` and `Workload` code with no browser
-awareness. `.random_network()` injects seeded latency and connection drops, so
+awareness. `.enable_chaos([Chaos::Network(ChaosMode::Random)])` injects seeded latency and connection drops, so
 some round trips come back slow and some never come back at all. A generic
 recorder reads the same trace timeline your invariants read and turns it into the
 picture.

--- a/docs/specs/reboot.md
+++ b/docs/specs/reboot.md
@@ -140,12 +140,17 @@ SimulationBuilder::new()
     // Test driver: survives reboots
     .workload(TestDriver::new())
     // Built-in attrition (chaos phase only)
-    .attrition(Attrition {
-        max_dead: 1,
-        prob_graceful: 0.3,
-        prob_crash: 0.5,
-        prob_wipe: 0.2,
-    })
+    .enable_chaos([Chaos::Attrition {
+        config: Attrition {
+            max_dead: 1,
+            prob_graceful: 0.3,
+            prob_crash: 0.5,
+            prob_wipe: 0.2,
+            recovery_delay_ms: None,
+            grace_period_ms: None,
+        },
+        mode: ChaosMode::Random,
+    }])
     // OR custom fault injector
     .fault(MyCustomInjector::new())
     // Cross-system invariants (always run, even during recovery)
@@ -257,7 +262,11 @@ SimulationBuilder::new()
     .processes(5, || PaxosNode)
         .tags(&[("dc", &["east", "west", "eu"])])
     .workload(PaxosTest)
-    .attrition(Attrition { max_dead: 1, prob_graceful: 0.3, prob_crash: 0.5, prob_wipe: 0.2 })
+    .enable_chaos([Chaos::Attrition {
+        config: Attrition { max_dead: 1, prob_graceful: 0.3, prob_crash: 0.5, prob_wipe: 0.2,
+                            recovery_delay_ms: None, grace_period_ms: None },
+        mode: ChaosMode::Random,
+    }])
     .invariant(LinearizabilityCheck)
     .set_iterations(100)
     .run()
@@ -295,7 +304,11 @@ impl Workload for ActorTest {
 SimulationBuilder::new()
     .processes(3, || ActorHostProcess)
     .workload(ActorTest)
-    .attrition(Attrition { max_dead: 1, prob_graceful: 0.5, prob_crash: 0.5, prob_wipe: 0.0 })
+    .enable_chaos([Chaos::Attrition {
+        config: Attrition { max_dead: 1, prob_graceful: 0.5, prob_crash: 0.5, prob_wipe: 0.0,
+                            recovery_delay_ms: None, grace_period_ms: None },
+        mode: ChaosMode::Random,
+    }])
     .invariant(SingleActivation)
     .run()
 ```

--- a/moonpool-sim-examples/src/dungeon.rs
+++ b/moonpool-sim-examples/src/dungeon.rs
@@ -553,7 +553,7 @@ pub struct Dungeon {
     game: dungeon_game::Game,
     last_action_index: Option<u8>,
     /// Per-seed enabled subset of the action alphabet (swarm testing). Without
-    /// `.swarm()` this is the full alphabet, so behavior is unchanged.
+    /// `.swarm_operations()` this is the full alphabet, so behavior is unchanged.
     enabled_actions: Vec<u8>,
 }
 

--- a/moonpool-sim/src/lib.rs
+++ b/moonpool-sim/src/lib.rs
@@ -157,9 +157,9 @@ pub use sim::{
 
 // Runner module re-exports
 pub use runner::{
-    Attrition, ClientId, FaultContext, FaultInjector, IterationControl, Process, ProcessTags,
-    RebootKind, SimContext, SimulationBuilder, SimulationMetrics, SimulationReport, TagRegistry,
-    Workload, WorkloadCount, WorkloadTopology,
+    Attrition, Chaos, ChaosMode, ClientId, FaultContext, FaultInjector, IterationControl, Process,
+    ProcessTags, RebootKind, SimContext, SimulationBuilder, SimulationMetrics, SimulationReport,
+    TagRegistry, Workload, WorkloadCount, WorkloadTopology,
 };
 
 // Chaos module re-exports

--- a/moonpool-sim/src/runner/builder.rs
+++ b/moonpool-sim/src/runner/builder.rs
@@ -330,15 +330,59 @@ enum WorkloadEntry {
     },
 }
 
+/// How an enabled chaos surface is sampled each seed.
+///
+/// This is the *sampling-strategy* axis, orthogonal to *which* surface is
+/// enabled (see [`Chaos`]). It does not apply to the workload operation-alphabet
+/// swarm, which is a test-driver concern with its own switch
+/// ([`SimulationBuilder::swarm_operations`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChaosMode {
+    /// Full surface every seed: all sub-families active, intensities seed-randomized.
+    ///
+    /// Network/storage use `random_for_seed`; attrition uses the configured regime
+    /// as written (reboot kinds still vary per seed via the in-run RNG).
+    Random,
+    /// Swarm testing (Groce et al., ISSTA 2012): a per-seed random *subset* of
+    /// sub-families is active, the rest fully off.
+    ///
+    /// Network/storage use `swarm_for_seed`; attrition randomizes the reboot regime
+    /// per seed, including the never-reboot and single-mode cases.
+    Swarm,
+}
+
+/// A chaos surface to enable, and how to sample it per seed.
+///
+/// Pass these to [`SimulationBuilder::enable_chaos`]. A surface absent from the
+/// enable list is **off**. The two axes are orthogonal: enabling a surface
+/// (which variant) is distinct from how it is sampled (its [`ChaosMode`]).
+#[derive(Debug, Clone, PartialEq)]
+pub enum Chaos {
+    /// Network faults (clogging, partitions, bit-flips, random close, …).
+    Network(ChaosMode),
+    /// Storage faults (read/write/crash/misdirect/phantom/sync).
+    Storage(ChaosMode),
+    /// Process attrition (chaos reboots). Carries the base regime; requires
+    /// [`chaos_duration`](SimulationBuilder::chaos_duration) to actually run.
+    Attrition {
+        /// Base reboot regime (weights, `max_dead`, delays).
+        config: Attrition,
+        /// How the regime is sampled per seed.
+        mode: ChaosMode,
+    },
+}
+
 /// Builder pattern for configuring and running simulation experiments.
 pub struct SimulationBuilder {
     iteration_control: IterationControl,
     entries: Vec<WorkloadEntry>,
     process_entry: Option<ProcessEntry>,
     attrition: Option<Attrition>,
+    attrition_mode: ChaosMode,
     seeds: Vec<u64>,
-    use_random_config: bool,
-    use_swarm_config: bool,
+    network_chaos: Option<ChaosMode>,
+    storage_chaos: Option<ChaosMode>,
+    swarm_operations: bool,
     invariants: Vec<Box<dyn Invariant + Send>>,
     fault_injectors: Vec<Box<dyn FaultInjector>>,
     chaos_duration: Option<Duration>,
@@ -363,9 +407,11 @@ impl SimulationBuilder {
             entries: Vec::new(),
             process_entry: None,
             attrition: None,
+            attrition_mode: ChaosMode::Random,
             seeds: Vec::new(),
-            use_random_config: false,
-            use_swarm_config: false,
+            network_chaos: None,
+            storage_chaos: None,
+            swarm_operations: false,
             invariants: Vec::new(),
             fault_injectors: Vec::new(),
             chaos_duration: None,
@@ -648,27 +694,57 @@ impl SimulationBuilder {
         self
     }
 
-    /// Enable randomized network configuration for chaos testing.
+    /// Enable chaos surfaces and choose how each is sampled per seed.
+    ///
+    /// Each [`Chaos`] entry turns on one surface (network / storage / attrition)
+    /// in a given [`ChaosMode`] — `Random` (full surface every seed) or `Swarm`
+    /// (a per-seed random *subset* of sub-families, the rest fully off). A surface
+    /// not listed stays off. Later entries override earlier ones for the same
+    /// surface.
+    ///
+    /// `Swarm` mode defeats passive suppression: when every fault is always
+    /// slightly on (`Random`) families crowd each other out and the extreme
+    /// single-family configs that surface bugs almost never occur. Subset
+    /// decisions are drawn from a dedicated `CONFIG_RNG` stream, so they are
+    /// reproducible per seed yet never perturb in-run randomness or fork-explorer
+    /// replay.
+    ///
+    /// The workload operation-alphabet swarm is a separate, test-driver concern —
+    /// see [`swarm_operations`](Self::swarm_operations).
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// builder.enable_chaos([
+    ///     Chaos::Network(ChaosMode::Swarm),
+    ///     Chaos::Storage(ChaosMode::Swarm),
+    /// ]);
+    /// ```
     #[must_use]
-    pub fn random_network(mut self) -> Self {
-        self.use_random_config = true;
+    pub fn enable_chaos(mut self, surfaces: impl IntoIterator<Item = Chaos>) -> Self {
+        for surface in surfaces {
+            match surface {
+                Chaos::Network(mode) => self.network_chaos = Some(mode),
+                Chaos::Storage(mode) => self.storage_chaos = Some(mode),
+                Chaos::Attrition { config, mode } => {
+                    self.attrition = Some(config);
+                    self.attrition_mode = mode;
+                }
+            }
+        }
         self
     }
 
-    /// Enable swarm testing: each seed enables a random *subset* of network
-    /// fault families (~50% each, the rest fully off), including the all-off
-    /// subset.
+    /// Enable per-seed swarm testing of the workload operation alphabet.
     ///
-    /// This defeats passive suppression — when every fault is always slightly on
-    /// (as with [`random_network`](Self::random_network)) families crowd each
-    /// other out and the extreme single-family configs that surface bugs almost
-    /// never occur. Subset decisions are drawn from a dedicated `CONFIG_RNG`
-    /// stream, so they are reproducible per seed yet never perturb in-run
-    /// randomness or fork-explorer replay. Takes precedence over
-    /// `random_network`.
+    /// When enabled, each seed exposes a random *subset* of each workload's
+    /// operation alphabet via [`swarm_op_enabled`](crate::swarm_op_enabled), so
+    /// bugs reachable only when whole operation groups are suppressed become
+    /// reachable across seeds. Decisions come from a dedicated per-seed stream and
+    /// are reproducible. Independent of [`enable_chaos`](Self::enable_chaos).
     #[must_use]
-    pub fn swarm(mut self) -> Self {
-        self.use_swarm_config = true;
+    pub fn swarm_operations(mut self) -> Self {
+        self.swarm_operations = true;
         self
     }
 
@@ -781,22 +857,30 @@ impl SimulationBuilder {
         })
     }
 
-    /// Build a `SimWorld` for the iteration, picking a swarm-subset, randomised,
-    /// or default network configuration. `use_swarm` takes precedence over
-    /// `use_random`.
+    /// Build a `SimWorld` for the iteration, picking each chaos surface's config
+    /// from its [`ChaosMode`]: `None` ⇒ default (off), `Random` ⇒ `random_for_seed`,
+    /// `Swarm` ⇒ `swarm_for_seed`.
+    ///
+    /// The network mask (if any) draws from `CONFIG_RNG` before the storage mask,
+    /// keeping the per-seed draw order fixed and reproducible.
     fn build_sim_for_iteration(
-        use_random: bool,
-        use_swarm: bool,
+        network_chaos: Option<ChaosMode>,
+        storage_chaos: Option<ChaosMode>,
         seed: u64,
     ) -> crate::sim::SimWorld {
-        let network_config = if use_swarm {
-            crate::NetworkConfiguration::swarm_for_seed()
-        } else if use_random {
-            crate::NetworkConfiguration::random_for_seed()
-        } else {
-            crate::NetworkConfiguration::default()
+        let network_config = match network_chaos {
+            Some(ChaosMode::Swarm) => crate::NetworkConfiguration::swarm_for_seed(),
+            Some(ChaosMode::Random) => crate::NetworkConfiguration::random_for_seed(),
+            None => crate::NetworkConfiguration::default(),
         };
-        crate::sim::SimWorld::new_with_network_config_and_seed(network_config, seed)
+        let storage_config = match storage_chaos {
+            Some(ChaosMode::Swarm) => crate::storage::StorageConfiguration::swarm_for_seed(),
+            Some(ChaosMode::Random) => crate::storage::StorageConfiguration::random_for_seed(),
+            None => crate::storage::StorageConfiguration::default(),
+        };
+        let mut sim = crate::sim::SimWorld::new_with_network_config_and_seed(network_config, seed);
+        sim.set_storage_config(storage_config);
+        sim
     }
 
     /// Drain user-provided fault injectors and, when present, append the
@@ -977,7 +1061,11 @@ impl SimulationBuilder {
     }
 
     /// Reset per-iteration state: capture buffers, RNG, buggify, and chaos.
-    fn reset_per_iteration_state(seed: u64, use_swarm: bool, obs_handle: &SimulationLayerHandle) {
+    fn reset_per_iteration_state(
+        seed: u64,
+        swarm_operations: bool,
+        obs_handle: &SimulationLayerHandle,
+    ) {
         obs_handle.reset_for_seed();
         crate::sim::reset_sim_rng();
         crate::sim::set_sim_seed(seed);
@@ -986,7 +1074,7 @@ impl SimulationBuilder {
         crate::sim::set_config_seed(seed);
         // Per-seed base for the workload operation-alphabet swarm mask; `None`
         // disables masking so workloads see the full alphabet.
-        crate::sim::set_swarm_op_seed(use_swarm.then_some(seed));
+        crate::sim::set_swarm_op_seed(swarm_operations.then_some(seed));
         crate::chaos::reset_always_violations();
         // Use moderate probabilities: 50% activation rate, 25% firing rate.
         crate::chaos::buggify_init(0.5, 0.25);
@@ -1276,7 +1364,7 @@ impl SimulationBuilder {
             hook();
         }
 
-        Self::reset_per_iteration_state(seed, self.use_swarm_config, obs_handle);
+        Self::reset_per_iteration_state(seed, self.swarm_operations, obs_handle);
 
         if matches!(
             self.iteration_control,
@@ -1316,11 +1404,18 @@ impl SimulationBuilder {
             .as_ref()
             .map(Self::resolve_process_config);
 
-        let sim =
-            Self::build_sim_for_iteration(self.use_random_config, self.use_swarm_config, seed);
+        let sim = Self::build_sim_for_iteration(self.network_chaos, self.storage_chaos, seed);
         let start_time = Instant::now();
+        // Derive the per-seed attrition regime: `Swarm` draws a fresh reboot regime
+        // from `CONFIG_RNG` (after the network/storage masks, keeping the draw order
+        // fixed); `Random` uses the configured weights as written.
+        let attrition = match (self.attrition.as_ref(), self.attrition_mode) {
+            (Some(base), ChaosMode::Swarm) => Some(base.swarm_for_seed()),
+            (Some(base), ChaosMode::Random) => Some(base.clone()),
+            (None, _) => None,
+        };
         let fault_injectors =
-            Self::collect_fault_injectors(&mut self.fault_injectors, self.attrition.as_ref());
+            Self::collect_fault_injectors(&mut self.fault_injectors, attrition.as_ref());
         let outcome = Self::run_orchestrator_blocking(RunOrchestratorInputs {
             seed,
             iteration_count,

--- a/moonpool-sim/src/runner/mod.rs
+++ b/moonpool-sim/src/runner/mod.rs
@@ -23,7 +23,7 @@ pub(crate) mod wall_clock;
 pub mod workload;
 
 // Re-export main types at module level
-pub use builder::{ClientId, WorkloadCount};
+pub use builder::{Chaos, ChaosMode, ClientId, WorkloadCount};
 pub use builder::{IterationControl, SimulationBuilder};
 pub use context::SimContext;
 pub use fault_injector::{FaultContext, FaultInjector};

--- a/moonpool-sim/src/runner/process.rs
+++ b/moonpool-sim/src/runner/process.rs
@@ -155,4 +155,100 @@ impl Attrition {
             RebootKind::CrashAndWipe
         }
     }
+
+    /// Derive a per-seed swarm reboot regime from this base configuration.
+    ///
+    /// Implements *swarm testing* (Groce et al., ISSTA 2012) for attrition: each
+    /// seed exercises a random reboot *regime* rather than the fixed configured
+    /// one. This surfaces bug classes that a single fixed regime hides — most
+    /// importantly the **never-reboot** case (needed to find slow leaks / timer
+    /// overflows) and single-mode cases ("always crash", "graceful-only").
+    ///
+    /// Draws exactly four `config_random_bool` values from the independent
+    /// `CONFIG_RNG` stream (fixed sequence ⇒ reproducible per seed, never
+    /// perturbs in-run randomness). The first draw, with ~50% probability, sets
+    /// `max_dead = 0` — the never-reboot regime, where the injector's
+    /// `dead_count() >= max_dead` gate is always true so it never reboots. The
+    /// remaining three each mask one reboot-kind weight to `0.0` with ~50%
+    /// probability.
+    ///
+    /// When all three kind weights are masked off, [`choose_kind`](Self::choose_kind)
+    /// falls back to [`RebootKind::Crash`] — the "always crash" single-mode regime.
+    #[must_use]
+    pub fn swarm_for_seed(&self) -> Attrition {
+        let mut regime = self.clone();
+        if !crate::sim::config_random_bool(0.5) {
+            regime.max_dead = 0;
+        }
+        if !crate::sim::config_random_bool(0.5) {
+            regime.prob_graceful = 0.0;
+        }
+        if !crate::sim::config_random_bool(0.5) {
+            regime.prob_crash = 0.0;
+        }
+        if !crate::sim::config_random_bool(0.5) {
+            regime.prob_wipe = 0.0;
+        }
+        regime
+    }
+}
+
+#[cfg(test)]
+mod swarm_tests {
+    use super::Attrition;
+    use crate::sim::rng::set_config_seed;
+
+    /// A representative base regime: all three reboot kinds enabled.
+    fn base() -> Attrition {
+        Attrition {
+            max_dead: 2,
+            prob_graceful: 0.3,
+            prob_crash: 0.5,
+            prob_wipe: 0.2,
+            recovery_delay_ms: None,
+            grace_period_ms: None,
+        }
+    }
+
+    /// Build a swarm regime the way the runner does: config stream seeded per iteration.
+    fn swarm_for(seed: u64) -> Attrition {
+        set_config_seed(seed);
+        base().swarm_for_seed()
+    }
+
+    #[test]
+    fn swarm_regime_is_deterministic_per_seed() {
+        for seed in [0_u64, 1, 42, 12_345] {
+            assert_eq!(
+                swarm_for(seed),
+                swarm_for(seed),
+                "swarm regime must be reproducible for seed {seed}"
+            );
+        }
+    }
+
+    #[test]
+    fn swarm_reaches_never_reboot() {
+        let saw_never_reboot = (0..1000_u64).any(|s| swarm_for(s).max_dead == 0);
+        assert!(
+            saw_never_reboot,
+            "no seed in 0..1000 produced the never-reboot regime (max_dead == 0)"
+        );
+    }
+
+    #[test]
+    fn swarm_reaches_single_mode() {
+        let saw_single_mode = (0..1000_u64).any(|s| {
+            let r = swarm_for(s);
+            let on = [r.prob_graceful, r.prob_crash, r.prob_wipe]
+                .iter()
+                .filter(|&&w| w > 0.0)
+                .count();
+            on == 1
+        });
+        assert!(
+            saw_single_mode,
+            "no seed in 0..1000 produced a single-mode regime (one kind enabled)"
+        );
+    }
 }

--- a/moonpool-sim/src/sim/rng.rs
+++ b/moonpool-sim/src/sim/rng.rs
@@ -49,8 +49,8 @@ thread_local! {
 
     /// Thread-local per-seed base for workload operation-alphabet swarm masks.
     ///
-    /// `Some(seed)` when `.swarm()` is enabled for the current iteration,
-    /// `None` otherwise. See [`swarm_op_enabled`] for how it is consumed; like
+    /// `Some(seed)` when `.swarm_operations()` is enabled for the current
+    /// iteration, `None` otherwise. See [`swarm_op_enabled`] for how it is consumed; like
     /// [`CONFIG_RNG`] it never touches the [`SIM_RNG`] call count.
     static SWARM_OP_SEED: Cell<Option<u64>> = const { Cell::new(None) };
 }
@@ -312,8 +312,8 @@ pub fn config_random_bool(p: f64) -> bool {
 
 /// Set the per-seed base for workload operation-alphabet swarm masks.
 ///
-/// Called once per iteration by the runner: `Some(seed)` when `.swarm()` is
-/// enabled, `None` otherwise. With `None`, [`swarm_op_enabled`] reports every
+/// Called once per iteration by the runner: `Some(seed)` when `.swarm_operations()`
+/// is enabled, `None` otherwise. With `None`, [`swarm_op_enabled`] reports every
 /// operation as enabled (full alphabet — zero behavior change).
 pub fn set_swarm_op_seed(seed: Option<u64>) {
     SWARM_OP_SEED.with(|s| s.set(seed));

--- a/moonpool-sim/src/storage/config.rs
+++ b/moonpool-sim/src/storage/config.rs
@@ -50,7 +50,7 @@
 //! - Storage faults: TigerBeetle storage simulation
 //! - Crash consistency: FDB AsyncFileKAIO, TigerBeetle deterministic testing
 
-use crate::sim::rng::sim_random_range;
+use crate::sim::rng::{config_random_bool, sim_random_range};
 use std::ops::Range;
 use std::time::Duration;
 
@@ -215,6 +215,52 @@ impl StorageConfiguration {
         }
     }
 
+    /// Create a swarm-testing storage configuration for seed-based testing.
+    ///
+    /// Starts from [`random_for_seed`](Self::random_for_seed), then disables each
+    /// fault family with ~50% probability (drawn from the independent `CONFIG_RNG`
+    /// stream). This implements *swarm testing* (Groce et al., ISSTA 2012): each
+    /// seed exercises a random *subset* of storage fault families — including the
+    /// all-off subset — instead of every family being slightly on at once (which
+    /// lets families crowd each other out, the passive-suppression anti-pattern).
+    #[must_use]
+    pub fn swarm_for_seed() -> Self {
+        let mut config = Self::random_for_seed();
+        config.apply_swarm_mask();
+        config
+    }
+
+    /// Disable each fault family with ~50% probability using the `CONFIG_RNG`
+    /// stream (see [`swarm_for_seed`](Self::swarm_for_seed)).
+    ///
+    /// Draws exactly seven `config_random_bool` values (one per family) so the
+    /// `CONFIG_RNG` call sequence is fixed and reproducible per seed. Performance
+    /// parameters (IOPS, bandwidth, latencies) stay as sampled — only the fault
+    /// families are masked.
+    fn apply_swarm_mask(&mut self) {
+        if !config_random_bool(0.5) {
+            self.read_fault_probability = 0.0;
+        }
+        if !config_random_bool(0.5) {
+            self.write_fault_probability = 0.0;
+        }
+        if !config_random_bool(0.5) {
+            self.crash_fault_probability = 0.0;
+        }
+        if !config_random_bool(0.5) {
+            self.misdirect_read_probability = 0.0;
+        }
+        if !config_random_bool(0.5) {
+            self.misdirect_write_probability = 0.0;
+        }
+        if !config_random_bool(0.5) {
+            self.phantom_write_probability = 0.0;
+        }
+        if !config_random_bool(0.5) {
+            self.sync_failure_probability = 0.0;
+        }
+    }
+
     /// Create a configuration optimized for fast local testing.
     ///
     /// Minimal latencies and no fault injection for predictable,
@@ -238,5 +284,96 @@ impl StorageConfiguration {
             phantom_write_probability: 0.0,
             sync_failure_probability: 0.0,
         }
+    }
+}
+
+#[cfg(test)]
+mod swarm_tests {
+    use super::StorageConfiguration;
+    use crate::sim::rng::{reset_sim_rng, set_config_seed, set_sim_seed};
+
+    /// The on/off state of each swarmed fault family, in mask order.
+    fn enabled_families(config: &StorageConfiguration) -> [bool; 7] {
+        [
+            config.read_fault_probability > 0.0,
+            config.write_fault_probability > 0.0,
+            config.crash_fault_probability > 0.0,
+            config.misdirect_read_probability > 0.0,
+            config.misdirect_write_probability > 0.0,
+            config.phantom_write_probability > 0.0,
+            config.sync_failure_probability > 0.0,
+        ]
+    }
+
+    /// Build a swarm config the way the runner does: both streams seeded per iteration.
+    fn swarm_for(seed: u64) -> StorageConfiguration {
+        reset_sim_rng();
+        set_sim_seed(seed);
+        set_config_seed(seed);
+        StorageConfiguration::swarm_for_seed()
+    }
+
+    #[test]
+    fn swarm_subset_is_deterministic_per_seed() {
+        for seed in [0_u64, 1, 42, 12_345] {
+            let first = enabled_families(&swarm_for(seed));
+            let second = enabled_families(&swarm_for(seed));
+            assert_eq!(
+                first, second,
+                "swarm subset must be reproducible for seed {seed}"
+            );
+        }
+    }
+
+    #[test]
+    fn swarm_reaches_all_off_and_mixed_subsets() {
+        let mut saw_all_off = false;
+        let mut saw_mixed = false;
+
+        for seed in 0..1000_u64 {
+            let families = enabled_families(&swarm_for(seed));
+            let on = families.iter().filter(|&&e| e).count();
+            if on == 0 {
+                saw_all_off = true;
+            }
+            if on > 0 && on < families.len() {
+                saw_mixed = true;
+            }
+            if saw_all_off && saw_mixed {
+                break;
+            }
+        }
+
+        assert!(
+            saw_all_off,
+            "no seed in 0..1000 produced the all-off subset"
+        );
+        assert!(saw_mixed, "no seed in 0..1000 produced a mixed subset");
+    }
+
+    #[test]
+    fn swarm_all_off_seed_has_zero_fault_probabilities() {
+        // Find a seed whose subset is entirely off, then assert every family is inert.
+        let seed = (0..1000_u64)
+            .find(|&s| enabled_families(&swarm_for(s)).iter().all(|&e| !e))
+            .expect("expected an all-off seed within 0..1000");
+
+        let config = swarm_for(seed);
+        assert_zero(config.read_fault_probability);
+        assert_zero(config.write_fault_probability);
+        assert_zero(config.crash_fault_probability);
+        assert_zero(config.misdirect_read_probability);
+        assert_zero(config.misdirect_write_probability);
+        assert_zero(config.phantom_write_probability);
+        assert_zero(config.sync_failure_probability);
+    }
+
+    /// Assert an f64 is exactly `+0.0` (bit-exact, avoiding the float-cmp lint).
+    fn assert_zero(value: f64) {
+        assert_eq!(
+            value.to_bits(),
+            0.0_f64.to_bits(),
+            "expected 0.0, got {value}"
+        );
     }
 }

--- a/moonpool-sim/tests/chaos/swarm.rs
+++ b/moonpool-sim/tests/chaos/swarm.rs
@@ -14,7 +14,7 @@
 //! so it exercises the swarm-configured network provider without that coupling.
 
 use async_trait::async_trait;
-use moonpool_sim::{NetworkProvider, SimContext, SimulationBuilder, Workload};
+use moonpool_sim::{Chaos, ChaosMode, NetworkProvider, SimContext, SimulationBuilder, Workload};
 
 /// Minimal workload: touches the swarm-configured network provider via `bind`
 /// and fires a coverage gate. Always completes, regardless of fault subset.
@@ -41,7 +41,7 @@ impl Workload for SwarmSmokeWorkload {
 #[test]
 fn swarm_runs_clean_across_seeds() {
     let report = SimulationBuilder::new()
-        .swarm()
+        .enable_chaos([Chaos::Network(ChaosMode::Swarm)])
         .set_iterations(50)
         .workload(SwarmSmokeWorkload)
         .run();

--- a/moonpool-sim/tests/reboot.rs
+++ b/moonpool-sim/tests/reboot.rs
@@ -7,9 +7,9 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use moonpool_sim::{
-    Attrition, FaultContext, FaultInjector, Invariant, NetworkProvider, Process, RebootKind,
-    SIM_FAULT_EVENT_NAME, SimContext, SimulationBuilder, SimulationResult, TcpListenerTrait,
-    TimeProvider, TraceQuery, Workload, assert_always,
+    Attrition, Chaos, ChaosMode, FaultContext, FaultInjector, Invariant, NetworkProvider, Process,
+    RebootKind, SIM_FAULT_EVENT_NAME, SimContext, SimulationBuilder, SimulationResult,
+    TcpListenerTrait, TimeProvider, TraceQuery, Workload, assert_always,
 };
 
 use std::cell::Cell;
@@ -213,14 +213,17 @@ fn test_builtin_attrition() {
     let report = SimulationBuilder::new()
         .processes(3, || Box::new(EchoProcess))
         .workload(TimedWorkload(Duration::from_secs(25)))
-        .attrition(Attrition {
-            max_dead: 1,
-            prob_graceful: 0.3,
-            prob_crash: 0.5,
-            prob_wipe: 0.2,
-            recovery_delay_ms: None,
-            grace_period_ms: None,
-        })
+        .enable_chaos([Chaos::Attrition {
+            config: Attrition {
+                max_dead: 1,
+                prob_graceful: 0.3,
+                prob_crash: 0.5,
+                prob_wipe: 0.2,
+                recovery_delay_ms: None,
+                grace_period_ms: None,
+            },
+            mode: ChaosMode::Random,
+        }])
         .chaos_duration(Duration::from_secs(10))
         .set_iterations(3)
         .set_debug_seeds(vec![42, 123, 999])
@@ -553,14 +556,17 @@ fn test_attrition_timing_invariant() {
     let report = SimulationBuilder::new()
         .processes(3, || Box::new(EchoProcess))
         .workload(TimedWorkload(Duration::from_secs(25)))
-        .attrition(Attrition {
-            max_dead: 1,
-            prob_graceful: 0.5,
-            prob_crash: 0.3,
-            prob_wipe: 0.2,
-            recovery_delay_ms: Some(500..2000),
-            grace_period_ms: Some(1000..3000),
-        })
+        .enable_chaos([Chaos::Attrition {
+            config: Attrition {
+                max_dead: 1,
+                prob_graceful: 0.5,
+                prob_crash: 0.3,
+                prob_wipe: 0.2,
+                recovery_delay_ms: Some(500..2000),
+                grace_period_ms: Some(1000..3000),
+            },
+            mode: ChaosMode::Random,
+        }])
         .invariant(RebootTimingInvariant::new())
         .chaos_duration(Duration::from_secs(10))
         .set_iterations(5)
@@ -580,14 +586,17 @@ fn test_max_dead_limits_concurrent_kills_via_attrition() {
     let report = SimulationBuilder::new()
         .processes(5, || Box::new(EchoProcess))
         .workload(TimedWorkload(Duration::from_secs(25)))
-        .attrition(Attrition {
-            max_dead: 1,
-            prob_graceful: 0.0,
-            prob_crash: 1.0,
-            prob_wipe: 0.0,
-            recovery_delay_ms: Some(500..2000),
-            grace_period_ms: None,
-        })
+        .enable_chaos([Chaos::Attrition {
+            config: Attrition {
+                max_dead: 1,
+                prob_graceful: 0.0,
+                prob_crash: 1.0,
+                prob_wipe: 0.0,
+                recovery_delay_ms: Some(500..2000),
+                grace_period_ms: None,
+            },
+            mode: ChaosMode::Random,
+        }])
         .chaos_duration(Duration::from_secs(10))
         .set_iterations(5)
         .set_debug_seeds(vec![42, 123, 999, 7, 314])

--- a/moonpool-sim/tests/swarm_op_alphabet.rs
+++ b/moonpool-sim/tests/swarm_op_alphabet.rs
@@ -1,6 +1,6 @@
 //! Integration test for workload operation-alphabet swarm testing (issue #129).
 //!
-//! Verifies the end-to-end wiring: with `.swarm()`, each seed enables a random
+//! Verifies the end-to-end wiring: with `.swarm_operations()`, each seed enables a random
 //! *subset* of a workload's operation alphabet (via [`swarm_op_enabled`]), so a
 //! demonstrator that only triggers when a whole operation sub-group is masked
 //! off becomes reachable across seeds — yet stays unreachable under the
@@ -60,7 +60,7 @@ fn seeds() -> Vec<u64> {
 #[test]
 fn swarm_makes_group_suppression_reachable() {
     let report = SimulationBuilder::new()
-        .swarm()
+        .swarm_operations()
         .set_debug_seeds(seeds())
         .set_iterations(400)
         .workload(OpAlphabetWorkload)

--- a/moonpool-transport-sim/src/bin/sim/transport.rs
+++ b/moonpool-transport-sim/src/bin/sim/transport.rs
@@ -6,8 +6,8 @@
 use std::process;
 use std::time::Duration;
 
-use moonpool_sim::SimulationBuilder;
 use moonpool_sim::runner::builder::{ProcessCount, WorkloadCount};
+use moonpool_sim::{Chaos, ChaosMode, SimulationBuilder};
 
 use moonpool_transport_sim::invariants::TransportIntegrityInvariant;
 use moonpool_transport_sim::process::TransportServerProcess;
@@ -25,8 +25,9 @@ fn main() {
         .chaos_duration(Duration::from_secs(10))
         // Swarm: each seed runs a random *subset* of both the network fault
         // families and the workload's operation alphabet (the rest fully off),
-        // defeating passive/active suppression. Supersedes `.random_network()`.
-        .swarm()
+        // defeating passive/active suppression.
+        .enable_chaos([Chaos::Network(ChaosMode::Swarm)])
+        .swarm_operations()
         .set_iterations(20)
         .seed_warning_timeout(Duration::from_secs(15))
         .run();

--- a/moonpool-wasm-demo/README.md
+++ b/moonpool-wasm-demo/README.md
@@ -21,7 +21,7 @@ Because it keys off that standard event contract, the *same* recorder visualizes
 any transport workload that emits it — swap in a consensus layer and you'd watch
 its messages and chaos with no recorder changes.
 
-`.random_network()` turns on seeded network chaos — variable latency, reordering,
+`.enable_chaos([Chaos::Network(ChaosMode::Random)])` turns on seeded network chaos — variable latency, reordering,
 connection drops — so a request comes back fast, slowly, or not at all. The
 front-end animates each round trip as a ball flying A→B→A; a dropped request is a
 ball lost at the net (red ✗). Nothing really waits: logical time is driven by the

--- a/moonpool-wasm-demo/src/lib.rs
+++ b/moonpool-wasm-demo/src/lib.rs
@@ -16,7 +16,7 @@
 //! recorder visualizes any transport workload that emits it (e.g. the
 //! hash-chain workload in `moonpool-transport-sim`) with no changes.
 //!
-//! `.random_network()` turns on seeded network chaos — variable latency,
+//! `.enable_chaos([Chaos::Network(ChaosMode::Random)])` turns on seeded network chaos — variable latency,
 //! reordering, connection drops — so a request comes back fast, slowly, or not
 //! at all. Each acknowledged request becomes two [`Shot`] legs (A→B then B→A)
 //! split over the observed round-trip time; a failed request becomes a single
@@ -31,9 +31,9 @@
 use async_trait::async_trait;
 use moonpool_sim::runner::builder::{ProcessCount, WorkloadCount};
 use moonpool_sim::{
-    Invariant, Process, SIM_FAULT_EVENT_NAME, SimContext, SimulationBuilder, SimulationError,
-    SimulationResult, TimeProvider, TraceQuery, Workload, assert_always, assert_reachable,
-    assert_sometimes,
+    Chaos, ChaosMode, Invariant, Process, SIM_FAULT_EVENT_NAME, SimContext, SimulationBuilder,
+    SimulationError, SimulationResult, TimeProvider, TraceQuery, Workload, assert_always,
+    assert_reachable, assert_sometimes,
 };
 use moonpool_transport::{
     Endpoint, JsonCodec, NetTransport, NetTransportBuilder, NetworkAddress, ReplyError,
@@ -431,7 +431,7 @@ pub fn run_seed(seed: u64) -> RunResult {
         .workloads(WorkloadCount::Fixed(1), |_| Box::new(PingClient))
         .invariant(TimelineRecorder { data: data.clone() })
         .chaos_duration(Duration::from_secs(CHAOS_SECS))
-        .random_network()
+        .enable_chaos([Chaos::Network(ChaosMode::Random)])
         .set_iterations(1)
         .set_debug_seeds(vec![seed])
         .run();


### PR DESCRIPTION
Closes #130. Completes epic #131 (swarm testing) — #128/#129/#130 now all done.

## What

Replaces the overloaded `.swarm()` / `.random_network()` / `.attrition()` builder methods with a declarative, type-safe API:

```rust
.enable_chaos([
    Chaos::Network(ChaosMode::Swarm),
    Chaos::Storage(ChaosMode::Swarm),
    Chaos::Attrition { config: attr, mode: ChaosMode::Swarm },
])
.swarm_operations()   // op-alphabet swarm — its own switch
```

Two orthogonal axes, previously conflated in one `.swarm()` flag:
- **Which surface is enabled** — `Chaos::{Network, Storage, Attrition}` (absent ⇒ off)
- **How it's sampled per seed** — `ChaosMode::Random` (full surface) vs `ChaosMode::Swarm` (per-seed random subset, rest fully off)

## Why

Two chaos surfaces never varied per seed before:
- **Attrition** reboot weights were fixed and cloned every iteration — no "never reboot" regime (which surfaces slow-leak / timer bugs that constant restarting hides).
- **Storage** `random_for_seed()` existed but was **never called** — every run used the all-off default; storage faults never participated in per-seed variation.

## Changes

- **storage** (`storage/config.rs`): `swarm_for_seed()` + `apply_swarm_mask()` masking the 7 fault families via the independent `CONFIG_RNG` stream; wired into `build_sim_for_iteration` through the existing `set_storage_config`.
- **attrition** (`runner/process.rs`): `swarm_for_seed()` randomizes the reboot regime — never-reboot (`max_dead = 0`), single-mode (always-crash / graceful-only), and mixes.
- **builder** (`runner/builder.rs`): `Chaos`/`ChaosMode` enums (re-exported from `moonpool_sim`), `enable_chaos` / `swarm_operations`; deletes the `use_random_config`/`use_swarm_config` bools and old methods.
- **migration**: transport sim, `chaos/swarm.rs`, `swarm_op_alphabet.rs`, wasm-demo, 3 `reboot.rs` sites, plus book / CLAUDE.md / spec docs.

## Backward-compat / safety

Library isn't in external use, so old APIs are deleted (no deprecation). The redesign is additive in behavior: every surface is off unless listed, so migrated callers behave as before and default runs draw zero new RNG (byte-identical). Verified no existing swarm/random caller does storage I/O or configures attrition, so the storage/attrition paths don't perturb them.

## Validation

- `cargo fmt`, `cargo clippy --all-targets -- -D warnings` (pedantic, no `#[allow]`)
- `cargo nextest run` → 555 passed, incl. 6 new swarm unit tests (3 storage, 3 attrition)
- Portability: `clippy -p moonpool-sim --no-default-features` + `check --target wasm32-unknown-unknown`
- `mdbook build book/`
- Transport sim end-to-end: 20/20 iterations passed

## Follow-up

Overlap noted on #125 (buggify knob randomization): `ChaosMode::Swarm` delivers the on/off framing the epic said subsumes it; its remaining unique scope is value-spiking. Candidate for close-as-subsumed or reframe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)