### PR TITLE
feat(moonpool-sim): buggify-driven config-knob value-perturbation (#125)

### DIFF
--- a/book/src/part3-building/08-buggify.md
+++ b/book/src/part3-building/08-buggify.md
@@ -103,6 +103,37 @@ if buggify_with_prob!(0.01) {
 }
 ```
 
+## Spiking Config Knobs
+
+The patterns above scatter `buggify!()` through your own code. But the simulation has its own knobs: network latencies, disk IOPS, partition durations, fault probabilities. FoundationDB randomizes these the same way it randomizes everything else, with a one-liner at config construction:
+
+```cpp
+if (randomize && BUGGIFY) KNOB = deterministicRandom()->random(lo, hi);
+```
+
+Moonpool gives us `buggify_knob!(default, lo..hi)`. It returns `default` on most seeds, but when its call site activates and fires it returns a random value inside the range:
+
+```rust
+// Most seeds keep the sampled IOPS. A few push the disk to a crawl.
+self.iops = buggify_knob!(self.iops, 100..5_000);
+```
+
+This is a different coverage axis from swarm testing. **Swarm decides which fault families are on. Buggify-knobs decides how hard an enabled knob gets pushed.** A seed might run with only storage faults active, and within that, a disk throttled to 100 IOPS instead of the usual 25,000. The two compose, multiplying the configurations a night of seeds explores.
+
+We opt in through the same `enable_chaos` list we use for everything else:
+
+```rust
+SimulationBuilder::new()
+    .enable_chaos([
+        Chaos::Storage(ChaosMode::Swarm),
+        Chaos::BuggifyKnobs,
+    ])
+    .workload(MyWorkload)
+    .run();
+```
+
+`Chaos::BuggifyKnobs` is a modifier, not a surface of its own. It only perturbs knobs on surfaces we already enabled, so it never silently switches on a fault family we left off. Like every other buggify decision, each spike is deterministic per seed, so a failing seed replays exactly.
+
 ## Probability Calibration
 
 Not all buggify points should fire at the same rate. FoundationDB uses a three-tier calibration:

--- a/moonpool-sim/src/chaos/buggify.rs
+++ b/moonpool-sim/src/chaos/buggify.rs
@@ -4,6 +4,7 @@
 //! Active locations fire probabilistically on each call.
 
 use crate::sim::rng::sim_random;
+use rand::distr::uniform::SampleUniform;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 
@@ -62,6 +63,26 @@ pub fn buggify_internal(prob: f64, location: &'static str) -> bool {
     })
 }
 
+/// Buggify a knob *value* within bounds.
+///
+/// Returns `default` on most seeds, but when this call site is buggify-activated
+/// and fires (same two-phase model as [`buggify_internal`]) it returns a random
+/// value drawn from `range`. Deterministic per `(location, seed)`; varies across
+/// seeds. Mirrors `FoundationDB`'s `if (randomize && BUGGIFY) KNOB = random(lo, hi)`
+/// (`Buggify.h`): a knob keeps its configured value most of the time, but a given
+/// seed occasionally spikes it to an extreme within `range`.
+#[must_use]
+pub fn buggify_knob_internal<T>(default: T, range: std::ops::Range<T>, location: &'static str) -> T
+where
+    T: SampleUniform + PartialOrd + Clone,
+{
+    if buggify_internal(0.25, location) {
+        crate::sim::sim_random_range_or_default(range)
+    } else {
+        default
+    }
+}
+
 /// Buggify with 25% probability
 #[macro_export]
 macro_rules! buggify {
@@ -75,6 +96,24 @@ macro_rules! buggify {
 macro_rules! buggify_with_prob {
     ($prob:expr) => {
         $crate::chaos::buggify::buggify_internal($prob as f64, concat!(file!(), ":", line!()))
+    };
+}
+
+/// Buggify a config knob *value* within bounds.
+///
+/// `buggify_knob!(default, lo..hi)` evaluates to `default` on most seeds, but when
+/// buggify is enabled and this call site is activated + fires (same model as
+/// [`buggify!`]) it evaluates to a random value in `lo..hi`. Deterministic per
+/// `(location, seed)`, so replay is exact. Mirrors `FoundationDB`'s
+/// `if (randomize && BUGGIFY) KNOB = random(lo, hi)`.
+#[macro_export]
+macro_rules! buggify_knob {
+    ($default:expr, $range:expr) => {
+        $crate::chaos::buggify::buggify_knob_internal(
+            $default,
+            $range,
+            concat!(file!(), ":", line!()),
+        )
     };
 }
 
@@ -131,5 +170,65 @@ mod tests {
         }
 
         assert_eq!(results1, results2);
+    }
+
+    /// Collect a fixed sequence of `buggify_knob!` results for one seed.
+    fn knob_sequence(seed: u64) -> Vec<u64> {
+        reset_sim_rng();
+        set_sim_seed(seed);
+        buggify_init(0.8, 0.8);
+        let mut out = Vec::new();
+        for i in 0..20 {
+            // Distinct call-site identity per index without a real source line.
+            let location = Box::leak(format!("knob_{i}").into_boxed_str());
+            out.push(buggify_knob_internal::<u64>(100, 1_000..2_000, location));
+        }
+        buggify_reset();
+        out
+    }
+
+    #[test]
+    fn test_buggify_knob_deterministic() {
+        const SEED: u64 = 98765;
+        assert_eq!(knob_sequence(SEED), knob_sequence(SEED));
+    }
+
+    #[test]
+    fn test_buggify_knob_varies_across_seeds() {
+        let sequences: Vec<Vec<u64>> = [111u64, 222, 333, 444, 555]
+            .iter()
+            .map(|s| knob_sequence(*s))
+            .collect();
+        let unique = sequences
+            .iter()
+            .collect::<std::collections::HashSet<_>>()
+            .len();
+        assert!(
+            unique > 1,
+            "different seeds should yield different knob spikes"
+        );
+    }
+
+    #[test]
+    fn test_buggify_knob_disabled_returns_default() {
+        reset_sim_rng();
+        set_sim_seed(42);
+        buggify_reset(); // disabled: never spike
+        for _ in 0..10 {
+            assert_eq!(buggify_knob_internal::<u64>(100, 1_000..2_000, "loc"), 100);
+        }
+    }
+
+    #[test]
+    fn test_buggify_knob_spiked_value_in_range() {
+        reset_sim_rng();
+        set_sim_seed(7);
+        buggify_init(1.0, 1.0); // always active + fire
+        let v = buggify_knob_internal::<u64>(100, 1_000..2_000, "always");
+        buggify_reset();
+        assert!(
+            (1_000..2_000).contains(&v),
+            "spiked value must be in range, got {v}"
+        );
     }
 }

--- a/moonpool-sim/src/chaos/mod.rs
+++ b/moonpool-sim/src/chaos/mod.rs
@@ -139,6 +139,6 @@ pub use assertions::{
     on_assertion_numeric, on_assertion_sometimes_all, on_sometimes_each, record_always_violation,
     reset_always_violations, reset_assertion_results, validate_assertion_contracts,
 };
-pub use buggify::{buggify_init, buggify_internal, buggify_reset};
+pub use buggify::{buggify_init, buggify_internal, buggify_knob_internal, buggify_reset};
 pub use fault_events::{SIM_FAULT_EVENT_NAME, SimFaultEvent};
 pub use state_handle::StateHandle;

--- a/moonpool-sim/src/network/config.rs
+++ b/moonpool-sim/src/network/config.rs
@@ -385,6 +385,21 @@ impl ChaosConfiguration {
             self.max_pair_latency = Duration::ZERO..Duration::ZERO;
         }
     }
+
+    /// Spike selected fault *magnitudes* under buggify (FDB's
+    /// `if (randomize && BUGGIFY) KNOB = random(lo, hi)`).
+    ///
+    /// Composes on top of [`random_for_seed`](Self::random_for_seed) /
+    /// [`swarm_for_seed`](Self::swarm_for_seed): each knob keeps its sampled value
+    /// unless its own [`buggify_knob!`](crate::buggify_knob) call site fires for the
+    /// seed, in which case it jumps to an aggressive value within bounds. A
+    /// representative subset — extend by adding more `buggify_knob!` lines.
+    pub fn apply_buggify_knobs(&mut self) {
+        self.clog_probability = crate::buggify_knob!(self.clog_probability, 0.5..1.0);
+        self.partition_probability = crate::buggify_knob!(self.partition_probability, 0.3..0.8);
+        self.random_close_probability =
+            crate::buggify_knob!(self.random_close_probability, 0.01..0.1);
+    }
 }
 
 /// Configuration for network simulation parameters

--- a/moonpool-sim/src/runner/builder.rs
+++ b/moonpool-sim/src/runner/builder.rs
@@ -374,6 +374,12 @@ pub enum Chaos {
         /// How the regime is sampled per seed.
         mode: ChaosMode,
     },
+    /// Buggify-driven knob value-perturbation. An additive *modifier*, not a
+    /// surface of its own: on enabled network/storage surfaces it occasionally
+    /// spikes individual knob *values* (latencies, IOPS, fault rates) to an
+    /// extreme within bounds, per FDB's `if (randomize && BUGGIFY) KNOB =
+    /// random(lo, hi)`. Composes with [`ChaosMode::Random`]/[`ChaosMode::Swarm`].
+    BuggifyKnobs,
 }
 
 /// Builder pattern for configuring and running simulation experiments.
