### PR TITLE
feat(moonpool-sim): long-tail latency distribution (exponential/bimodal) for network + storage (#67)

### DIFF
--- a/book/src/appendix/03-configuration.md
+++ b/book/src/appendix/03-configuration.md
@@ -115,11 +115,11 @@ Top-level network simulation parameters.
 
 | Field | Type | Default |
 |-------|------|---------|
-| `bind_latency` | `Range<Duration>` | 50us..150us |
-| `accept_latency` | `Range<Duration>` | 1ms..6ms |
-| `connect_latency` | `Range<Duration>` | 1ms..11ms |
-| `read_latency` | `Range<Duration>` | 10us..60us |
-| `write_latency` | `Range<Duration>` | 100us..600us |
+| `bind_latency` | `LatencyDistribution` | `Uniform` 50us..150us |
+| `accept_latency` | `LatencyDistribution` | `Uniform` 1ms..6ms |
+| `connect_latency` | `LatencyDistribution` | `Uniform` 1ms..11ms |
+| `read_latency` | `LatencyDistribution` | `Uniform` 10us..60us |
+| `write_latency` | `LatencyDistribution` | `Uniform` 100us..600us |
 | `chaos` | `ChaosConfiguration` | See below |
 
 ### Constructor variants
@@ -129,6 +129,18 @@ Top-level network simulation parameters.
 | `NetworkConfiguration::default()` | Standard defaults with chaos enabled |
 | `NetworkConfiguration::random_for_seed()` | Randomized per seed for chaos testing |
 | `NetworkConfiguration::fast_local()` | Minimal latencies, all chaos disabled |
+
+### Latency distribution
+
+Each per-operation latency field above is a `LatencyDistribution`, not a plain range. This lets a simulation exercise the heavy P99 tail where timeout cascades and retry storms live. Every variant samples deterministically through the simulation RNG.
+
+| Variant | Shape | Models |
+|---------|-------|--------|
+| `Uniform { start, end }` | Flat over `[start, end)`, the default with unchanged behavior | Baseline jitter |
+| `Exponential { min, mean }` | `min + mean * (-ln u)`, a long right tail | Slow disks, GC pauses (TigerBeetle) |
+| `Bimodal { fast_range, slow_range, slow_probability }` | Fast cluster with a rare slow tail | Cross-datacenter hops, GC spikes (FoundationDB) |
+
+`default()` and `fast_local()` keep every field `Uniform`, so behavior is unchanged unless you opt in. `random_for_seed()` mixes all three shapes per field for chaos seeds. The same `LatencyDistribution` type configures storage `read_latency`, `write_latency`, and `sync_latency`.
 
 ## ChaosConfiguration
 
@@ -211,16 +223,6 @@ Each ordered IP pair samples one fixed latency from this range at first contact 
 | `connect_failure_probability` | `f64` | 0.5 (50%) |
 
 **ConnectFailureMode** variants: `Disabled`, `AlwaysFail`, `Probabilistic` (50% refused, 50% hang).
-
-### Latency Distribution
-
-| Field | Type | Default |
-|-------|------|---------|
-| `latency_distribution` | `LatencyDistribution` | `Uniform` |
-| `slow_latency_probability` | `f64` | 0.001 (0.1%) |
-| `slow_latency_multiplier` | `f64` | 10.0 |
-
-**LatencyDistribution** variants: `Uniform`, `Bimodal` (99.9% fast, 0.1% slow).
 
 ### Handshake Delay
 

--- a/book/src/appendix/04-fault-reference.md
+++ b/book/src/appendix/04-fault-reference.md
@@ -26,9 +26,9 @@ Configured via `ChaosConfiguration` (nested under `NetworkConfiguration::chaos`)
 
 | Fault | Config Field | Default | Real-World Scenario |
 |-------|-------------|---------|---------------------|
-| Latency distribution | `latency_distribution` | `Uniform` | P99/P99.9 tail latency testing |
-| Slow latency spike | `slow_latency_probability` | 0.1% (bimodal mode only) | GC pauses, cross-datacenter hops |
-| Slow latency multiplier | `slow_latency_multiplier` | 10x normal | Magnitude of tail latency spikes |
+| Operation latency shape | `bind/accept/connect/read/write_latency` | `Uniform` | P99/P99.9 tail latency testing |
+| Exponential tail | `LatencyDistribution::Exponential { min, mean }` | opt-in | Slow disks, GC pauses (TigerBeetle model) |
+| Bimodal tail | `LatencyDistribution::Bimodal { fast_range, slow_range, slow_probability }` | opt-in | Rare cross-datacenter hops, GC spikes (FoundationDB model) |
 | Write clogging | `clog_probability` / `clog_duration` | 0%, 100-300ms | Backpressure handling, flow control |
 | Per-pair permanent latency | `max_pair_latency` | `ZERO..ZERO` (off) | One stably-slow peer blocking quorum, asymmetric link delay |
 | Clock drift | `clock_drift_enabled` / `clock_drift_max` | enabled, 100ms | Lease expiration, distributed consensus, TTL handling |
@@ -94,9 +94,9 @@ Storage also simulates realistic performance characteristics independent of faul
 |-----------|-------------|---------|-------------|
 | IOPS | `iops` | 25,000 | I/O operations per second limit |
 | Bandwidth | `bandwidth` | 150 MB/s | Maximum throughput |
-| Read latency | `read_latency` | 50-200us | Per-read operation delay |
-| Write latency | `write_latency` | 100-500us | Per-write operation delay |
-| Sync latency | `sync_latency` | 1-5ms | Per-sync/flush delay |
+| Read latency | `read_latency` | `Uniform` 50-200us | Per-read operation delay (a `LatencyDistribution`) |
+| Write latency | `write_latency` | `Uniform` 100-500us | Per-write operation delay (a `LatencyDistribution`) |
+| Sync latency | `sync_latency` | `Uniform` 1-5ms | Per-sync/flush delay (a `LatencyDistribution`) |
 
 ## Process Lifecycle Faults
 

--- a/moonpool-sim/src/lib.rs
+++ b/moonpool-sim/src/lib.rs
@@ -177,8 +177,8 @@ pub use observability::{
 
 // Network exports
 pub use network::{
-    ChaosConfiguration, ConnectFailureMode, NetworkConfiguration, SimNetworkProvider,
-    sample_duration,
+    ChaosConfiguration, ConnectFailureMode, LatencyDistribution, NetworkConfiguration,
+    SimNetworkProvider, sample_duration, sample_latency,
 };
 
 // Storage exports

--- a/moonpool-sim/src/network/config.rs
+++ b/moonpool-sim/src/network/config.rs
@@ -80,7 +80,9 @@
 //! - Clock drift: FDB sim2.actor.cpp:1058-1064
 //! - Connect failures: FDB sim2.actor.cpp:1243-1250
 
-use crate::sim::rng::{config_random_bool, sim_random_range, sim_random_range_or_default};
+use crate::sim::rng::{
+    config_random_bool, sim_random_f64, sim_random_range, sim_random_range_or_default,
+};
 use std::ops::Range;
 use std::time::Duration;
 
@@ -388,16 +390,16 @@ impl ChaosConfiguration {
 /// Configuration for network simulation parameters
 #[derive(Debug, Clone)]
 pub struct NetworkConfiguration {
-    /// Latency range for bind operations
-    pub bind_latency: Range<Duration>,
-    /// Latency range for accept operations
-    pub accept_latency: Range<Duration>,
-    /// Latency range for connect operations
-    pub connect_latency: Range<Duration>,
-    /// Latency range for read operations
-    pub read_latency: Range<Duration>,
-    /// Latency range for write operations
-    pub write_latency: Range<Duration>,
+    /// Latency distribution for bind operations
+    pub bind_latency: LatencyDistribution,
+    /// Latency distribution for accept operations
+    pub accept_latency: LatencyDistribution,
+    /// Latency distribution for connect operations
+    pub connect_latency: LatencyDistribution,
+    /// Latency distribution for read operations
+    pub read_latency: LatencyDistribution,
+    /// Latency distribution for write operations
+    pub write_latency: LatencyDistribution,
 
     /// Chaos injection configuration
     pub chaos: ChaosConfiguration,
@@ -406,11 +408,26 @@ pub struct NetworkConfiguration {
 impl Default for NetworkConfiguration {
     fn default() -> Self {
         Self {
-            bind_latency: Duration::from_micros(50)..Duration::from_micros(150),
-            accept_latency: Duration::from_millis(1)..Duration::from_millis(6),
-            connect_latency: Duration::from_millis(1)..Duration::from_millis(11),
-            read_latency: Duration::from_micros(10)..Duration::from_micros(60),
-            write_latency: Duration::from_micros(100)..Duration::from_micros(600),
+            bind_latency: LatencyDistribution::Uniform {
+                start: Duration::from_micros(50),
+                end: Duration::from_micros(150),
+            },
+            accept_latency: LatencyDistribution::Uniform {
+                start: Duration::from_millis(1),
+                end: Duration::from_millis(6),
+            },
+            connect_latency: LatencyDistribution::Uniform {
+                start: Duration::from_millis(1),
+                end: Duration::from_millis(11),
+            },
+            read_latency: LatencyDistribution::Uniform {
+                start: Duration::from_micros(10),
+                end: Duration::from_micros(60),
+            },
+            write_latency: LatencyDistribution::Uniform {
+                start: Duration::from_micros(100),
+                end: Duration::from_micros(600),
+            },
             chaos: ChaosConfiguration::default(),
         }
     }
@@ -419,10 +436,161 @@ impl Default for NetworkConfiguration {
 /// Sample a random duration from a range
 #[must_use]
 pub fn sample_duration(range: &Range<Duration>) -> Duration {
-    let start_nanos = u64::try_from(range.start.as_nanos()).unwrap_or(u64::MAX);
-    let end_nanos = u64::try_from(range.end.as_nanos()).unwrap_or(u64::MAX);
-    let random_nanos = sim_random_range_or_default(start_nanos..end_nanos);
-    Duration::from_nanos(random_nanos)
+    uniform_nanos(range.start, range.end)
+}
+
+/// Sample a uniform duration in `[start, end)` using the simulation RNG.
+///
+/// Shared by [`sample_duration`] and [`LatencyDistribution::Uniform`] so both
+/// consume exactly one RNG draw with identical semantics. A degenerate range
+/// (`start >= end`) returns `start` and consumes no draw (see
+/// [`sim_random_range_or_default`]).
+fn uniform_nanos(start: Duration, end: Duration) -> Duration {
+    let start_nanos = u64::try_from(start.as_nanos()).unwrap_or(u64::MAX);
+    let end_nanos = u64::try_from(end.as_nanos()).unwrap_or(u64::MAX);
+    Duration::from_nanos(sim_random_range_or_default(start_nanos..end_nanos))
+}
+
+/// A pluggable latency distribution for per-operation latency sampling.
+///
+/// Replaces plain uniform `Range<Duration>` sampling so simulations can exercise
+/// the heavy P99 tail where timeout cascades, retry storms, and backpressure
+/// collapse live. All variants sample deterministically through the simulation
+/// RNG, so the same seed always yields the same sequence.
+///
+/// The default is [`Uniform`](Self::Uniform), which samples identically to the
+/// historical [`sample_duration`] (one RNG draw, no extra draws), keeping default
+/// behavior unchanged.
+///
+/// # References
+///
+/// - `Exponential` mirrors `TigerBeetle`'s `random_int_exponential` storage/network
+///   delay (`packet_simulator.zig`).
+/// - `Bimodal` mirrors `FoundationDB`'s `halfLatency` fast/slow split (`sim2.actor.cpp`).
+#[derive(Debug, Clone, PartialEq)]
+pub enum LatencyDistribution {
+    /// Uniform latency in `[start, end)`. Equivalent to the historical
+    /// `Range<Duration>` sampling.
+    Uniform {
+        /// Inclusive lower bound.
+        start: Duration,
+        /// Exclusive upper bound.
+        end: Duration,
+    },
+    /// Exponential latency with a minimum floor, modelling a long tail.
+    ///
+    /// Samples `min + mean * (-ln(u))` with `u` drawn uniformly from `(0, 1]`,
+    /// giving a mean delay of roughly `min + mean`. Note this is the additive
+    /// form from the issue; `TigerBeetle` instead clamps with `max(min, exp(mean))`.
+    Exponential {
+        /// Minimum latency added to every sample.
+        min: Duration,
+        /// Mean of the exponential component (the tail scale).
+        mean: Duration,
+    },
+    /// Bimodal latency: a fast cluster most of the time, a slow tail rarely.
+    ///
+    /// With probability `slow_probability` the sample is drawn uniformly from
+    /// `slow_range`; otherwise from `fast_range`.
+    Bimodal {
+        /// Range sampled on the common, fast path.
+        fast_range: Range<Duration>,
+        /// Range sampled on the rare, slow path.
+        slow_range: Range<Duration>,
+        /// Probability in `[0, 1]` of taking the slow path.
+        slow_probability: f64,
+    },
+}
+
+impl Default for LatencyDistribution {
+    fn default() -> Self {
+        // Callers (config constructors) set real bounds per field; this
+        // type-level default is only a neutral fallback.
+        Self::Uniform {
+            start: Duration::ZERO,
+            end: Duration::ZERO,
+        }
+    }
+}
+
+impl LatencyDistribution {
+    /// Return the `(start, end)` bounds when this is a [`Uniform`](Self::Uniform)
+    /// distribution, otherwise `None`. Convenience for tests and reporting.
+    #[must_use]
+    pub fn uniform_bounds(&self) -> Option<(Duration, Duration)> {
+        match self {
+            Self::Uniform { start, end } => Some((*start, *end)),
+            _ => None,
+        }
+    }
+}
+
+/// Sample a latency from a [`LatencyDistribution`] using the simulation RNG.
+///
+/// Deterministic for a given seed. The [`Uniform`](LatencyDistribution::Uniform)
+/// variant consumes exactly one RNG draw (identical to [`sample_duration`]);
+/// `Exponential` consumes one `f64` draw; `Bimodal` consumes one `f64` draw to
+/// pick the branch plus one uniform draw.
+#[must_use]
+pub fn sample_latency(distribution: &LatencyDistribution) -> Duration {
+    match distribution {
+        LatencyDistribution::Uniform { start, end } => uniform_nanos(*start, *end),
+        LatencyDistribution::Exponential { min, mean } => {
+            // u in [0.0, 1.0); 1.0 - u in (0.0, 1.0] so -ln(.) in [0.0, +inf),
+            // never inf or NaN. Compute in f64 seconds via `Duration`'s own API
+            // to avoid lossy manual casts. A product that overflows `Duration`
+            // saturates to `Duration::MAX` instead of panicking.
+            let u = sim_random_f64();
+            let factor = -(1.0 - u).ln();
+            let extra_secs = mean.as_secs_f64() * factor;
+            let extra = Duration::try_from_secs_f64(extra_secs).unwrap_or(Duration::MAX);
+            min.saturating_add(extra)
+        }
+        LatencyDistribution::Bimodal {
+            fast_range,
+            slow_range,
+            slow_probability,
+        } => {
+            // Draw the branch selector unconditionally so the RNG call-count is
+            // stable regardless of which path is taken.
+            if sim_random_f64() < *slow_probability {
+                uniform_nanos(slow_range.start, slow_range.end)
+            } else {
+                uniform_nanos(fast_range.start, fast_range.end)
+            }
+        }
+    }
+}
+
+/// Pick a per-field [`LatencyDistribution`] for chaos seeds, mixing all three
+/// variants around a baseline uniform range.
+///
+/// One in three seeds keeps the field uniform; the others derive an exponential
+/// or bimodal shape from the same baseline so the mean stays comparable. Draws
+/// from the simulation RNG, so it is deterministic per seed.
+pub(crate) fn random_latency_for_seed(uniform: Range<Duration>) -> LatencyDistribution {
+    match sim_random_range(0..3) {
+        0 => LatencyDistribution::Uniform {
+            start: uniform.start,
+            end: uniform.end,
+        },
+        1 => LatencyDistribution::Exponential {
+            min: uniform.start,
+            // Mean tail scale of one baseline width above the floor.
+            mean: uniform.end.saturating_sub(uniform.start),
+        },
+        _ => {
+            // Slow path is one decade beyond the baseline upper bound.
+            let slow_start = uniform.end;
+            let slow_end = uniform.end.saturating_mul(10);
+            LatencyDistribution::Bimodal {
+                fast_range: uniform,
+                slow_range: slow_start..slow_end,
+                // 0.1% .. 1% slow tail.
+                slow_probability: f64::from(sim_random_range(1..10)) / 1000.0,
+            }
+        }
+    }
 }
 
 impl NetworkConfiguration {
@@ -436,16 +604,26 @@ impl NetworkConfiguration {
     #[must_use]
     pub fn random_for_seed() -> Self {
         Self {
-            bind_latency: Duration::from_micros(sim_random_range(10..200))
-                ..Duration::from_micros(sim_random_range(50..300)),
-            accept_latency: Duration::from_micros(sim_random_range(1000..10_000))
-                ..Duration::from_micros(sim_random_range(5000..15_000)),
-            connect_latency: Duration::from_micros(sim_random_range(1000..50_000))
-                ..Duration::from_micros(sim_random_range(10_000..100_000)),
-            read_latency: Duration::from_micros(sim_random_range(5..100))
-                ..Duration::from_micros(sim_random_range(50..200)),
-            write_latency: Duration::from_micros(sim_random_range(50..1000))
-                ..Duration::from_micros(sim_random_range(200..2000)),
+            bind_latency: random_latency_for_seed(
+                Duration::from_micros(sim_random_range(10..200))
+                    ..Duration::from_micros(sim_random_range(50..300)),
+            ),
+            accept_latency: random_latency_for_seed(
+                Duration::from_micros(sim_random_range(1000..10_000))
+                    ..Duration::from_micros(sim_random_range(5000..15_000)),
+            ),
+            connect_latency: random_latency_for_seed(
+                Duration::from_micros(sim_random_range(1000..50_000))
+                    ..Duration::from_micros(sim_random_range(10_000..100_000)),
+            ),
+            read_latency: random_latency_for_seed(
+                Duration::from_micros(sim_random_range(5..100))
+                    ..Duration::from_micros(sim_random_range(50..200)),
+            ),
+            write_latency: random_latency_for_seed(
+                Duration::from_micros(sim_random_range(50..1000))
+                    ..Duration::from_micros(sim_random_range(200..2000)),
+            ),
             chaos: ChaosConfiguration::random_for_seed(),
         }
     }
@@ -468,12 +646,13 @@ impl NetworkConfiguration {
     pub fn fast_local() -> Self {
         let one_us = Duration::from_micros(1);
         let ten_us = Duration::from_micros(10);
+        let uniform = |start, end| LatencyDistribution::Uniform { start, end };
         Self {
-            bind_latency: one_us..one_us,
-            accept_latency: ten_us..ten_us,
-            connect_latency: ten_us..ten_us,
-            read_latency: one_us..one_us,
-            write_latency: one_us..one_us,
+            bind_latency: uniform(one_us, one_us),
+            accept_latency: uniform(ten_us, ten_us),
+            connect_latency: uniform(ten_us, ten_us),
+            read_latency: uniform(one_us, one_us),
+            write_latency: uniform(one_us, one_us),
             chaos: ChaosConfiguration::disabled(),
         }
     }
@@ -568,5 +747,188 @@ mod swarm_tests {
             0.0_f64.to_bits(),
             "expected 0.0, got {value}"
         );
+    }
+}
+
+#[cfg(test)]
+mod latency_distribution_tests {
+    use super::{LatencyDistribution, NetworkConfiguration, sample_duration, sample_latency};
+    use crate::sim::rng::set_sim_seed;
+    use crate::storage::StorageConfiguration;
+    use std::time::Duration;
+
+    /// Collect `n` samples from a distribution under a fresh seed.
+    fn samples(seed: u64, dist: &LatencyDistribution, n: usize) -> Vec<Duration> {
+        set_sim_seed(seed);
+        (0..n).map(|_| sample_latency(dist)).collect()
+    }
+
+    /// The 99th percentile of a sample set, by sorted index.
+    fn p99(mut values: Vec<Duration>) -> Duration {
+        values.sort_unstable();
+        let idx = ((values.len() * 99) / 100).min(values.len() - 1);
+        values[idx]
+    }
+
+    #[test]
+    fn uniform_matches_sample_duration_byte_for_byte() {
+        // The Uniform variant must consume exactly the same RNG as the legacy
+        // `sample_duration`: identical value AND identical resulting RNG state
+        // (one draw, no extra). Two interleaved draws prove both.
+        let start = Duration::from_micros(100);
+        let end = Duration::from_micros(600);
+        let dist = LatencyDistribution::Uniform { start, end };
+        let range = start..end;
+
+        set_sim_seed(7);
+        let a1 = sample_latency(&dist);
+        let a2 = sample_duration(&range);
+
+        set_sim_seed(7);
+        let b1 = sample_duration(&range);
+        let b2 = sample_duration(&range);
+
+        assert_eq!((a1, a2), (b1, b2));
+    }
+
+    #[test]
+    fn each_variant_is_deterministic_per_seed() {
+        let variants = [
+            LatencyDistribution::Uniform {
+                start: Duration::from_micros(10),
+                end: Duration::from_micros(60),
+            },
+            LatencyDistribution::Exponential {
+                min: Duration::from_micros(10),
+                mean: Duration::from_micros(100),
+            },
+            LatencyDistribution::Bimodal {
+                fast_range: Duration::from_millis(1)..Duration::from_millis(2),
+                slow_range: Duration::from_millis(50)..Duration::from_millis(100),
+                slow_probability: 0.05,
+            },
+        ];
+        for dist in &variants {
+            let first = samples(42, dist, 64);
+            let second = samples(42, dist, 64);
+            assert_eq!(first, second, "distribution not deterministic: {dist:?}");
+        }
+    }
+
+    #[test]
+    fn default_configs_are_all_uniform() {
+        let net = NetworkConfiguration::default();
+        for dist in [
+            &net.bind_latency,
+            &net.accept_latency,
+            &net.connect_latency,
+            &net.read_latency,
+            &net.write_latency,
+        ] {
+            assert!(
+                dist.uniform_bounds().is_some(),
+                "network default not uniform: {dist:?}"
+            );
+        }
+        let storage = StorageConfiguration::default();
+        for dist in [
+            &storage.read_latency,
+            &storage.write_latency,
+            &storage.sync_latency,
+        ] {
+            assert!(
+                dist.uniform_bounds().is_some(),
+                "storage default not uniform: {dist:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn exponential_has_heavier_tail_than_uniform_at_equal_mean() {
+        // Uniform [0, 2ms) and Exponential{min: 0, mean: 1ms} share a 1ms mean,
+        // but the exponential's tail pushes its p99 well above the uniform's.
+        let uniform = LatencyDistribution::Uniform {
+            start: Duration::ZERO,
+            end: Duration::from_millis(2),
+        };
+        let exponential = LatencyDistribution::Exponential {
+            min: Duration::ZERO,
+            mean: Duration::from_millis(1),
+        };
+        let uni_p99 = p99(samples(123, &uniform, 10_000));
+        let exp_p99 = p99(samples(123, &exponential, 10_000));
+        assert!(
+            exp_p99 > uni_p99,
+            "exponential p99 {exp_p99:?} should exceed uniform p99 {uni_p99:?}"
+        );
+    }
+
+    #[test]
+    fn bimodal_shows_fast_cluster_and_slow_tail() {
+        let fast = Duration::from_millis(1)..Duration::from_millis(2);
+        let slow = Duration::from_millis(50)..Duration::from_millis(100);
+        let dist = LatencyDistribution::Bimodal {
+            fast_range: fast.clone(),
+            slow_range: slow.clone(),
+            slow_probability: 0.05,
+        };
+        let values = samples(99, &dist, 10_000);
+        let fast_count = values.iter().filter(|d| fast.contains(d)).count();
+        let slow_count = values.iter().filter(|d| slow.contains(d)).count();
+        assert!(
+            fast_count > 8_000,
+            "expected a dominant fast cluster, got {fast_count}"
+        );
+        assert!(slow_count > 0, "expected a non-empty slow tail");
+        assert_eq!(fast_count + slow_count, values.len());
+    }
+
+    #[test]
+    fn exponential_with_zero_mean_returns_min() {
+        let dist = LatencyDistribution::Exponential {
+            min: Duration::from_micros(42),
+            mean: Duration::ZERO,
+        };
+        set_sim_seed(5);
+        for _ in 0..100 {
+            assert_eq!(sample_latency(&dist), Duration::from_micros(42));
+        }
+    }
+
+    #[test]
+    fn bimodal_probability_bounds_select_expected_range() {
+        let fast = Duration::from_millis(1)..Duration::from_millis(2);
+        let slow = Duration::from_millis(50)..Duration::from_millis(100);
+        let never_slow = LatencyDistribution::Bimodal {
+            fast_range: fast.clone(),
+            slow_range: slow.clone(),
+            slow_probability: 0.0,
+        };
+        let always_slow = LatencyDistribution::Bimodal {
+            fast_range: fast.clone(),
+            slow_range: slow.clone(),
+            slow_probability: 1.0,
+        };
+        for d in samples(1, &never_slow, 500) {
+            assert!(fast.contains(&d), "slow_probability 0.0 produced {d:?}");
+        }
+        for d in samples(2, &always_slow, 500) {
+            assert!(slow.contains(&d), "slow_probability 1.0 produced {d:?}");
+        }
+    }
+
+    #[test]
+    fn exponential_saturates_instead_of_panicking() {
+        // A mean near the Duration ceiling can overflow when scaled by the tail
+        // factor; sampling must saturate, never panic.
+        let dist = LatencyDistribution::Exponential {
+            min: Duration::from_secs(1),
+            mean: Duration::from_secs(u64::MAX / 2),
+        };
+        set_sim_seed(3);
+        for _ in 0..1_000 {
+            let sampled = sample_latency(&dist);
+            assert!(sampled >= Duration::from_secs(1));
+        }
     }
 }

--- a/moonpool-sim/src/network/mod.rs
+++ b/moonpool-sim/src/network/mod.rs
@@ -11,8 +11,8 @@ pub mod sim;
 
 // Re-export configuration
 pub use config::{
-    ChaosConfiguration, ConnectFailureMode, NetworkConfiguration, PartitionStrategy,
-    sample_duration,
+    ChaosConfiguration, ConnectFailureMode, LatencyDistribution, NetworkConfiguration,
+    PartitionStrategy, sample_duration, sample_latency,
 };
 
 // Re-export simulation network provider

--- a/moonpool-sim/src/network/sim/provider.rs
+++ b/moonpool-sim/src/network/sim/provider.rs
@@ -49,7 +49,7 @@ impl NetworkProvider for SimNetworkProvider {
 
         // Get bind delay from network configuration and schedule bind completion event
         let delay =
-            sim.with_network_config(|config| crate::network::sample_duration(&config.bind_latency));
+            sim.with_network_config(|config| crate::network::sample_latency(&config.bind_latency));
 
         // Schedule bind completion event to advance simulation time
         let listener_id = sim.create_listener();
@@ -124,7 +124,7 @@ impl NetworkProvider for SimNetworkProvider {
 
         // Get connect delay from network configuration and schedule connection event
         let delay = sim
-            .with_network_config(|config| crate::network::sample_duration(&config.connect_latency));
+            .with_network_config(|config| crate::network::sample_latency(&config.connect_latency));
 
         // Create a connection pair for bidirectional communication
         let (client_id, server_id) = sim.create_connection_pair("client-addr", addr);

--- a/moonpool-sim/src/network/sim/stream.rs
+++ b/moonpool-sim/src/network/sim/stream.rs
@@ -546,7 +546,7 @@ impl Future for AcceptFuture {
 
         // Get accept delay from network configuration
         let delay = sim
-            .with_network_config(|config| crate::network::sample_duration(&config.accept_latency));
+            .with_network_config(|config| crate::network::sample_latency(&config.accept_latency));
 
         // Schedule accept completion event to advance simulation time
         sim.schedule_event(

--- a/moonpool-sim/src/sim/storage_ops.rs
+++ b/moonpool-sim/src/sim/storage_ops.rs
@@ -656,7 +656,7 @@ impl SimWorld {
         // Use sync latency from per-process config
         let owner_ip = file_state.owner_ip;
         let config = inner.storage.config_for(owner_ip);
-        let latency = crate::network::sample_duration(&config.sync_latency);
+        let latency = crate::network::sample_latency(&config.sync_latency);
         let scheduled_time = inner.current_time + latency;
         let sequence = inner.next_sequence;
         inner.next_sequence += 1;
@@ -714,7 +714,7 @@ impl SimWorld {
         // Use write latency from per-process config
         let owner_ip = file_state.owner_ip;
         let config = inner.storage.config_for(owner_ip);
-        let latency = crate::network::sample_duration(&config.write_latency);
+        let latency = crate::network::sample_latency(&config.write_latency);
         let scheduled_time = inner.current_time + latency;
         let sequence = inner.next_sequence;
         inner.next_sequence += 1;
@@ -869,7 +869,7 @@ impl SimWorld {
         } else {
             &config.read_latency
         };
-        let base = crate::network::sample_duration(base_range);
+        let base = crate::network::sample_latency(base_range);
 
         // IOPS overhead: 1/iops seconds per operation.
         // Precision loss is acceptable: iops is typically << 2^52.

--- a/moonpool-sim/src/sim/world.rs
+++ b/moonpool-sim/src/sim/world.rs
@@ -1460,7 +1460,7 @@ impl SimWorld {
             Duration::from_nanos(1)
         } else {
             send_delay.unwrap_or_else(|| {
-                crate::network::sample_duration(&inner.network.config.write_latency)
+                crate::network::sample_latency(&inner.network.config.write_latency)
             })
         };
 

--- a/moonpool-sim/src/storage/config.rs
+++ b/moonpool-sim/src/storage/config.rs
@@ -50,8 +50,8 @@
 //! - Storage faults: TigerBeetle storage simulation
 //! - Crash consistency: FDB AsyncFileKAIO, TigerBeetle deterministic testing
 
+use crate::network::config::{LatencyDistribution, random_latency_for_seed};
 use crate::sim::rng::{config_random_bool, sim_random_range};
-use std::ops::Range;
 use std::time::Duration;
 
 /// Configuration for storage simulation parameters.
@@ -79,27 +79,27 @@ pub struct StorageConfiguration {
     /// - HDD: 100-200 MB/s
     pub bandwidth: u64,
 
-    /// Latency range for read operations.
+    /// Latency distribution for read operations.
     ///
     /// Typical values:
     /// - `NVMe` SSD: 20-100µs
     /// - SATA SSD: 50-200µs
     /// - HDD: 2-10ms
-    pub read_latency: Range<Duration>,
+    pub read_latency: LatencyDistribution,
 
-    /// Latency range for write operations.
+    /// Latency distribution for write operations.
     ///
     /// Typical values:
     /// - `NVMe` SSD: 20-100µs
     /// - SATA SSD: 100-500µs
     /// - HDD: 2-10ms
-    pub write_latency: Range<Duration>,
+    pub write_latency: LatencyDistribution,
 
-    /// Latency range for sync/flush operations.
+    /// Latency distribution for sync/flush operations.
     ///
     /// Sync operations ensure data durability and typically take
     /// longer than regular read/write operations.
-    pub sync_latency: Range<Duration>,
+    pub sync_latency: LatencyDistribution,
 
     // =========================================================================
     // Fault Injection Probabilities
@@ -160,9 +160,18 @@ impl Default for StorageConfiguration {
             // Performance parameters matching a typical SATA SSD
             iops: 25_000,
             bandwidth: 150_000_000, // 150 MB/s
-            read_latency: Duration::from_micros(50)..Duration::from_micros(200),
-            write_latency: Duration::from_micros(100)..Duration::from_micros(500),
-            sync_latency: Duration::from_millis(1)..Duration::from_millis(5),
+            read_latency: LatencyDistribution::Uniform {
+                start: Duration::from_micros(50),
+                end: Duration::from_micros(200),
+            },
+            write_latency: LatencyDistribution::Uniform {
+                start: Duration::from_micros(100),
+                end: Duration::from_micros(500),
+            },
+            sync_latency: LatencyDistribution::Uniform {
+                start: Duration::from_millis(1),
+                end: Duration::from_millis(5),
+            },
 
             // Fault probabilities - disabled by default for predictable behavior
             read_fault_probability: 0.0,
@@ -196,13 +205,19 @@ impl StorageConfiguration {
             // Randomize bandwidth between 50 MB/s and 500 MB/s
             bandwidth: sim_random_range(50_000_000..500_000_000),
 
-            // Randomize latencies
-            read_latency: Duration::from_micros(sim_random_range(20..100))
-                ..Duration::from_micros(sim_random_range(100..500)),
-            write_latency: Duration::from_micros(sim_random_range(50..200))
-                ..Duration::from_micros(sim_random_range(200..1000)),
-            sync_latency: Duration::from_micros(sim_random_range(500..2000))
-                ..Duration::from_micros(sim_random_range(2000..10000)),
+            // Randomize latencies, mixing distribution shapes per field
+            read_latency: random_latency_for_seed(
+                Duration::from_micros(sim_random_range(20..100))
+                    ..Duration::from_micros(sim_random_range(100..500)),
+            ),
+            write_latency: random_latency_for_seed(
+                Duration::from_micros(sim_random_range(50..200))
+                    ..Duration::from_micros(sim_random_range(200..1000)),
+            ),
+            sync_latency: random_latency_for_seed(
+                Duration::from_micros(sim_random_range(500..2000))
+                    ..Duration::from_micros(sim_random_range(2000..10000)),
+            ),
 
             // Low fault probabilities for chaos testing (0.001% to 0.1%)
             read_fault_probability: f64::from(sim_random_range(0..100)) / 100_000.0,
@@ -268,12 +283,16 @@ impl StorageConfiguration {
     #[must_use]
     pub fn fast_local() -> Self {
         let one_us = Duration::from_micros(1);
+        let uniform = LatencyDistribution::Uniform {
+            start: one_us,
+            end: one_us,
+        };
         Self {
             iops: 1_000_000,          // Very high IOPS
             bandwidth: 1_000_000_000, // 1 GB/s
-            read_latency: one_us..one_us,
-            write_latency: one_us..one_us,
-            sync_latency: one_us..one_us,
+            read_latency: uniform.clone(),
+            write_latency: uniform.clone(),
+            sync_latency: uniform,
 
             // All faults disabled
             read_fault_probability: 0.0,

--- a/moonpool-sim/tests/network/latency.rs
+++ b/moonpool-sim/tests/network/latency.rs
@@ -1,8 +1,14 @@
 use futures::io::AsyncWriteExt;
 use moonpool_sim::{
-    ChaosConfiguration, NetworkConfiguration, NetworkProvider, SimWorld, TcpListenerTrait,
+    ChaosConfiguration, LatencyDistribution, NetworkConfiguration, NetworkProvider, SimWorld,
+    TcpListenerTrait,
 };
 use std::time::Duration;
+
+/// Build a uniform latency distribution over `[start, end)` for test configs.
+fn uniform(start: Duration, end: Duration) -> LatencyDistribution {
+    LatencyDistribution::Uniform { start, end }
+}
 
 // Simple networking test that measures bind + connect + accept latency
 async fn simple_network_test<P>(provider: P, addr: &str) -> std::io::Result<()>
@@ -93,11 +99,11 @@ fn test_custom_latency_configuration() {
     local_runtime.block_on(async move {
         // Create custom configuration with specific latency ranges
         let config = NetworkConfiguration {
-            bind_latency: Duration::from_millis(5)..Duration::from_millis(5),
-            accept_latency: Duration::from_millis(10)..Duration::from_millis(10),
-            connect_latency: Duration::from_millis(1)..Duration::from_millis(1),
-            read_latency: Duration::from_micros(10)..Duration::from_micros(10),
-            write_latency: Duration::from_millis(2)..Duration::from_millis(2),
+            bind_latency: uniform(Duration::from_millis(5), Duration::from_millis(5)),
+            accept_latency: uniform(Duration::from_millis(10), Duration::from_millis(10)),
+            connect_latency: uniform(Duration::from_millis(1), Duration::from_millis(1)),
+            read_latency: uniform(Duration::from_micros(10), Duration::from_micros(10)),
+            write_latency: uniform(Duration::from_millis(2), Duration::from_millis(2)),
             chaos: ChaosConfiguration::disabled(),
         };
 
@@ -136,11 +142,11 @@ fn test_latency_range_sampling() {
     local_runtime.block_on(async move {
         // Test multiple runs to verify latency variance with jitter
         let config = NetworkConfiguration {
-            bind_latency: Duration::from_millis(1)..Duration::from_millis(6), // 1-6ms range
-            accept_latency: Duration::from_millis(1)..Duration::from_millis(6),
-            connect_latency: Duration::from_millis(1)..Duration::from_millis(6),
-            read_latency: Duration::from_micros(10)..Duration::from_micros(10),
-            write_latency: Duration::from_millis(1)..Duration::from_millis(6),
+            bind_latency: uniform(Duration::from_millis(1), Duration::from_millis(6)), // 1-6ms range
+            accept_latency: uniform(Duration::from_millis(1), Duration::from_millis(6)),
+            connect_latency: uniform(Duration::from_millis(1), Duration::from_millis(6)),
+            read_latency: uniform(Duration::from_micros(10), Duration::from_micros(10)),
+            write_latency: uniform(Duration::from_millis(1), Duration::from_millis(6)),
             chaos: ChaosConfiguration::disabled(),
         };
 
@@ -190,11 +196,11 @@ fn test_network_randomization_ranges() {
     local_runtime.block_on(async move {
         // Create custom configuration with predictable latencies
         let config = NetworkConfiguration {
-            bind_latency: Duration::from_millis(1)..Duration::from_millis(1),
-            accept_latency: Duration::from_millis(2)..Duration::from_millis(2),
-            connect_latency: Duration::from_millis(3)..Duration::from_millis(3),
-            read_latency: Duration::from_micros(100)..Duration::from_micros(100),
-            write_latency: Duration::from_micros(500)..Duration::from_micros(500),
+            bind_latency: uniform(Duration::from_millis(1), Duration::from_millis(1)),
+            accept_latency: uniform(Duration::from_millis(2), Duration::from_millis(2)),
+            connect_latency: uniform(Duration::from_millis(3), Duration::from_millis(3)),
+            read_latency: uniform(Duration::from_micros(100), Duration::from_micros(100)),
+            write_latency: uniform(Duration::from_micros(500), Duration::from_micros(500)),
             chaos: ChaosConfiguration::disabled(),
         };
 

--- a/moonpool-sim/tests/sim/rng.rs
+++ b/moonpool-sim/tests/sim/rng.rs
@@ -1,6 +1,6 @@
 use moonpool_sim::{
-    NetworkConfiguration, SimWorld, reset_sim_rng, sample_duration, set_sim_seed, sim_random,
-    sim_random_range,
+    NetworkConfiguration, SimWorld, reset_sim_rng, sample_duration, sample_latency, set_sim_seed,
+    sim_random, sim_random_range,
 };
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -36,10 +36,10 @@ fn test_thread_local_rng_determinism() {
 fn test_simworld_with_seed_determinism() {
     // Test that SimWorld::new_with_seed produces deterministic behavior
     let sim1 = SimWorld::new_with_seed(123);
-    let delay1 = sim1.with_network_config(|config| sample_duration(&config.connect_latency));
+    let delay1 = sim1.with_network_config(|config| sample_latency(&config.connect_latency));
 
     let sim2 = SimWorld::new_with_seed(123);
-    let delay2 = sim2.with_network_config(|config| sample_duration(&config.connect_latency));
+    let delay2 = sim2.with_network_config(|config| sample_latency(&config.connect_latency));
 
     assert_eq!(delay1, delay2);
 }
@@ -47,10 +47,10 @@ fn test_simworld_with_seed_determinism() {
 #[test]
 fn test_simworld_different_seeds_different_behavior() {
     let sim1 = SimWorld::new_with_seed(1);
-    let delay1 = sim1.with_network_config(|config| sample_duration(&config.connect_latency));
+    let delay1 = sim1.with_network_config(|config| sample_latency(&config.connect_latency));
 
     let sim2 = SimWorld::new_with_seed(2);
-    let delay2 = sim2.with_network_config(|config| sample_duration(&config.connect_latency));
+    let delay2 = sim2.with_network_config(|config| sample_latency(&config.connect_latency));
 
     // Different seeds should produce different delays (with very high probability)
     assert_ne!(delay1, delay2);
@@ -63,14 +63,14 @@ fn test_consecutive_simulations_same_thread() {
 
     for seed in [1, 2, 3, 4, 5] {
         let sim = SimWorld::new_with_seed(seed);
-        let delay = sim.with_network_config(|config| sample_duration(&config.write_latency));
+        let delay = sim.with_network_config(|config| sample_latency(&config.write_latency));
         delays.push(delay);
     }
 
     // Repeat with same seeds - should get identical delays
     for (i, seed) in [1, 2, 3, 4, 5].iter().enumerate() {
         let sim = SimWorld::new_with_seed(*seed);
-        let delay = sim.with_network_config(|config| sample_duration(&config.write_latency));
+        let delay = sim.with_network_config(|config| sample_latency(&config.write_latency));
         assert_eq!(delays[i], delay, "Delay mismatch for seed {seed}");
     }
 }
@@ -189,10 +189,10 @@ fn test_simworld_network_config_integration() {
     let sim = SimWorld::new_with_network_config_and_seed(config, 456);
 
     // Sample various latencies
-    let bind_delay = sim.with_network_config(|config| sample_duration(&config.bind_latency));
-    let connect_delay = sim.with_network_config(|config| sample_duration(&config.connect_latency));
-    let read_delay = sim.with_network_config(|config| sample_duration(&config.read_latency));
-    let write_delay = sim.with_network_config(|config| sample_duration(&config.write_latency));
+    let bind_delay = sim.with_network_config(|config| sample_latency(&config.bind_latency));
+    let connect_delay = sim.with_network_config(|config| sample_latency(&config.connect_latency));
+    let read_delay = sim.with_network_config(|config| sample_latency(&config.read_latency));
+    let write_delay = sim.with_network_config(|config| sample_latency(&config.write_latency));
 
     // All should be within expected bounds
     assert!(bind_delay >= Duration::from_micros(50));
@@ -204,19 +204,19 @@ fn test_simworld_network_config_integration() {
     let sim2 = SimWorld::new_with_network_config_and_seed(NetworkConfiguration::default(), 456);
     assert_eq!(
         bind_delay,
-        sim2.with_network_config(|config| sample_duration(&config.bind_latency))
+        sim2.with_network_config(|config| sample_latency(&config.bind_latency))
     );
     assert_eq!(
         connect_delay,
-        sim2.with_network_config(|config| sample_duration(&config.connect_latency))
+        sim2.with_network_config(|config| sample_latency(&config.connect_latency))
     );
     assert_eq!(
         read_delay,
-        sim2.with_network_config(|config| sample_duration(&config.read_latency))
+        sim2.with_network_config(|config| sample_latency(&config.read_latency))
     );
     assert_eq!(
         write_delay,
-        sim2.with_network_config(|config| sample_duration(&config.write_latency))
+        sim2.with_network_config(|config| sample_latency(&config.write_latency))
     );
 }
 
@@ -246,10 +246,10 @@ fn run_complex_simulation_sequence(seed: u64) -> Vec<Duration> {
 
     // Simulate various network operations
     for _ in 0..5 {
-        results.push(sim.with_network_config(|config| sample_duration(&config.bind_latency)));
-        results.push(sim.with_network_config(|config| sample_duration(&config.connect_latency)));
-        results.push(sim.with_network_config(|config| sample_duration(&config.write_latency)));
-        results.push(sim.with_network_config(|config| sample_duration(&config.read_latency)));
+        results.push(sim.with_network_config(|config| sample_latency(&config.bind_latency)));
+        results.push(sim.with_network_config(|config| sample_latency(&config.connect_latency)));
+        results.push(sim.with_network_config(|config| sample_latency(&config.write_latency)));
+        results.push(sim.with_network_config(|config| sample_latency(&config.read_latency)));
     }
 
     results
@@ -267,7 +267,7 @@ fn test_multiple_simulations_same_thread_no_contamination() {
 
         for _ in 0..3 {
             sim_results
-                .push(sim.with_network_config(|config| sample_duration(&config.connect_latency)));
+                .push(sim.with_network_config(|config| sample_latency(&config.connect_latency)));
         }
 
         all_results.push(sim_results);
@@ -280,7 +280,7 @@ fn test_multiple_simulations_same_thread_no_contamination() {
 
         for _ in 0..3 {
             sim_results
-                .push(sim.with_network_config(|config| sample_duration(&config.connect_latency)));
+                .push(sim.with_network_config(|config| sample_latency(&config.connect_latency)));
         }
 
         assert_eq!(

--- a/moonpool-sim/tests/storage/config.rs
+++ b/moonpool-sim/tests/storage/config.rs
@@ -3,8 +3,13 @@
 //! These tests verify that `StorageConfiguration` presets and customization
 //! work correctly, following the same pattern as network configuration tests.
 
-use moonpool_sim::{SimWorld, StorageConfiguration, set_sim_seed};
+use moonpool_sim::{LatencyDistribution, SimWorld, StorageConfiguration, set_sim_seed};
 use std::time::Duration;
+
+/// Build a uniform latency distribution over `[start, end)` for test configs.
+fn uniform(start: Duration, end: Duration) -> LatencyDistribution {
+    LatencyDistribution::Uniform { start, end }
+}
 
 /// Assert two f64 values are bit-identical.
 fn assert_f64_eq(left: f64, right: f64) {
@@ -35,12 +40,9 @@ fn test_fast_local_configuration_values() {
 
     // Minimal latencies (1µs)
     let one_us = Duration::from_micros(1);
-    assert_eq!(config.read_latency.start, one_us);
-    assert_eq!(config.read_latency.end, one_us);
-    assert_eq!(config.write_latency.start, one_us);
-    assert_eq!(config.write_latency.end, one_us);
-    assert_eq!(config.sync_latency.start, one_us);
-    assert_eq!(config.sync_latency.end, one_us);
+    assert_eq!(config.read_latency, uniform(one_us, one_us));
+    assert_eq!(config.write_latency, uniform(one_us, one_us));
+    assert_eq!(config.sync_latency, uniform(one_us, one_us));
 
     // All faults disabled
     assert_f64_eq(config.read_fault_probability, 0.0);
@@ -62,12 +64,18 @@ fn test_default_configuration_values() {
     assert_eq!(config.bandwidth, 150_000_000); // 150 MB/s
 
     // Realistic latency ranges
-    assert_eq!(config.read_latency.start, Duration::from_micros(50));
-    assert_eq!(config.read_latency.end, Duration::from_micros(200));
-    assert_eq!(config.write_latency.start, Duration::from_micros(100));
-    assert_eq!(config.write_latency.end, Duration::from_micros(500));
-    assert_eq!(config.sync_latency.start, Duration::from_millis(1));
-    assert_eq!(config.sync_latency.end, Duration::from_millis(5));
+    assert_eq!(
+        config.read_latency,
+        uniform(Duration::from_micros(50), Duration::from_micros(200))
+    );
+    assert_eq!(
+        config.write_latency,
+        uniform(Duration::from_micros(100), Duration::from_micros(500))
+    );
+    assert_eq!(
+        config.sync_latency,
+        uniform(Duration::from_millis(1), Duration::from_millis(5))
+    );
 
     // All faults disabled by default
     assert_f64_eq(config.read_fault_probability, 0.0);
@@ -228,9 +236,9 @@ fn test_custom_configuration() {
     let custom = StorageConfiguration {
         iops: 50_000,
         bandwidth: 200_000_000,
-        read_latency: Duration::from_micros(30)..Duration::from_micros(100),
-        write_latency: Duration::from_micros(50)..Duration::from_micros(200),
-        sync_latency: Duration::from_millis(2)..Duration::from_millis(8),
+        read_latency: uniform(Duration::from_micros(30), Duration::from_micros(100)),
+        write_latency: uniform(Duration::from_micros(50), Duration::from_micros(200)),
+        sync_latency: uniform(Duration::from_millis(2), Duration::from_millis(8)),
         read_fault_probability: 0.01,
         write_fault_probability: 0.02,
         crash_fault_probability: 0.001,
@@ -243,8 +251,10 @@ fn test_custom_configuration() {
     // Verify all fields are set correctly
     assert_eq!(custom.iops, 50_000);
     assert_eq!(custom.bandwidth, 200_000_000);
-    assert_eq!(custom.read_latency.start, Duration::from_micros(30));
-    assert_eq!(custom.read_latency.end, Duration::from_micros(100));
+    assert_eq!(
+        custom.read_latency,
+        uniform(Duration::from_micros(30), Duration::from_micros(100))
+    );
     assert_f64_eq(custom.read_fault_probability, 0.01);
     assert_f64_eq(custom.write_fault_probability, 0.02);
     assert_f64_eq(custom.crash_fault_probability, 0.001);
@@ -282,9 +292,9 @@ fn test_hdd_like_configuration() {
     let hdd_config = StorageConfiguration {
         iops: 150,              // HDDs are very slow on random I/O
         bandwidth: 150_000_000, // Sequential is decent (~150 MB/s)
-        read_latency: Duration::from_millis(5)..Duration::from_millis(15),
-        write_latency: Duration::from_millis(5)..Duration::from_millis(15),
-        sync_latency: Duration::from_millis(10)..Duration::from_millis(50),
+        read_latency: uniform(Duration::from_millis(5), Duration::from_millis(15)),
+        write_latency: uniform(Duration::from_millis(5), Duration::from_millis(15)),
+        sync_latency: uniform(Duration::from_millis(10), Duration::from_millis(50)),
         read_fault_probability: 0.0,
         write_fault_probability: 0.0,
         crash_fault_probability: 0.0,
@@ -295,7 +305,11 @@ fn test_hdd_like_configuration() {
     };
 
     assert_eq!(hdd_config.iops, 150);
-    assert!(hdd_config.read_latency.start >= Duration::from_millis(1));
+    let (hdd_read_start, _) = hdd_config
+        .read_latency
+        .uniform_bounds()
+        .expect("read_latency is uniform");
+    assert!(hdd_read_start >= Duration::from_millis(1));
 }
 
 /// Test NVMe-like configuration
@@ -304,9 +318,9 @@ fn test_nvme_like_configuration() {
     let nvme_config = StorageConfiguration {
         iops: 500_000,            // NVMe can do 500K+ IOPS
         bandwidth: 3_500_000_000, // ~3.5 GB/s
-        read_latency: Duration::from_micros(10)..Duration::from_micros(50),
-        write_latency: Duration::from_micros(10)..Duration::from_micros(50),
-        sync_latency: Duration::from_micros(100)..Duration::from_micros(500),
+        read_latency: uniform(Duration::from_micros(10), Duration::from_micros(50)),
+        write_latency: uniform(Duration::from_micros(10), Duration::from_micros(50)),
+        sync_latency: uniform(Duration::from_micros(100), Duration::from_micros(500)),
         read_fault_probability: 0.0,
         write_fault_probability: 0.0,
         crash_fault_probability: 0.0,
@@ -317,7 +331,11 @@ fn test_nvme_like_configuration() {
     };
 
     assert_eq!(nvme_config.iops, 500_000);
-    assert!(nvme_config.read_latency.start < Duration::from_micros(100));
+    let (nvme_read_start, _) = nvme_config
+        .read_latency
+        .uniform_bounds()
+        .expect("read_latency is uniform");
+    assert!(nvme_read_start < Duration::from_micros(100));
 }
 
 /// Test fault probability boundaries

--- a/moonpool-sim/tests/storage/latency.rs
+++ b/moonpool-sim/tests/storage/latency.rs
@@ -5,9 +5,14 @@
 
 use futures::io::{AsyncReadExt, AsyncWriteExt};
 use moonpool_core::{OpenOptions, StorageFile, StorageProvider};
-use moonpool_sim::{SimWorld, StorageConfiguration};
+use moonpool_sim::{LatencyDistribution, SimWorld, StorageConfiguration};
 use std::net::IpAddr;
 use std::time::Duration;
+
+/// Build a uniform latency distribution over `[start, end)` for test configs.
+fn uniform(start: Duration, end: Duration) -> LatencyDistribution {
+    LatencyDistribution::Uniform { start, end }
+}
 
 const TEST_IP_STR: &str = "127.0.0.1";
 
@@ -107,9 +112,9 @@ fn test_custom_latency_ranges() {
         let config = StorageConfiguration {
             iops: 1_000_000,          // Very high - minimal IOPS overhead
             bandwidth: 1_000_000_000, // Very high - minimal transfer time
-            read_latency: ten_ms..ten_ms,
-            write_latency: ten_ms..ten_ms,
-            sync_latency: ten_ms..ten_ms,
+            read_latency: uniform(ten_ms, ten_ms),
+            write_latency: uniform(ten_ms, ten_ms),
+            sync_latency: uniform(ten_ms, ten_ms),
             read_fault_probability: 0.0,
             write_fault_probability: 0.0,
             crash_fault_probability: 0.0,
@@ -155,9 +160,9 @@ fn test_latency_formula() {
         let config = StorageConfiguration {
             iops: 1000,           // 1ms per operation
             bandwidth: 1_000_000, // 1 MB/s = 1µs per byte
-            read_latency: Duration::from_micros(100)..Duration::from_micros(100),
-            write_latency: base_write..base_write,
-            sync_latency: Duration::from_micros(100)..Duration::from_micros(100),
+            read_latency: uniform(Duration::from_micros(100), Duration::from_micros(100)),
+            write_latency: uniform(base_write, base_write),
+            sync_latency: uniform(Duration::from_micros(100), Duration::from_micros(100)),
             read_fault_probability: 0.0,
             write_fault_probability: 0.0,
             crash_fault_probability: 0.0,
@@ -208,9 +213,9 @@ fn test_read_latency_scales_with_size() {
         let config = StorageConfiguration {
             iops: 1_000_000,
             bandwidth: 100_000, // 100 KB/s - slow to make size effect visible
-            read_latency: base..base,
-            write_latency: base..base,
-            sync_latency: base..base,
+            read_latency: uniform(base, base),
+            write_latency: uniform(base, base),
+            sync_latency: uniform(base, base),
             read_fault_probability: 0.0,
             write_fault_probability: 0.0,
             crash_fault_probability: 0.0,
@@ -309,9 +314,9 @@ fn test_write_latency_scales_with_size() {
         let config = StorageConfiguration {
             iops: 1_000_000,
             bandwidth: 100_000, // 100 KB/s - slow to make size effect visible
-            read_latency: base..base,
-            write_latency: base..base,
-            sync_latency: base..base,
+            read_latency: uniform(base, base),
+            write_latency: uniform(base, base),
+            sync_latency: uniform(base, base),
             read_fault_probability: 0.0,
             write_fault_probability: 0.0,
             crash_fault_probability: 0.0,

--- a/moonpool-sim/tests/storage/performance.rs
+++ b/moonpool-sim/tests/storage/performance.rs
@@ -6,9 +6,14 @@
 
 use futures::io::{AsyncReadExt, AsyncWriteExt};
 use moonpool_core::{OpenOptions, StorageFile, StorageProvider};
-use moonpool_sim::{SimWorld, StorageConfiguration};
+use moonpool_sim::{LatencyDistribution, SimWorld, StorageConfiguration};
 use std::net::IpAddr;
 use std::time::Duration;
+
+/// Build a uniform latency distribution over `[start, end)` for test configs.
+fn uniform(start: Duration, end: Duration) -> LatencyDistribution {
+    LatencyDistribution::Uniform { start, end }
+}
 
 const TEST_IP_STR: &str = "127.0.0.1";
 
@@ -55,9 +60,9 @@ fn test_low_iops_increases_latency() {
         let high_iops_config = StorageConfiguration {
             iops: 1_000_000, // 1µs per IOPS
             bandwidth: 1_000_000_000,
-            read_latency: base..base,
-            write_latency: base..base,
-            sync_latency: base..base,
+            read_latency: uniform(base, base),
+            write_latency: uniform(base, base),
+            sync_latency: uniform(base, base),
             ..StorageConfiguration::fast_local()
         };
 
@@ -65,9 +70,9 @@ fn test_low_iops_increases_latency() {
         let low_iops_config = StorageConfiguration {
             iops: 100, // 10ms per IOPS
             bandwidth: 1_000_000_000,
-            read_latency: base..base,
-            write_latency: base..base,
-            sync_latency: base..base,
+            read_latency: uniform(base, base),
+            write_latency: uniform(base, base),
+            sync_latency: uniform(base, base),
             ..StorageConfiguration::fast_local()
         };
 
@@ -130,9 +135,9 @@ fn test_low_bandwidth_increases_latency() {
         let high_bw_config = StorageConfiguration {
             iops: 1_000_000,
             bandwidth: 1_000_000_000, // 1 GB/s
-            read_latency: base..base,
-            write_latency: base..base,
-            sync_latency: base..base,
+            read_latency: uniform(base, base),
+            write_latency: uniform(base, base),
+            sync_latency: uniform(base, base),
             ..StorageConfiguration::fast_local()
         };
 
@@ -140,9 +145,9 @@ fn test_low_bandwidth_increases_latency() {
         let low_bw_config = StorageConfiguration {
             iops: 1_000_000,
             bandwidth: 10_000, // 10 KB/s - very slow
-            read_latency: base..base,
-            write_latency: base..base,
-            sync_latency: base..base,
+            read_latency: uniform(base, base),
+            write_latency: uniform(base, base),
+            sync_latency: uniform(base, base),
             ..StorageConfiguration::fast_local()
         };
 
@@ -200,9 +205,9 @@ fn test_large_file_bandwidth_constraint() {
         let config = StorageConfiguration {
             iops: 1_000_000,
             bandwidth: 100_000, // 100 KB/s
-            read_latency: base..base,
-            write_latency: base..base,
-            sync_latency: base..base,
+            read_latency: uniform(base, base),
+            write_latency: uniform(base, base),
+            sync_latency: uniform(base, base),
             ..StorageConfiguration::fast_local()
         };
 
@@ -245,9 +250,9 @@ fn test_iops_and_bandwidth_combine() {
         let config = StorageConfiguration {
             iops: 100,         // 10ms per op
             bandwidth: 10_000, // 10KB/s
-            read_latency: base..base,
-            write_latency: base..base,
-            sync_latency: base..base,
+            read_latency: uniform(base, base),
+            write_latency: uniform(base, base),
+            sync_latency: uniform(base, base),
             ..StorageConfiguration::fast_local()
         };
 
@@ -285,9 +290,9 @@ fn test_read_bandwidth_constraint() {
         let config = StorageConfiguration {
             iops: 1_000_000,
             bandwidth: 50_000, // 50 KB/s
-            read_latency: base..base,
-            write_latency: base..base,
-            sync_latency: base..base,
+            read_latency: uniform(base, base),
+            write_latency: uniform(base, base),
+            sync_latency: uniform(base, base),
             ..StorageConfiguration::fast_local()
         };
 
@@ -355,9 +360,9 @@ fn test_sequential_small_ops_iops_limited() {
         let config = StorageConfiguration {
             iops: 50, // 20ms per operation
             bandwidth: 1_000_000_000,
-            read_latency: base..base,
-            write_latency: base..base,
-            sync_latency: base..base,
+            read_latency: uniform(base, base),
+            write_latency: uniform(base, base),
+            sync_latency: uniform(base, base),
             ..StorageConfiguration::fast_local()
         };
 
@@ -424,9 +429,9 @@ fn test_hdd_vs_ssd_performance() {
         let hdd_config = StorageConfiguration {
             iops: 150,
             bandwidth: 150_000_000, // 150 MB/s sequential
-            read_latency: Duration::from_millis(5)..Duration::from_millis(5),
-            write_latency: Duration::from_millis(5)..Duration::from_millis(5),
-            sync_latency: Duration::from_millis(10)..Duration::from_millis(10),
+            read_latency: uniform(Duration::from_millis(5), Duration::from_millis(5)),
+            write_latency: uniform(Duration::from_millis(5), Duration::from_millis(5)),
+            sync_latency: uniform(Duration::from_millis(10), Duration::from_millis(10)),
             ..StorageConfiguration::fast_local()
         };
 
@@ -434,9 +439,9 @@ fn test_hdd_vs_ssd_performance() {
         let ssd_config = StorageConfiguration {
             iops: 50_000,
             bandwidth: 500_000_000, // 500 MB/s
-            read_latency: Duration::from_micros(100)..Duration::from_micros(100),
-            write_latency: Duration::from_micros(100)..Duration::from_micros(100),
-            sync_latency: Duration::from_millis(1)..Duration::from_millis(1),
+            read_latency: uniform(Duration::from_micros(100), Duration::from_micros(100)),
+            write_latency: uniform(Duration::from_micros(100), Duration::from_micros(100)),
+            sync_latency: uniform(Duration::from_millis(1), Duration::from_millis(1)),
             ..StorageConfiguration::fast_local()
         };
 


### PR DESCRIPTION
## Summary

Closes #67. Replaces moonpool-sim's **uniform** per-operation latency sampling with a pluggable `LatencyDistribution` enum, so simulations can exercise the heavy P99 tail where timeout cascades, retry storms, and backpressure collapse live. Deterministic via the sim RNG; **default behavior unchanged** (all `Uniform`).

```rust
pub enum LatencyDistribution {
    Uniform { start, end },                                   // legacy behavior
    Exponential { min, mean },                                // TigerBeetle-style long tail
    Bimodal { fast_range, slow_range, slow_probability },     // FoundationDB halfLatency
}
```

## Scope

Migrated the **8 operation-latency fields** only:
- `NetworkConfiguration`: bind / accept / connect / read / write latency
- `StorageConfiguration`: read / write / sync latency

The chaos fault-window fields (`clog_duration`, `partition_duration`, `max_pair_latency`) stay `Range<Duration>` sampled by `sample_duration` (which is retained) — they're fault durations / per-pair base latency, not per-operation latency, and #124/#126 own that territory.

## Behavior & determinism

- The `Uniform` arm consumes the **same single RNG draw** as the legacy `sample_duration`, so existing seeds and the fork-explorer replay call-count stay byte-identical.
- `Default` and `fast_local` keep every field `Uniform` — zero behavior change unless opted in.
- `random_for_seed` mixes all three shapes per field for chaos seeds.
- `Exponential` follows the issue's additive `min + mean*(-ln u)` form (TigerBeetle uses `max(min, exp)`; the divergence is documented). Computed in `f64` seconds via `Duration::try_from_secs_f64`/`as_secs_f64` (no manual casts), saturating to `Duration::MAX` on overflow rather than panicking.
- `Bimodal` is a fast cluster with a rare slow tail.

## Tests (8 new)

Per-seed determinism per variant; `Uniform` ↔ `sample_duration` parity; default-is-all-Uniform; exponential p99 > uniform p99 at equal mean; bimodal fast-cluster + slow-tail; exponential-with-zero-mean → min; exponential saturation without panic. ~21 config literals + projections migrated across 5 test files.

## Docs

Book appendix (`03-configuration.md`, `04-fault-reference.md`) reconciled — replaced the stale forward-reference placeholder (a non-existent global toggle) with the real per-field enum.

## Verification

- `cargo fmt`, `cargo clippy --all-targets -- -D warnings` (pedantic, no `#[allow]`)
- `cargo nextest run` → 566 passed, 1 skipped
- Portability: `clippy -p moonpool-sim --no-default-features` + `cargo check --target wasm32-unknown-unknown -p moonpool-sim --no-default-features`
- `mdbook build book/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)