### PR TITLE
feat(moonpool-sim): partial read delivery in simulated connections (#66)

### DIFF
--- a/book/src/appendix/03-configuration.md
+++ b/book/src/appendix/03-configuration.md
@@ -174,6 +174,12 @@ Each ordered IP pair samples one fixed latency from this range at first contact 
 |-------|------|---------|
 | `partial_write_max_bytes` | `usize` | 1000 |
 
+### Partial Reads
+
+| Field | Type | Default |
+|-------|------|---------|
+| `partial_read_max_bytes` | `usize` | 1000 |
+
 ### Random Connection Close
 
 | Field | Type | Default |

--- a/book/src/appendix/04-fault-reference.md
+++ b/book/src/appendix/04-fault-reference.md
@@ -53,6 +53,7 @@ Manual partition methods are also available on `SimWorld`: `partition_pair()`, `
 | Flip range | `bit_flip_min_bits` / `bit_flip_max_bits` | 1-32 bits | Power-law distribution of corruption severity |
 | Flip cooldown | `bit_flip_cooldown` | 0 (no cooldown) | Rate-limiting corruption events |
 | Partial writes | `partial_write_max_bytes` | 1000 bytes | TCP fragmentation, message framing |
+| Partial reads | `partial_read_max_bytes` | 1000 bytes | TCP short reads, message reassembly / framing |
 
 ### Half-Open Connections
 

--- a/book/src/part3-building/10-network-faults.md
+++ b/book/src/part3-building/10-network-faults.md
@@ -34,6 +34,10 @@ Write clogging stalls data delivery on a connection for a random duration (100-3
 
 Writes are truncated to a random length (0 to 1000 bytes by default), following FoundationDB's approach. This tests TCP fragmentation handling and message framing logic. If your wire protocol assumes that a single write delivers a complete message, partial writes will break that assumption immediately.
 
+### Partial Reads
+
+Reads are the mirror image: a read returns a random prefix of what is buffered (1 to 1000 bytes by default), and the rest stays buffered for the next read. FoundationDB's `Sim2Conn` does the same 50/50 split on the receiver. The one asymmetry with writes is that a partial read always delivers **at least one byte** when data is available, because a zero-byte read is how the stream signals end-of-file. This exercises the reassembly side of your wire protocol: code that calls `read` once and assumes it got a whole message will drop bytes the moment a short read splits a header or a length prefix.
+
 ### Bit Flips
 
 Packet data is corrupted with random bit flips at low probability (0.01% by default). The number of flipped bits follows a power-law distribution between 1 and 32. This tests checksum validation and corruption detection. Without bit-flip injection, corruption bugs only surface in production when cosmic rays or faulty NICs flip bits for you.

--- a/moonpool-sim/src/network/config.rs
+++ b/moonpool-sim/src/network/config.rs
@@ -38,11 +38,12 @@
 //! |-------|--------------|---------|---------------------|
 //! | Bit flip | `bit_flip_probability` + `bit_flip_min/max_bits` | 0.01%, 1-32 bits | CRC/checksum validation, data corruption detection |
 //!
-//! ## Partial Write Simulation
+//! ## Partial Write/Read Simulation
 //!
 //! | Feature | Config Field | Default | Real-World Scenario |
 //! |---------|--------------|---------|---------------------|
 //! | Short writes | `partial_write_max_bytes` | 1000 bytes | TCP fragmentation handling, message framing |
+//! | Short reads | `partial_read_max_bytes` | 1000 bytes | TCP short reads, message reassembly / framing |
 //!
 //! ## Configuration Examples
 //!
@@ -167,6 +168,12 @@ pub struct ChaosConfiguration {
     /// Following FDB's approach of truncating writes to test TCP backpressure handling
     pub partial_write_max_bytes: usize,
 
+    /// Maximum bytes for partial read simulation (BUGGIFY truncates reads to 1-max_bytes)
+    /// Mirrors FDB's `Sim2Conn` partial delivery on the receiver to test short reads
+    /// and message reassembly. Always delivers at least one byte so a partial read is
+    /// never mistaken for EOF.
+    pub partial_read_max_bytes: usize,
+
     /// Random connection close probability per I/O operation (0.0 - 1.0)
     /// FDB default: 0.00001 (0.001%) - see sim2.actor.cpp:584
     pub random_close_probability: f64,
@@ -240,6 +247,7 @@ impl Default for ChaosConfiguration {
             bit_flip_max_bits: 32,
             bit_flip_cooldown: Duration::ZERO, // No cooldown by default for maximum chaos
             partial_write_max_bytes: 1000,     // Matches FDB's randomInt(0, 1000)
+            partial_read_max_bytes: 1000,      // Symmetric with partial writes
             random_close_probability: 0.00001, // 0.001% - matches FDB's sim2.actor.cpp:584
             random_close_cooldown: Duration::from_secs(5), // Reasonable default
             random_close_explicit_ratio: 0.3,  // 30% explicit - matches FDB's sim2.actor.cpp:602
@@ -270,6 +278,7 @@ impl ChaosConfiguration {
             bit_flip_max_bits: 32,
             bit_flip_cooldown: Duration::ZERO,
             partial_write_max_bytes: 1000,
+            partial_read_max_bytes: 1000,
             random_close_probability: 0.0,
             random_close_cooldown: Duration::ZERO,
             random_close_explicit_ratio: 0.3,
@@ -322,6 +331,9 @@ impl ChaosConfiguration {
             // buggifies MAX_CLOGGING_LATENCY to 0.1s). Kept last so existing RNG
             // draws above are unaffected.
             max_pair_latency: Duration::ZERO..Duration::from_millis(sim_random_range(0..100)),
+            // Vary max bytes for different scenarios. Appended last (after
+            // max_pair_latency) so the RNG draws above keep their per-seed values.
+            partial_read_max_bytes: sim_random_range(100..2000),
         }
     }
 

--- a/moonpool-sim/src/sim/world.rs
+++ b/moonpool-sim/src/sim/world.rs
@@ -561,12 +561,46 @@ impl SimWorld {
             .write()
             .expect("RwLock poisoned: prior task panicked");
 
+        // Read the config knob before borrowing the connection mutably (disjoint
+        // fields, but keeping it a local sidesteps any borrow friction).
+        let partial_read_max_bytes = inner.network.config.chaos.partial_read_max_bytes;
+
         if let Some(connection) = inner.network.connections.get_mut(&connection_id) {
+            let available = std::cmp::min(buf.len(), connection.receive_buffer.len());
+
+            // BUGGIFY: simulate a partial read by delivering fewer bytes than are
+            // available, leaving the remainder buffered for the next read (mirrors
+            // FDB's Sim2Conn receiver). Skip stable connections. Always deliver at
+            // least one byte so the caller never mistakes a partial read for EOF,
+            // which would leave poll_read waiting on data already in the buffer.
+            let limit = if available > 0 && !connection.flags.is_stable() && crate::buggify!() {
+                let max_read = std::cmp::min(available, partial_read_max_bytes);
+                if max_read >= 1 {
+                    let n = sim_random_range(1..max_read + 1);
+                    if n < available {
+                        tracing::debug!(
+                            "BUGGIFY: Partial read on connection {} - delivering {} of {} bytes",
+                            connection_id.0,
+                            n,
+                            available
+                        );
+                    }
+                    n
+                } else {
+                    available
+                }
+            } else {
+                available
+            };
+
             let mut bytes_read = 0;
-            while bytes_read < buf.len() && !connection.receive_buffer.is_empty() {
-                if let Some(byte) = connection.receive_buffer.pop_front() {
-                    buf[bytes_read] = byte;
-                    bytes_read += 1;
+            while bytes_read < limit {
+                match connection.receive_buffer.pop_front() {
+                    Some(byte) => {
+                        buf[bytes_read] = byte;
+                        bytes_read += 1;
+                    }
+                    None => break,
                 }
             }
             Ok(bytes_read)

--- a/moonpool-sim/tests/chaos.rs
+++ b/moonpool-sim/tests/chaos.rs
@@ -12,6 +12,8 @@ mod buggify;
 mod clock_drift;
 #[path = "chaos/connect_failure.rs"]
 mod connect_failure;
+#[path = "chaos/partial_read.rs"]
+mod partial_read;
 #[path = "chaos/random_close.rs"]
 mod random_close;
 #[path = "chaos/swarm.rs"]

--- a/moonpool-sim/tests/chaos/partial_read.rs
+++ b/moonpool-sim/tests/chaos/partial_read.rs
@@ -1,0 +1,151 @@
+//! Integration tests for partial read chaos injection.
+//!
+//! Tests verify that partial reads (mirroring FDB's `Sim2Conn` receiver):
+//! - Deliver fewer bytes than available when BUGGIFY fires
+//! - Leave the remainder buffered, preserving FIFO order (no data loss)
+//! - Never return 0 bytes while data is buffered (which would stall `poll_read`)
+//! - Are inert when BUGGIFY is disabled (baseline single-read behavior)
+//!
+//! `buggify!()` fires at ~25% per call (the macro's fixed firing probability),
+//! so we cannot assert a cap on every individual read. Instead each seed asserts
+//! the deterministic invariant — the payload reassembles correctly across short
+//! reads with no zero-length read — and the fixed seed range collectively proves
+//! that partial reads do occur (a fully-buffered payload split across >1 read).
+
+use futures::io::{AsyncReadExt, AsyncWriteExt};
+use moonpool_sim::{
+    NetworkConfiguration, NetworkProvider, SimWorld, TcpListenerTrait, buggify_init, buggify_reset,
+};
+
+/// Drive one buggified exchange of `payload` with the given `partial_read_max_bytes`,
+/// returning how many reads it took to drain the fully-buffered payload. Asserts
+/// reassembly correctness and that no read returns 0 bytes while data is buffered.
+async fn drain_with_partial_reads(seed: u64, max_bytes: usize, payload: &[u8]) -> usize {
+    buggify_init(1.0, 1.0); // location always active; fires at the macro's 25%
+
+    let mut config = NetworkConfiguration::fast_local();
+    config.chaos.partial_read_max_bytes = max_bytes;
+
+    let mut sim = SimWorld::new_with_network_config_and_seed(config, seed);
+    let provider = sim.network_provider();
+
+    let addr = "partial-read-server";
+    let listener = provider.bind(addr).await.unwrap();
+    let mut client = provider.connect(addr).await.unwrap();
+    let (mut server, _) = listener.accept().await.unwrap();
+
+    client.write_all(payload).await.unwrap();
+    // Drain the network so every byte sits in the server's receive buffer.
+    sim.run_until_empty();
+
+    let mut received = Vec::new();
+    let mut reads = 0;
+    let mut buf = vec![0u8; payload.len()];
+    while received.len() < payload.len() {
+        let n = server.read(&mut buf).await.unwrap();
+        assert!(
+            n > 0,
+            "seed {seed}: partial read returned 0 bytes while data was buffered (would stall poll_read)"
+        );
+        received.extend_from_slice(&buf[..n]);
+        reads += 1;
+    }
+
+    assert_eq!(
+        received, payload,
+        "seed {seed}: data must reassemble in FIFO order"
+    );
+    reads
+}
+
+/// Across a fixed seed range, every seed reassembles the payload correctly and at
+/// least one seed splits the fully-buffered payload across multiple reads.
+#[test]
+fn test_partial_reads_preserve_data() {
+    let local_runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .enable_time()
+        .build()
+        .expect("Failed to build local runtime");
+
+    local_runtime.block_on(async move {
+        let payload: Vec<u8> = (0u8..200).collect();
+        let mut any_partial = false;
+        for seed in 0..40u64 {
+            let reads = drain_with_partial_reads(seed, 8, &payload).await;
+            if reads > 1 {
+                any_partial = true;
+            }
+        }
+        assert!(
+            any_partial,
+            "expected at least one seed in 0..40 to deliver a fully-buffered payload across multiple reads"
+        );
+    });
+}
+
+/// Boundary case: `partial_read_max_bytes == 1` drives the at-least-one-byte rule
+/// on its tightest edge — a fired read samples `1..2`, returning exactly one byte.
+/// Guards against an off-by-one that would make the sample range empty and panic.
+#[test]
+fn test_partial_read_single_byte_boundary() {
+    let local_runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .enable_time()
+        .build()
+        .expect("Failed to build local runtime");
+
+    local_runtime.block_on(async move {
+        let payload: Vec<u8> = (0u8..32).collect();
+        let mut any_partial = false;
+        for seed in 0..40u64 {
+            let reads = drain_with_partial_reads(seed, 1, &payload).await;
+            if reads > 1 {
+                any_partial = true;
+            }
+        }
+        assert!(
+            any_partial,
+            "expected at least one seed in 0..40 to exercise the single-byte partial read path"
+        );
+    });
+}
+
+/// Without BUGGIFY, reads behave normally: a single read drains the whole buffer.
+#[test]
+fn test_partial_read_disabled_without_buggify() {
+    let local_runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .enable_time()
+        .build()
+        .expect("Failed to build local runtime");
+
+    local_runtime.block_on(async move {
+        buggify_reset(); // BUGGIFY disabled -> no partial reads
+
+        let config = NetworkConfiguration::fast_local();
+        let mut sim = SimWorld::new_with_network_config(config);
+        let provider = sim.network_provider();
+
+        let addr = "no-partial-read-server";
+        let listener = provider.bind(addr).await.unwrap();
+        let mut client = provider.connect(addr).await.unwrap();
+        let (mut server, _) = listener.accept().await.unwrap();
+
+        let payload: Vec<u8> = (0u8..100).collect();
+        client.write_all(&payload).await.unwrap();
+        sim.run_until_empty();
+
+        let mut buf = vec![0u8; payload.len()];
+        let n = server.read(&mut buf).await.unwrap();
+
+        assert_eq!(
+            n,
+            payload.len(),
+            "without BUGGIFY a single read returns all buffered bytes"
+        );
+        assert_eq!(&buf[..n], &payload[..], "data must be intact");
+
+        println!("✅ Partial reads inert when BUGGIFY disabled");
+    });
+}


### PR DESCRIPTION
Closes #66.

## What

Mirrors the existing partial-**write** fault on the **read** path. With BUGGIFY probability, `read_from_connection` now delivers fewer bytes than are buffered and leaves the remainder for the next read — modelling FoundationDB's `Sim2Conn` receiver. This exercises message-reassembly / framing logic that assumes a single read yields a whole message.

## The key asymmetry vs partial writes

A zero-byte read is how `poll_read` signals **EOF**. Returning 0 bytes while data is still buffered would stall the stream — `poll_read` registers a waker and returns `Pending`, but no event ever arrives to wake it (the data is already in the buffer). So a partial read **always delivers at least one byte** when data is available. Partial writes can truncate to 0 safely because the send buffer is retried.

## Changes

- **`network/config.rs`** — new `partial_read_max_bytes` field (default `1000`). The `random_for_seed` draw is appended **last** in the struct literal so every existing field's per-seed RNG draw — and thus reproducibility — is unchanged.
- **`sim/world.rs`** — BUGGIFY-gated truncation in `read_from_connection`; skips stable connections; unread bytes simply stay in the `VecDeque` (FIFO preserved for free).
- **`tests/chaos/partial_read.rs`** (new) — three tests: multi-seed reassembly correctness + "a partial occurred", the single-byte boundary (guards the sample-range off-by-one), and the BUGGIFY-disabled baseline.
- **Book** — network-faults chapter + configuration & fault-reference appendices.

Note: `buggify!()` fires at a fixed ~25% per call, so the tests assert the deterministic invariant (correct reassembly + no zero-length reads per seed) plus aggregate occurrence over a fixed seed range, rather than a per-read size cap.

## Verification

All green: `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, full-workspace `cargo nextest run` (**558 passed**, including the new tests, no regression from the RNG-ordering change), `cargo check --target wasm32-unknown-unknown -p moonpool-sim --no-default-features`, no-default-features clippy, and `mdbook build book/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)