@@ -386,6 +392,10 @@ pub struct SimulationBuilder {
     seeds: Vec<u64>,
     network_chaos: Option<ChaosMode>,
     storage_chaos: Option<ChaosMode>,
+    /// Buggify-driven knob value-perturbation, enabled via [`Chaos::BuggifyKnobs`].
+    /// Internal flag (not a public builder method) so the opt-in stays inside the
+    /// `enable_chaos`/`Chaos` model.
+    buggify_knobs: bool,
     swarm_operations: bool,
     invariants: Vec<Box<dyn Invariant + Send>>,
     fault_injectors: Vec<Box<dyn FaultInjector>>,
@@ -415,6 +425,7 @@ impl SimulationBuilder {
             seeds: Vec::new(),
             network_chaos: None,
             storage_chaos: None,
+            buggify_knobs: false,
             swarm_operations: false,
             invariants: Vec::new(),
             fault_injectors: Vec::new(),
@@ -775,6 +786,7 @@ impl SimulationBuilder {
                     self.attrition = Some(config);
                     self.attrition_mode = mode;
                 }
+                Chaos::BuggifyKnobs => self.buggify_knobs = true,
             }
         }
         self
@@ -911,18 +923,31 @@ impl SimulationBuilder {
     fn build_sim_for_iteration(
         network_chaos: Option<ChaosMode>,
         storage_chaos: Option<ChaosMode>,
+        buggify_knobs: bool,
         seed: u64,
     ) -> crate::sim::SimWorld {
-        let network_config = match network_chaos {
+        let mut network_config = match network_chaos {
             Some(ChaosMode::Swarm) => crate::NetworkConfiguration::swarm_for_seed(),
             Some(ChaosMode::Random) => crate::NetworkConfiguration::random_for_seed(),
             None => crate::NetworkConfiguration::default(),
         };
-        let storage_config = match storage_chaos {
+        let mut storage_config = match storage_chaos {
             Some(ChaosMode::Swarm) => crate::storage::StorageConfiguration::swarm_for_seed(),
             Some(ChaosMode::Random) => crate::storage::StorageConfiguration::random_for_seed(),
             None => crate::storage::StorageConfiguration::default(),
         };
+        // Buggify value-perturbation is a modifier layered on top of an enabled
+        // surface — only spike knobs where chaos is actually on, so it never
+        // silently switches on a fault family that wasn't enabled. Draws from
+        // `SIM_RNG` (buggify is live by now; see `reset_per_iteration_state`).
+        if buggify_knobs {
+            if network_chaos.is_some() {
+                network_config.chaos.apply_buggify_knobs();
+            }
+            if storage_chaos.is_some() {
+                storage_config.apply_buggify_knobs();
+            }
+        }
         let mut sim = crate::sim::SimWorld::new_with_network_config_and_seed(network_config, seed);
         sim.set_storage_config(storage_config);
         sim
@@ -1463,7 +1488,12 @@ impl SimulationBuilder {
             .as_ref()
             .map(Self::resolve_process_config);
 
-        let sim = Self::build_sim_for_iteration(self.network_chaos, self.storage_chaos, seed);
+        let sim = Self::build_sim_for_iteration(
+            self.network_chaos,
+            self.storage_chaos,
+            self.buggify_knobs,
+            seed,
+        );
         let start_time = Instant::now();
         // Derive the per-seed attrition regime: `Swarm` draws a fresh reboot regime
         // from `CONFIG_RNG` (after the network/storage masks, keeping the draw order

--- a/moonpool-sim/src/storage/config.rs
+++ b/moonpool-sim/src/storage/config.rs
@@ -276,6 +276,22 @@ impl StorageConfiguration {
         }
     }
 
+    /// Spike selected disk knob *magnitudes* under buggify (FDB's
+    /// `if (randomize && BUGGIFY) KNOB = random(lo, hi)`).
+    ///
+    /// Composes on top of [`random_for_seed`](Self::random_for_seed) /
+    /// [`swarm_for_seed`](Self::swarm_for_seed): each knob keeps its sampled value
+    /// unless its own [`buggify_knob!`](crate::buggify_knob) call site fires for the
+    /// seed. Demonstrates both throttling *down* (IOPS/bandwidth → extreme-slow
+    /// disk) and spiking a fault rate *up*. A representative subset — extend by
+    /// adding more `buggify_knob!` lines.
+    pub fn apply_buggify_knobs(&mut self) {
+        self.iops = crate::buggify_knob!(self.iops, 100..5_000);
+        self.bandwidth = crate::buggify_knob!(self.bandwidth, 1_000_000..20_000_000);
+        self.sync_failure_probability =
+            crate::buggify_knob!(self.sync_failure_probability, 0.05..0.2);
+    }
+
     /// Create a configuration optimized for fast local testing.
     ///
     /// Minimal latencies and no fault injection for predictable,
@@ -393,6 +409,51 @@ mod swarm_tests {
             value.to_bits(),
             0.0_f64.to_bits(),
             "expected 0.0, got {value}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod buggify_knob_tests {
+    use super::StorageConfiguration;
+    use crate::chaos::{buggify_init, buggify_reset};
+    use crate::sim::rng::{reset_sim_rng, set_config_seed, set_sim_seed};
+
+    /// Sample the buggify-spiked knobs the way the runner does: seed both RNG
+    /// streams and enable buggify before perturbing. Returns the spiked knobs
+    /// (`sync_failure_probability` as bits for exact comparison).
+    fn buggified_knobs(seed: u64) -> (u64, u64, u64) {
+        reset_sim_rng();
+        set_sim_seed(seed);
+        set_config_seed(seed);
+        buggify_init(0.8, 0.8);
+        let mut config = StorageConfiguration::swarm_for_seed();
+        config.apply_buggify_knobs();
+        buggify_reset();
+        (
+            config.iops,
+            config.bandwidth,
+            config.sync_failure_probability.to_bits(),
+        )
+    }
+
+    #[test]
+    fn buggify_knobs_deterministic_per_seed() {
+        for seed in [0_u64, 1, 42, 12_345] {
+            assert_eq!(
+                buggified_knobs(seed),
+                buggified_knobs(seed),
+                "buggify knob spikes must be reproducible for seed {seed}"
+            );
+        }
+    }
+
+    #[test]
+    fn buggify_knobs_vary_across_seeds() {
+        let distinct: std::collections::HashSet<_> = (0..50_u64).map(buggified_knobs).collect();
+        assert!(
+            distinct.len() > 1,
+            "buggify knob spikes should vary across seeds"
         );
     }
 }

--- a/moonpool-sim/tests/chaos/swarm.rs
+++ b/moonpool-sim/tests/chaos/swarm.rs
@@ -53,3 +53,29 @@ fn swarm_runs_clean_across_seeds() {
     );
     assert_eq!(report.iterations, 50, "expected all 50 seeds to run");
 }
+
+/// `Chaos::BuggifyKnobs` layered on top of swarm must build a per-seed config
+/// (with occasional knob-value spikes applied in `build_sim_for_iteration`) and
+/// complete every seed cleanly. Exercises both the network and storage
+/// `apply_buggify_knobs` wiring. The buggify network spikes (clog/partition/
+/// random-close magnitudes) never touch `connect_failure_mode`, so the bind-only
+/// workload still can't deadlock.
+#[test]
+fn buggify_knobs_runs_clean_across_seeds() {
+    let report = SimulationBuilder::new()
+        .enable_chaos([
+            Chaos::Network(ChaosMode::Swarm),
+            Chaos::Storage(ChaosMode::Swarm),
+            Chaos::BuggifyKnobs,
+        ])
+        .set_iterations(50)
+        .workload(SwarmSmokeWorkload)
+        .run();
+
+    assert_eq!(
+        report.failed_runs, 0,
+        "buggify-knobs run had {} failed seeds",
+        report.failed_runs
+    );
+    assert_eq!(report.iterations, 50, "expected all 50 seeds to run");
+}


### PR DESCRIPTION
Closes #125.

## What

Adds the **value-perturbation** coverage axis FoundationDB gets from
`if (randomize && BUGGIFY) KNOB = random(lo, hi)`. Swarm testing decides *which*
fault families are on per seed; this decides *how hard* an enabled knob is pushed.
The two compose, multiplying the configurations a night of seeds explores.

## Changes

- **`chaos/buggify.rs`** — new `buggify_knob!(default, lo..hi)` macro + `buggify_knob_internal<T>`.
  Reuses the existing two-phase `buggify_internal` for activation/firing and draws via
  `sim_random_range_or_default`, so each spike is deterministic per `(location, seed)` and
  varies across seeds.
- **`network/config.rs` / `storage/config.rs`** — `apply_buggify_knobs(&mut self)` spiking a
  representative knob subset (clog/partition/random-close probabilities; IOPS + bandwidth
  throttled *down* to model an extreme-slow disk; sync-failure rate spiked *up*).
- **`runner/builder.rs`** — new `Chaos::BuggifyKnobs` marker sets an internal `buggify_knobs`
  flag (no new public builder bool). `build_sim_for_iteration` applies spikes only to surfaces
  that are *already enabled*, so it composes with `swarm_for_seed`/`random_for_seed` and never
  silently switches on a fault family that was left off. (Verified buggify is live at config-build
  time: `reset_per_iteration_state` → `buggify_init` runs before `build_sim_for_iteration`.)
- **`tests/chaos/swarm.rs`** — end-to-end smoke test over 50 seeds with
  `[Network(Swarm), Storage(Swarm), BuggifyKnobs]`.
- **`book/src/part3-building/08-buggify.md`** — new "Spiking Config Knobs" section documenting
  `buggify_knob!` and the `Chaos::BuggifyKnobs` opt-in.

## Notes on the spec

- Consolidated the issue's loose `buggify_knob!(lo..hi)` / `buggify_knob!(default)` wording into
  the single two-arg `buggify_knob!(default, lo..hi)` form, matching the issue's own
  `buggify_knob_internal(default, lo, hi, location)` signature.
- Swapped the planned `buggified_delay_max` (Duration) network knob for `random_close_probability`
  to avoid a `u128 → u64` cast that trips clippy pedantic — same intent, clean lint.

## Acceptance criteria

- [x] `buggify_knob!` macro + internal fn; same value per (location, seed), varies across seeds.
- [x] Buggify-aware config builder spikes selected knob *values* only when active, composing with `swarm_for_seed`.
- [x] Integrates through `enable_chaos`/`ChaosMode` (no new top-level builder bool).
- [x] Existing `buggify!`/`buggify_with_prob!` and swarm semantics unchanged; determinism tests added.

## Verification

`cargo fmt --check`, full-workspace `clippy -D warnings`, `cargo nextest run --workspace`
(587 passed), `moonpool-sim` no-default-features clippy + wasm32 check, and `mdbook build` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)