### PR TITLE
feat(moonpool-sim): consolidate stop conditions into UntilCoverageStable (#135)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ attribute is not an acceptable resolution.
 - `cargo xtask sim run-all` — run all simulation binaries
 
 **Debug testing**:
-- Default: `UntilAllSometimesReached(1000)` for comprehensive chaos testing
+- Default: `UntilCoverageStable { plateau_seeds: 10, max_iterations: 1000 }` — runs adaptively until every `assert_sometimes!`/`assert_reachable!` has fired AND code coverage plateaus (real sancov edges under `cargo xtask sim run`; assertion-coverage fallback otherwise)
 - Debug faulty seeds: `FixedCount(1)` with specific seed and ERROR log level
 
 ## Commit Messages
@@ -97,7 +97,7 @@ Where generics hurt, erase at a boundary (precedent: `Arc<dyn TransportHandle>`)
 **Goal**: 100% sometimes assertion coverage via chaos testing + comprehensive invariant validation
 **Target**: 100% success rate - no deadlocks/hangs acceptable
 
-**Multi-seed testing**: Default `UntilAllSometimesReached(1000)` runs until all assert_sometimes! statements have triggered
+**Multi-seed testing**: Default `UntilCoverageStable` runs adaptively until all assert_sometimes! statements have triggered and code coverage plateaus (`.until_coverage_stable(plateau_seeds, max_iterations)` to tune)
 **Failing seeds**: Debug with `SimulationBuilder::set_seed(failing_seed)` → fix root cause → verify → re-enable chaos
 **Infrastructure events**: Tests terminate early when only ConnectionRestore events remain
 **Invariant checking**: Cross-workload properties validated after every simulation step

--- a/book/src/appendix/03-configuration.md
+++ b/book/src/appendix/03-configuration.md
@@ -36,7 +36,7 @@ The builder pattern for configuring and running simulation experiments. Created 
 
 A freshly created `SimulationBuilder::new()` has:
 
-- **iteration_control**: `IterationControl::FixedCount(1)`
+- **iteration_control**: `IterationControl::UntilCoverageStable { plateau_seeds: 10, max_iterations: 1000 }`
 - **chaos**: all surfaces off (network/storage use `default()`, no attrition)
 - **swarm_operations**: `false` (workloads see the full operation alphabet)
 - **exploration**: disabled
@@ -49,10 +49,11 @@ Controls how many iterations a simulation runs.
 
 | Variant | Type | Description |
 |---------|------|-------------|
+| `UntilCoverageStable { plateau_seeds, max_iterations }` | `usize`, `usize` | **Default.** Stop once every observed `assert_sometimes!` / `assert_reachable!` has fired AND code coverage has not grown for `plateau_seeds` consecutive seeds. `max_iterations` is a safety cap. |
 | `FixedCount(n)` | `usize` | Run exactly `n` iterations |
 | `TimeLimit(duration)` | `Duration` | Run for a wall-clock time duration |
 
-**Note**: The `UntilAllSometimesReached(N)` pattern mentioned in CLAUDE.md is implemented at the test level by checking assertion coverage, not as a variant of `IterationControl`.
+**Note**: `UntilCoverageStable` uses real LLVM sancov code coverage when the binary is instrumented (built via `cargo xtask sim run`) and falls back to assertion-slot coverage otherwise. The report names the signal it used.
 
 ## ProcessCount
 

--- a/book/src/part3-building/04-simulation-builder.md
+++ b/book/src/part3-building/04-simulation-builder.md
@@ -49,10 +49,10 @@ One iteration is not enough. Different seeds produce different scheduling orders
 .set_time_limit(Duration::from_secs(60))
 ```
 
-**Coverage plateau** stops once `assert_sometimes!` and `assert_reachable!` coverage has not grown for a configurable number of consecutive seeds. Useful when you want chaos to run as long as it keeps finding new behaviour and stop automatically once it does not:
+**Until coverage stable** is the default. It stops once every observed `assert_sometimes!` / `assert_reachable!` has fired **and** code coverage has not grown for a configurable number of consecutive seeds. Useful when you want chaos to run as long as it keeps finding new behaviour and stop automatically once it does not:
 
 ```rust
-.until_coverage_plateau(50, 5_000)  // 50 plateau seeds, 5_000 safety cap
+.until_coverage_stable(10, 5_000)  // 10 quiet seeds, 5_000 safety cap
 ```
 
 Each iteration gets a different seed, producing a different execution. The seeds are deterministic and derived from the iteration manager, so the same configuration always explores the same seeds.

--- a/book/src/part3-building/05-running.md
+++ b/book/src/part3-building/05-running.md
@@ -142,24 +142,22 @@ The debugging workflow:
 
 ## Stop Conditions
 
-How long should a chaos run last? Moonpool exposes four answers via `IterationControl`, each suited to a different question.
+How long should a chaos run last? Any fixed seed count is wrong: too small misses bugs, too large burns time. The right answer is to **stop on a signal, not a count** — when the run has nothing left to discover. Moonpool exposes three answers via `IterationControl`.
 
-**`FixedCount(n)`** is the workhorse for CI. You commit to running exactly `n` seeds, the duration is bounded, and the report is reproducible across machines. Reach for this when budgets are predictable.
-
-**`TimeLimit(d)`** is the answer when "as much chaos as we have time for" is the right framing. Long-running soak runs and overnight loops use this. The seed count is unbounded but the wall clock is.
-
-**`UntilConverged { max_iterations }`** stops when every `assert_sometimes!` has fired at least once **and** the explorer's coverage bitmap stopped growing on the latest seed. It requires `.enable_exploration()` because it reads the fork-aware coverage map. Use it when you have configured exploration and want the run to end as soon as it has nothing left to discover.
-
-**`CoveragePlateau { plateau_seeds, require_all_sometimes, max_iterations }`** is the more general plateau detector. It tracks the set of `assert_sometimes!` / `assert_reachable!` messages that have ever fired and stops once that set has not grown for `plateau_seeds` consecutive seeds. The signal lives in moonpool-sim, so this works **with or without** fork-based exploration. Set `require_all_sometimes=true` if you want to refuse to stop until every observed sometimes assertion has fired at least once.
+**`UntilCoverageStable { plateau_seeds, max_iterations }`** is the default, and the one you want most of the time. It stops when every observed `assert_sometimes!` / `assert_reachable!` has fired at least once **and** code coverage has not grown for `plateau_seeds` consecutive seeds. The `max_iterations` field is a safety cap. Under `cargo xtask sim run` the binaries are sancov-instrumented, so the progress signal is **real code coverage** — the count of distinct edges the seeds have exercised. Under plain `cargo nextest run` there is no instrumentation, so it falls back to **assertion coverage** — the set of sometimes/reachable messages that have fired. The report names which signal it used, so the fallback is never silent. This works **with or without** fork-based exploration; no fork happens unless you call `.enable_exploration()`.
 
 ```rust
 SimulationBuilder::new()
     .workload(KvWorkload::new(200, keys))
-    .until_coverage_plateau(50, 5_000)
+    .until_coverage_stable(10, 5_000)  // 10 quiet seeds, 5_000 safety cap
     .run();
 ```
 
-Both `UntilConverged` and `CoveragePlateau` set `report.convergence_timeout = true` when the safety cap is hit before the run converges, so CI can fail loudly instead of silently treating "we ran out of seeds" as success.
+**`FixedCount(n)`** is the workhorse for reproducible replay. You commit to running exactly `n` seeds, the duration is bounded, and the report is identical across machines. Reach for this when debugging a specific seed or when budgets must be predictable.
+
+**`TimeLimit(d)`** is the answer when "as much chaos as we have time for" is the right framing. Long-running soak runs and overnight loops use this. The seed count is unbounded but the wall clock is.
+
+`UntilCoverageStable` sets `report.convergence_timeout = true` when the safety cap is hit before the run saturates, so CI can fail loudly instead of silently treating "we ran out of seeds" as success.
 
 ## cargo nextest vs cargo xtask sim
 

--- a/book/src/part4-networking/10-designing-rpc.md
+++ b/book/src/part4-networking/10-designing-rpc.md
@@ -139,4 +139,4 @@ The reason these strategies matter in moonpool is that **simulation testing will
 
 A process that uses `get_reply` for a non-idempotent request will see duplicate processing when the chaos engine severs and restores connections. A process that uses `try_get_reply` without handling `MaybeDelivered` will silently drop operations when the chaos engine triggers disconnects. A fire-and-forget heartbeat that should have been reliable will cause false failure detection when the chaos engine delays messages.
 
-The simulation does not know which strategy is "correct" for your use case. But it generates the failure patterns that expose incorrect choices. Run with `UntilAllSometimesReached(1000)` and let the chaos engine prove that your RPC strategy handles every failure mode your system will encounter in production.
+The simulation does not know which strategy is "correct" for your use case. But it generates the failure patterns that expose incorrect choices. Run with the default `UntilCoverageStable` stop condition and let the chaos engine prove that your RPC strategy handles every failure mode your system will encounter in production.

--- a/book/src/part5-building-on-top/06-multi-seed.md
+++ b/book/src/part5-building-on-top/06-multi-seed.md
@@ -62,7 +62,7 @@ Less total energy, faster wall-clock time, comparable bug discovery. The multi-s
 
 Five times faster with 20% less total energy. The two seeds happen to cover the state space from different angles, and each seed's warm start avoids re-exploring the other's territory.
 
-These speedups come from the coverage-preserving reset. Without it, multi-seed exploration would be N independent runs with no shared knowledge, which is what plain `UntilAllSometimesReached` already does. The explored map is the innovation that makes multi-seed better than the sum of its parts.
+These speedups come from the coverage-preserving reset. Without it, multi-seed exploration would be N independent runs with no shared knowledge, which is what a plain multi-seed loop already does. The explored map is the innovation that makes multi-seed better than the sum of its parts.
 
 ## The Builder Loop
 

--- a/moonpool-assertions/src/lib.rs
+++ b/moonpool-assertions/src/lib.rs
@@ -15,7 +15,8 @@
 //! children, and installs a [`DiscoveryHooks`] that turns "a new assertion state
 //! was reached" into coverage marking and fork dispatch. With no hooks installed
 //! the accounting is pure: assertions still record pass/fail/watermark/frontier,
-//! which is all `UntilAllSometimesReached` and contract validation need.
+//! which is all the `UntilCoverageStable` stop condition and contract
+//! validation need.
 //!
 //! See [`hooks`] for the coupling surface and [`region`] for the storage model.
 

--- a/moonpool-explorer/src/lib.rs
+++ b/moonpool-explorer/src/lib.rs
@@ -579,7 +579,9 @@ pub use moonpool_assertions::{
     assertion_table_ptr, each_bucket_read_all, msg_hash, unpack_quality,
 };
 pub use replay::{ParseTimelineError, format_timeline, parse_timeline};
-pub use sancov::{sancov_edge_count, sancov_edges_covered, sancov_is_available};
+pub use sancov::{
+    sancov_edge_count, sancov_edges_covered, sancov_edges_covered_live, sancov_is_available,
+};
 pub use shared_stats::{ExplorationStats, bug_recipe, exploration_stats};
 pub use split_loop::{AdaptiveConfig, Parallelism, exit_child};
 

--- a/moonpool-explorer/src/sancov.rs
+++ b/moonpool-explorer/src/sancov.rs
@@ -269,7 +269,7 @@
 //!   └── cleanup_sancov_shared()      free transfer + history + pool
 //! ```
 
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 use std::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
 
 // ---------------------------------------------------------------------------
@@ -307,6 +307,12 @@ thread_local! {
     ///
     /// Public so `setup_child()` can reset for nested splits.
     pub static SANCOV_POOL_SLOTS: Cell<usize> = const { Cell::new(0) };
+
+    /// Cumulative "ever non-zero" mask over the BSS counter array (one byte per
+    /// edge), for the fork-free live coverage reader. Lets the reader survive
+    /// 8-bit counter wraparound: once an edge has been seen non-zero it stays
+    /// counted, so the result is monotonic across seeds.
+    static SANCOV_SEEN: RefCell<Vec<u8>> = const { RefCell::new(Vec::new()) };
 }
 
 // ---------------------------------------------------------------------------
@@ -519,6 +525,46 @@ pub fn sancov_edges_covered() -> usize {
         }
     }
     count
+}
+
+/// Cumulative count of edges ever observed non-zero in the live BSS array.
+///
+/// Unlike [`sancov_edges_covered`], this reads the LLVM-instrumented counters
+/// directly in the current process — no `SANCOV_HISTORY`, no fork. Each call
+/// folds the current counters into a persistent "seen" mask ([`SANCOV_SEEN`])
+/// and returns the size of the union. Folding (rather than counting raw
+/// non-zero bytes) is essential: the 8-bit counters wrap at 256 and are not
+/// reset between seeds in the sequential path, so a hot edge whose cumulative
+/// count momentarily lands on a multiple of 256 would otherwise drop out of a
+/// raw count. The union is monotonic across seeds, so it can plateau.
+///
+/// Returns 0 when sancov is unavailable.
+pub fn sancov_edges_covered_live() -> usize {
+    if !sancov_is_available() {
+        return 0;
+    }
+    let ptr = COUNTERS_PTR.load(Ordering::Relaxed);
+    if ptr.is_null() {
+        return 0;
+    }
+    let len = COUNTERS_LEN.load(Ordering::Relaxed);
+    SANCOV_SEEN.with_borrow_mut(|seen| {
+        if seen.len() != len {
+            seen.clear();
+            seen.resize(len, 0);
+        }
+        let mut count = 0usize;
+        for (i, slot) in seen.iter_mut().enumerate() {
+            // Safety: the LLVM ctor registered `len` bytes starting at `ptr`.
+            if unsafe { *ptr.add(i) } != 0 {
+                *slot = 1;
+            }
+            if *slot != 0 {
+                count += 1;
+            }
+        }
+        count
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -806,6 +852,7 @@ mod tests {
         assert!(!sancov_is_available());
         assert_eq!(sancov_edge_count(), 0);
         assert_eq!(sancov_edges_covered(), 0);
+        assert_eq!(sancov_edges_covered_live(), 0);
         assert!(!has_new_sancov_coverage());
         assert!(!has_new_sancov_coverage_from(std::ptr::null_mut()));
 

--- a/moonpool-sim/README.md
+++ b/moonpool-sim/README.md
@@ -45,7 +45,7 @@ If your error handling code exists but `assert_sometimes!` never fires, you have
 
 ## Multi-Seed Testing
 
-Different seeds explore different execution orderings. `UntilAllSometimesReached(N)` runs simulations with different seeds until all `assert_sometimes!` statements have triggered at least once, up to N iterations.
+Different seeds explore different execution orderings. The default `UntilCoverageStable` stop condition runs simulations with different seeds until every `assert_sometimes!` / `assert_reachable!` has triggered at least once **and** code coverage has plateaued (capped at `max_iterations`). Tune it with `.until_coverage_stable(plateau_seeds, max_iterations)`.
 
 This transforms testing from "check known behaviors" to "explore the unknown until confident."
 

--- a/moonpool-sim/src/chaos/exploration_glue.rs
+++ b/moonpool-sim/src/chaos/exploration_glue.rs
@@ -37,16 +37,46 @@ pub fn cleanup_assertion_region() {
     moonpool_assertions::clear();
 }
 
-/// Number of bits set in the explored coverage map (0 without exploration).
+/// Cumulative real code-coverage edge count, or `None` when unavailable.
+///
+/// Returns `None` without the `exploration` feature, or when the binary was
+/// not sancov-instrumented (i.e. not built via `cargo xtask sim run`). When
+/// `exploration_active`, reads the fork-aggregated history; otherwise reads the
+/// live BSS counters of the current process (no fork).
 #[must_use]
-pub fn explored_coverage_bits() -> u32 {
+pub fn code_coverage_edges(exploration_active: bool) -> Option<usize> {
     #[cfg(feature = "exploration")]
     {
-        moonpool_explorer::explored_map_bits_set().unwrap_or(0)
+        if !moonpool_explorer::sancov_is_available() {
+            return None;
+        }
+        Some(if exploration_active {
+            moonpool_explorer::sancov_edges_covered()
+        } else {
+            moonpool_explorer::sancov_edges_covered_live()
+        })
     }
     #[cfg(not(feature = "exploration"))]
     {
-        0
+        let _ = exploration_active;
+        None
+    }
+}
+
+/// Total number of instrumented code edges, or `None` when unavailable.
+#[must_use]
+pub fn code_coverage_total() -> Option<usize> {
+    #[cfg(feature = "exploration")]
+    {
+        if moonpool_explorer::sancov_is_available() {
+            Some(moonpool_explorer::sancov_edge_count())
+        } else {
+            None
+        }
+    }
+    #[cfg(not(feature = "exploration"))]
+    {
+        None
     }
 }
 

--- a/moonpool-sim/src/chaos/mod.rs
+++ b/moonpool-sim/src/chaos/mod.rs
@@ -100,8 +100,9 @@
 //! }
 //! ```
 //!
-//! Multi-seed testing with `UntilAllSometimesReached(1000)` ensures all
-//! `assert_sometimes!` statements fire across the seed space.
+//! Multi-seed testing with the default `UntilCoverageStable` stop condition
+//! ensures all `assert_sometimes!` statements fire across the seed space and
+//! code coverage plateaus before stopping.
 //!
 //! # Strategic Placement
 //!

--- a/moonpool-sim/src/runner/builder.rs
+++ b/moonpool-sim/src/runner/builder.rs
@@ -53,6 +53,8 @@ type OrchestrationOutcome = Result<OrchestrateOutput, (Vec<u64>, usize)>;
 /// Per-run accumulators passed into the final-report builder.
 struct FinalReportInputs {
     converged: bool,
+    /// Saturation outcome captured during the last scan (`UntilCoverageStable`).
+    saturation: Option<super::report::SaturationReport>,
     #[cfg(feature = "exploration")]
     total_exploration_timelines: u64,
     #[cfg(feature = "exploration")]
@@ -71,9 +73,13 @@ struct ConvergenceState<'a> {
     iteration_count: usize,
     reached_sometimes: &'a std::collections::HashSet<String>,
     all_sometimes_count: usize,
-    prev_coverage_bits: &'a mut u32,
+    /// Whether fork-based exploration is active (selects sancov history vs
+    /// the live BSS counter reader for the code-coverage signal).
+    exploration_active: bool,
+    prev_signal: &'a mut usize,
     plateau_count: &'a mut usize,
-    prev_reached_count: &'a mut usize,
+    /// Captures the saturation outcome (signal source + coverage numbers).
+    saturation: &'a mut Option<super::report::SaturationReport>,
     already_converged: bool,
 }
 
@@ -101,10 +107,10 @@ impl RunState {
             #[cfg(feature = "exploration")]
             per_seed_timelines: Vec::new(),
             reached_sometimes: std::collections::HashSet::new(),
-            prev_coverage_bits: 0,
+            prev_signal: 0,
             converged: false,
             plateau_count: 0,
-            prev_reached_count: 0,
+            saturation: None,
         }
     }
 }
@@ -130,12 +136,15 @@ struct RunState {
     bug_recipes: Vec<super::report::BugRecipe>,
     #[cfg(feature = "exploration")]
     per_seed_timelines: Vec<u64>,
-    // Convergence + plateau tracking.
+    // Saturation tracking (`UntilCoverageStable`).
     reached_sometimes: std::collections::HashSet<String>,
-    prev_coverage_bits: u32,
+    /// Previous progress-signal value (code edges, or reached-assertion count
+    /// in the no-sancov fallback). Both signals are monotonic non-decreasing.
+    prev_signal: usize,
     converged: bool,
     plateau_count: usize,
-    prev_reached_count: usize,
+    /// Saturation outcome captured during the last scan, surfaced in the report.
+    saturation: Option<super::report::SaturationReport>,
 }
 
 /// Resolved workload entries for a single iteration.
@@ -158,23 +167,18 @@ pub enum IterationControl {
     FixedCount(usize),
     /// Run for a specific duration of wall-clock time
     TimeLimit(Duration),
-    /// Stop when all `assert_sometimes!` have been reached AND a new seed
-    /// produces no new code coverage. Requires exploration to be enabled.
-    /// The `max_iterations` field is a safety cap.
-    UntilConverged {
-        /// Maximum number of seeds before stopping regardless.
-        max_iterations: usize,
-    },
-    /// Stop after `plateau_seeds` consecutive seeds have added no new
-    /// `assert_sometimes!` / `assert_reachable!` coverage. Works with or
-    /// without [`SimulationBuilder::enable_exploration`]: the underlying
-    /// assertion table is initialised unconditionally.
-    CoveragePlateau {
+    /// Stop when the system is saturated: every observed
+    /// `assert_sometimes!` / `assert_reachable!` has fired **and** code
+    /// coverage has not grown for `plateau_seeds` consecutive seeds.
+    ///
+    /// Uses real LLVM sancov code coverage when the binary is instrumented
+    /// (i.e. built via `cargo xtask sim run`); otherwise falls back to the
+    /// count of distinct reached sometimes/reachable assertion slots. Works
+    /// with or without [`SimulationBuilder::enable_exploration`]; no fork
+    /// occurs unless exploration is explicitly enabled.
+    UntilCoverageStable {
         /// Number of consecutive seeds without coverage growth required to stop.
         plateau_seeds: usize,
-        /// If true, additionally require every observed sometimes/reachable
-        /// assertion to have fired at least once before stopping.
-        require_all_sometimes: bool,
         /// Maximum number of seeds before stopping regardless (safety cap).
         max_iterations: usize,
     },
@@ -417,7 +421,10 @@ impl SimulationBuilder {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            iteration_control: IterationControl::FixedCount(1),
+            iteration_control: IterationControl::UntilCoverageStable {
+                plateau_seeds: 10,
+                max_iterations: 1000,
+            },
             entries: Vec::new(),
             process_entry: None,
             attrition: None,
@@ -687,47 +694,20 @@ impl SimulationBuilder {
         self
     }
 
-    /// Run until exploration has converged: all `assert_sometimes!` assertions
-    /// have been reached and no new coverage was found on the last seed.
+    /// Run until the system is saturated: every observed
+    /// `assert_sometimes!` / `assert_reachable!` assertion has fired **and**
+    /// code coverage has not grown for `plateau_seeds` consecutive seeds
+    /// (capped at `max_iterations`).
     ///
-    /// Requires `.enable_exploration()` to be configured (and the `exploration`
-    /// feature). `max_iterations` is a safety cap to prevent infinite loops.
-    #[cfg(feature = "exploration")]
+    /// Uses real LLVM sancov code coverage when the binary is instrumented
+    /// (built via `cargo xtask sim run`); otherwise falls back to assertion-slot
+    /// coverage. Works with or without [`SimulationBuilder::enable_exploration`];
+    /// no fork occurs unless exploration is explicitly enabled.
+    /// e.g. `until_coverage_stable(10, 5000)`.
     #[must_use]
-    pub fn until_converged(mut self, max_iterations: usize) -> Self {
-        self.iteration_control = IterationControl::UntilConverged { max_iterations };
-        self
-    }
-
-    /// Run until `assert_sometimes!` / `assert_reachable!` coverage has not
-    /// grown for `plateau_seeds` consecutive seeds.
-    ///
-    /// Works with or without [`SimulationBuilder::enable_exploration`].
-    /// `max_iterations` is a safety cap to prevent infinite loops when the
-    /// plateau is never reached.
-    #[must_use]
-    pub fn until_coverage_plateau(mut self, plateau_seeds: usize, max_iterations: usize) -> Self {
-        self.iteration_control = IterationControl::CoveragePlateau {
+    pub fn until_coverage_stable(mut self, plateau_seeds: usize, max_iterations: usize) -> Self {
+        self.iteration_control = IterationControl::UntilCoverageStable {
             plateau_seeds,
-            require_all_sometimes: false,
-            max_iterations,
-        };
-        self
-    }
-
-    /// Like [`Self::until_coverage_plateau`] but also lets the caller require
-    /// every observed sometimes/reachable assertion to have fired before the
-    /// plateau is allowed to terminate the run.
-    #[must_use]
-    pub fn until_coverage_plateau_with(
-        mut self,
-        plateau_seeds: usize,
-        require_all_sometimes: bool,
-        max_iterations: usize,
-    ) -> Self {
-        self.iteration_control = IterationControl::CoveragePlateau {
-            plateau_seeds,
-            require_all_sometimes,
             max_iterations,
         };
         self
@@ -989,90 +969,91 @@ impl SimulationBuilder {
             assertion_details: Vec::new(),
             bucket_summaries: Vec::new(),
             convergence_timeout: false,
+            saturation: None,
         })
     }
 
-    /// Check whether the user's convergence / plateau condition has been
+    /// Check whether the `UntilCoverageStable` saturation condition has been
     /// met this iteration. Returns the new `converged` flag.
+    ///
+    /// Saturation = every observed sometimes/reachable assertion has fired AND
+    /// the progress signal (real code coverage when sancov is available, else
+    /// the reached-assertion count) has not grown for `plateau_seeds`
+    /// consecutive seeds. Both signals are monotonic non-decreasing, so
+    /// `current == prev` marks a quiet seed.
     fn check_convergence_or_plateau(state: ConvergenceState<'_>) -> bool {
         let ConvergenceState {
             iteration_control,
             iteration_count,
             reached_sometimes,
             all_sometimes_count,
-            prev_coverage_bits,
+            exploration_active,
+            prev_signal,
             plateau_count,
-            prev_reached_count,
+            saturation,
             already_converged,
         } = state;
         if already_converged {
             return true;
         }
-        match iteration_control {
-            IterationControl::UntilConverged { .. } => {
-                if iteration_count < 2 {
-                    return false;
-                }
-                let all_reached =
-                    all_sometimes_count > 0 && reached_sometimes.len() >= all_sometimes_count;
-                let current_bits = crate::chaos::exploration_glue::explored_coverage_bits();
-                let no_new_coverage = current_bits == *prev_coverage_bits;
-                tracing::warn!(
-                    "convergence: seed={} reached={}/{} coverage={}->{} delta={}",
-                    iteration_count,
-                    reached_sometimes.len(),
-                    all_sometimes_count,
-                    *prev_coverage_bits,
-                    current_bits,
-                    current_bits.saturating_sub(*prev_coverage_bits),
-                );
-                if all_reached && no_new_coverage {
-                    tracing::info!(
-                        "Converged after {} seeds: all {} sometimes reached, no new coverage",
-                        iteration_count,
-                        all_sometimes_count
-                    );
-                    return true;
-                }
-                false
-            }
-            IterationControl::CoveragePlateau {
-                plateau_seeds,
-                require_all_sometimes,
-                ..
-            } => {
-                let current_count = reached_sometimes.len();
-                if iteration_count == 1 {
-                    *prev_reached_count = current_count;
-                } else if current_count == *prev_reached_count {
-                    *plateau_count += 1;
-                } else {
-                    *plateau_count = 0;
-                    *prev_reached_count = current_count;
-                }
-                let all_reached = !*require_all_sometimes
-                    || (all_sometimes_count > 0 && reached_sometimes.len() >= all_sometimes_count);
-                tracing::warn!(
-                    "plateau: seed={} reached={}/{} consecutive_no_growth={}/{}",
-                    iteration_count,
-                    current_count,
-                    all_sometimes_count,
-                    *plateau_count,
-                    plateau_seeds,
-                );
-                if *plateau_count >= *plateau_seeds && all_reached {
-                    tracing::info!(
-                        "Coverage plateau after {} seeds: {} consecutive without growth, {} sometimes reached",
-                        iteration_count,
-                        *plateau_count,
-                        current_count
-                    );
-                    return true;
-                }
-                false
-            }
-            _ => false,
+        let IterationControl::UntilCoverageStable { plateau_seeds, .. } = iteration_control else {
+            return false;
+        };
+
+        // Pick the progress signal: real code coverage when instrumented, else
+        // the count of distinct reached sometimes/reachable slots.
+        let edges = crate::chaos::exploration_glue::code_coverage_edges(exploration_active);
+        let (signal, current) = match edges {
+            Some(n) => (super::report::SaturationSignal::CodeCoverage, n),
+            None => (
+                super::report::SaturationSignal::AssertionCoverage,
+                reached_sometimes.len(),
+            ),
+        };
+
+        if iteration_count == 1 {
+            *prev_signal = current;
+        } else if current == *prev_signal {
+            *plateau_count += 1;
+        } else {
+            *plateau_count = 0;
+            *prev_signal = current;
         }
+
+        let all_reached = all_sometimes_count > 0 && reached_sometimes.len() >= all_sometimes_count;
+
+        let edges_total = crate::chaos::exploration_glue::code_coverage_total().unwrap_or_default();
+        *saturation = Some(super::report::SaturationReport {
+            signal,
+            edges_covered: edges.unwrap_or_default(),
+            edges_total,
+            sometimes_hit: reached_sometimes.len(),
+            sometimes_total: all_sometimes_count,
+            plateau_seeds: *plateau_seeds,
+        });
+
+        tracing::warn!(
+            "saturation: seed={} sometimes={}/{} signal={:?}={} quiet_seeds={}/{}",
+            iteration_count,
+            reached_sometimes.len(),
+            all_sometimes_count,
+            signal,
+            current,
+            *plateau_count,
+            plateau_seeds,
+        );
+        if *plateau_count >= *plateau_seeds && all_reached {
+            tracing::info!(
+                "Saturated after {} seeds: all {} sometimes reached, {:?} stable ({}) for {} seeds",
+                iteration_count,
+                all_sometimes_count,
+                signal,
+                current,
+                *plateau_count,
+            );
+            return true;
+        }
+        false
     }
 
     /// Emit a `warn!` when an iteration exceeded the configured threshold.
@@ -1327,6 +1308,7 @@ impl SimulationBuilder {
             assertion_details: Vec::new(),
             bucket_summaries: Vec::new(),
             convergence_timeout: false,
+            saturation: None,
         }
     }
 
@@ -1355,14 +1337,6 @@ impl SimulationBuilder {
 
         Self::init_assertions_and_exploration(self.exploration_config.as_ref());
 
-        assert!(
-            !matches!(
-                self.iteration_control,
-                IterationControl::UntilConverged { .. }
-            ) || self.exploration_config.is_some(),
-            "IterationControl::UntilConverged requires enable_exploration() to be configured"
-        );
-
         let mut state = RunState::new(&self);
 
         while state.iteration_manager.should_continue() {
@@ -1381,6 +1355,7 @@ impl SimulationBuilder {
             &self.iteration_control,
             &FinalReportInputs {
                 converged: state.converged,
+                saturation: state.saturation,
                 #[cfg(feature = "exploration")]
                 total_exploration_timelines: state.total_exploration_timelines,
                 #[cfg(feature = "exploration")]
@@ -1405,7 +1380,7 @@ impl SimulationBuilder {
         let seed = state.iteration_manager.next_iteration();
         let iteration_count = state.iteration_manager.current_iteration();
 
-        self.prepare_iteration(state, obs_handle, seed, iteration_count);
+        self.prepare_iteration(obs_handle, seed, iteration_count);
 
         let (orchestration_result, start_time) =
             self.run_orchestrator_for_iteration(state, obs_handle, seed, iteration_count);
@@ -1425,10 +1400,9 @@ impl SimulationBuilder {
     }
 
     /// Run all per-iteration setup steps before the orchestrator starts:
-    /// prepare-next-seed, user hooks, reset state, snapshot coverage.
+    /// prepare-next-seed, user hooks, reset state.
     fn prepare_iteration(
         &mut self,
-        state: &mut RunState,
         obs_handle: &SimulationLayerHandle,
         seed: u64,
         iteration_count: usize,
@@ -1449,13 +1423,6 @@ impl SimulationBuilder {
         }
 
         Self::reset_per_iteration_state(seed, self.swarm_operations, obs_handle);
-
-        if matches!(
-            self.iteration_control,
-            IterationControl::UntilConverged { .. }
-        ) {
-            state.prev_coverage_bits = crate::chaos::exploration_glue::explored_coverage_bits();
-        }
     }
 
     /// Resolve workload entries, build the per-iteration sim/fault-injectors,
@@ -1598,7 +1565,7 @@ impl SimulationBuilder {
 
         let needs_assertion_scan = matches!(
             self.iteration_control,
-            IterationControl::UntilConverged { .. } | IterationControl::CoveragePlateau { .. }
+            IterationControl::UntilCoverageStable { .. }
         );
         if needs_assertion_scan {
             let all_sometimes_count = Self::scan_assertion_slots(&mut state.reached_sometimes);
@@ -1607,9 +1574,10 @@ impl SimulationBuilder {
                 iteration_count,
                 reached_sometimes: &state.reached_sometimes,
                 all_sometimes_count,
-                prev_coverage_bits: &mut state.prev_coverage_bits,
+                exploration_active: self.exploration_config.is_some(),
+                prev_signal: &mut state.prev_signal,
                 plateau_count: &mut state.plateau_count,
-                prev_reached_count: &mut state.prev_reached_count,
+                saturation: &mut state.saturation,
                 already_converged: state.converged,
             });
         }
@@ -1681,10 +1649,10 @@ impl SimulationBuilder {
         let bucket_summaries = build_bucket_summaries(&raw_each_buckets);
         let iteration_count = iteration_manager.current_iteration();
 
-        // Detect convergence timeout.
+        // Detect saturation timeout: the cap was hit without saturating.
         let convergence_timeout = matches!(
             iteration_control,
-            IterationControl::UntilConverged { .. } | IterationControl::CoveragePlateau { .. }
+            IterationControl::UntilCoverageStable { .. }
         ) && !converged;
 
         crate::chaos::buggify_reset();
@@ -1699,6 +1667,7 @@ impl SimulationBuilder {
             assertion_details,
             bucket_summaries,
             convergence_timeout,
+            saturation: inputs.saturation.clone(),
         })
     }
 }

--- a/moonpool-sim/src/runner/display.rs
+++ b/moonpool-sim/src/runner/display.rs
@@ -8,8 +8,8 @@ use std::io::{IsTerminal, Write};
 use moonpool_assertions::AssertKind;
 
 use super::report::{
-    AssertionDetail, AssertionStatus, BucketSiteSummary, ExplorationReport, SimulationReport,
-    format_recipe,
+    AssertionDetail, AssertionStatus, BucketSiteSummary, ExplorationReport, SaturationSignal,
+    SimulationReport, format_recipe,
 };
 
 // ---------------------------------------------------------------------------
@@ -327,19 +327,46 @@ fn write_report(w: &mut impl Write, report: &SimulationReport, color: bool) {
         write_buckets(w, &report.bucket_summaries, color);
     }
 
-    // === Convergence Timeout ===
-    if report.convergence_timeout {
-        section_header(w, "Convergence FAILED", color, ansi::BOLD_RED);
-        if color {
+    // === Saturation (UntilCoverageStable) ===
+    if let Some(sat) = &report.saturation {
+        let (title, style) = if report.convergence_timeout {
+            ("Saturation FAILED", ansi::BOLD_RED)
+        } else {
+            ("Saturated", ansi::BOLD)
+        };
+        section_header(w, title, color, style);
+        match sat.signal {
+            SaturationSignal::CodeCoverage => {
+                let _ = writeln!(
+                    w,
+                    "  {} / {} sometimes hit · code coverage stable at {} / {} edges for {} seeds",
+                    sat.sometimes_hit,
+                    sat.sometimes_total,
+                    fmt_num(u64::try_from(sat.edges_covered).unwrap_or(u64::MAX)),
+                    fmt_num(u64::try_from(sat.edges_total).unwrap_or(u64::MAX)),
+                    sat.plateau_seeds,
+                );
+            }
+            SaturationSignal::AssertionCoverage => {
+                let _ = writeln!(
+                    w,
+                    "  {} / {} sometimes hit · assertion coverage stable for {} seeds (no sancov — run via 'cargo xtask sim run' for code-coverage-driven stop)",
+                    sat.sometimes_hit, sat.sometimes_total, sat.plateau_seeds,
+                );
+            }
+        }
+        if report.convergence_timeout {
             let _ = writeln!(
                 w,
-                "  {}UntilConverged hit iteration cap without converging.{}",
-                ansi::BOLD_RED,
-                ansi::RESET,
+                "  UntilCoverageStable hit the iteration cap without saturating.",
             );
-        } else {
-            let _ = writeln!(w, "  UntilConverged hit iteration cap without converging.");
         }
+    } else if report.convergence_timeout {
+        section_header(w, "Saturation FAILED", color, ansi::BOLD_RED);
+        let _ = writeln!(
+            w,
+            "  UntilCoverageStable hit the iteration cap without saturating.",
+        );
     }
 
     // === Per-Seed Metrics ===

--- a/moonpool-sim/src/runner/orchestrator.rs
+++ b/moonpool-sim/src/runner/orchestrator.rs
@@ -1905,10 +1905,7 @@ impl IterationManager {
     pub(crate) fn should_continue(&self) -> bool {
         match &self.control {
             super::builder::IterationControl::FixedCount(count)
-            | super::builder::IterationControl::UntilConverged {
-                max_iterations: count,
-            }
-            | super::builder::IterationControl::CoveragePlateau {
+            | super::builder::IterationControl::UntilCoverageStable {
                 max_iterations: count,
                 ..
             } => self.iteration_count < *count,
@@ -1943,11 +1940,9 @@ impl IterationManager {
             match &self.control {
                 super::builder::IterationControl::FixedCount(count) => *count,
                 super::builder::IterationControl::TimeLimit(_) => 0,
-                super::builder::IterationControl::UntilConverged { max_iterations } => {
-                    *max_iterations
-                }
-                super::builder::IterationControl::CoveragePlateau { max_iterations, .. } =>
-                    *max_iterations,
+                super::builder::IterationControl::UntilCoverageStable {
+                    max_iterations, ..
+                } => *max_iterations,
             }
         );
 
@@ -1963,10 +1958,7 @@ impl IterationManager {
     pub(crate) fn max_iterations(&self) -> Option<usize> {
         match &self.control {
             super::builder::IterationControl::FixedCount(count)
-            | super::builder::IterationControl::UntilConverged {
-                max_iterations: count,
-            }
-            | super::builder::IterationControl::CoveragePlateau {
+            | super::builder::IterationControl::UntilCoverageStable {
                 max_iterations: count,
                 ..
             } => Some(*count),
@@ -2073,6 +2065,7 @@ impl MetricsCollector {
             assertion_details,
             bucket_summaries,
             convergence_timeout,
+            saturation,
         } = inputs;
         super::report::SimulationReport {
             iterations: iteration_count,
@@ -2089,6 +2082,7 @@ impl MetricsCollector {
             assertion_details,
             bucket_summaries,
             convergence_timeout,
+            saturation,
         }
     }
 }
@@ -2114,4 +2108,6 @@ pub(crate) struct GenerateReportInputs {
     pub(crate) bucket_summaries: Vec<super::report::BucketSiteSummary>,
     /// Whether the simulation stopped due to a convergence timeout.
     pub(crate) convergence_timeout: bool,
+    /// Saturation outcome for an `UntilCoverageStable` run.
+    pub(crate) saturation: Option<super::report::SaturationReport>,
 }

--- a/moonpool-sim/src/runner/report.rs
+++ b/moonpool-sim/src/runner/report.rs
@@ -81,6 +81,39 @@ pub struct ExplorationReport {
     pub per_seed_timelines: Vec<u64>,
 }
 
+/// Which progress signal an [`UntilCoverageStable`] run plateaued on.
+///
+/// [`UntilCoverageStable`]: crate::IterationControl::UntilCoverageStable
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SaturationSignal {
+    /// Real LLVM sancov edge coverage (binary built via `cargo xtask sim run`).
+    CodeCoverage,
+    /// Count of distinct reached sometimes/reachable assertion slots
+    /// (fallback when the binary is not sancov-instrumented).
+    AssertionCoverage,
+}
+
+/// Outcome of an [`UntilCoverageStable`] run: which signal it plateaued on and
+/// the final coverage numbers, so the report can name the stop reason
+/// explicitly.
+///
+/// [`UntilCoverageStable`]: crate::IterationControl::UntilCoverageStable
+#[derive(Debug, Clone)]
+pub struct SaturationReport {
+    /// The progress signal counted toward the plateau.
+    pub signal: SaturationSignal,
+    /// Code edges covered (meaningful only when `signal == CodeCoverage`).
+    pub edges_covered: usize,
+    /// Total instrumented code edges (meaningful only when `signal == CodeCoverage`).
+    pub edges_total: usize,
+    /// Number of observed sometimes/reachable assertions that fired.
+    pub sometimes_hit: usize,
+    /// Total number of observed sometimes/reachable assertions.
+    pub sometimes_total: usize,
+    /// Consecutive quiet seeds required to declare saturation.
+    pub plateau_seeds: usize,
+}
+
 /// Pass/fail/miss status for an assertion in the report.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum AssertionStatus {
@@ -151,8 +184,11 @@ pub struct SimulationReport {
     pub assertion_details: Vec<AssertionDetail>,
     /// Per-site summaries of `assert_sometimes_each!` buckets.
     pub bucket_summaries: Vec<BucketSiteSummary>,
-    /// True when `UntilConverged` hit its iteration cap without converging.
+    /// True when `UntilCoverageStable` hit its iteration cap without saturating.
     pub convergence_timeout: bool,
+    /// Saturation outcome for an `UntilCoverageStable` run (signal + coverage
+    /// numbers); `None` for other iteration-control modes.
+    pub saturation: Option<SaturationReport>,
 }
 
 impl SimulationReport {
@@ -334,6 +370,43 @@ fn fmt_timing(f: &mut fmt::Formatter<'_>, report: &SimulationReport) -> fmt::Res
         "  Avg Events:        {}",
         fmt_num(f64_to_u64_saturating(report.average_events_processed()))
     )
+}
+
+/// Render the `UntilCoverageStable` saturation outcome: which signal it
+/// plateaued on, the coverage numbers, and whether the cap was hit first.
+fn fmt_saturation(f: &mut fmt::Formatter<'_>, report: &SimulationReport) -> fmt::Result {
+    let Some(sat) = &report.saturation else {
+        return Ok(());
+    };
+    writeln!(f)?;
+    let status = if report.convergence_timeout {
+        "NOT saturated"
+    } else {
+        "saturated"
+    };
+    match sat.signal {
+        SaturationSignal::CodeCoverage => writeln!(
+            f,
+            "  {status}: {}/{} sometimes hit · code coverage stable at {}/{} edges for {} seeds",
+            sat.sometimes_hit,
+            sat.sometimes_total,
+            sat.edges_covered,
+            sat.edges_total,
+            sat.plateau_seeds,
+        )?,
+        SaturationSignal::AssertionCoverage => writeln!(
+            f,
+            "  {status}: {}/{} sometimes hit · assertion coverage stable for {} seeds (no sancov — run via 'cargo xtask sim run' for code-coverage-driven stop)",
+            sat.sometimes_hit, sat.sometimes_total, sat.plateau_seeds,
+        )?,
+    }
+    if report.convergence_timeout {
+        writeln!(
+            f,
+            "  UntilCoverageStable hit the iteration cap without saturating."
+        )?;
+    }
+    Ok(())
 }
 
 fn fmt_exploration(f: &mut fmt::Formatter<'_>, exp: &ExplorationReport) -> fmt::Result {
@@ -529,11 +602,14 @@ impl fmt::Display for SimulationReport {
             }
         }
 
-        // === Convergence Timeout ===
-        if self.convergence_timeout {
+        // === Saturation (UntilCoverageStable) ===
+        fmt_saturation(f, self)?;
+        if self.saturation.is_none() && self.convergence_timeout {
             writeln!(f)?;
-            writeln!(f, "--- Convergence FAILED ---")?;
-            writeln!(f, "  UntilConverged hit iteration cap without converging.")?;
+            writeln!(
+                f,
+                "  UntilCoverageStable hit the iteration cap without saturating."
+            )?;
         }
 
         // === Per-Seed Metrics ===

--- a/moonpool-sim/tests/coverage_plateau.rs
+++ b/moonpool-sim/tests/coverage_plateau.rs
@@ -1,8 +1,10 @@
-//! Integration tests for the `IterationControl::CoveragePlateau` stop condition.
+//! Integration tests for the `IterationControl::UntilCoverageStable` stop condition.
 //!
-//! These exercise the runner's ability to terminate early when
-//! `assert_sometimes!` / `assert_reachable!` coverage stops growing,
-//! both with and without fork-based exploration enabled.
+//! These exercise the runner's ability to terminate early when every observed
+//! `assert_sometimes!` / `assert_reachable!` has fired and coverage stops
+//! growing, both with and without fork-based exploration enabled. Under
+//! `cargo nextest` the binary is not sancov-instrumented, so these run on the
+//! assertion-coverage fallback signal.
 
 use async_trait::async_trait;
 #[cfg(feature = "exploration")]
@@ -32,7 +34,7 @@ impl Workload for ThreeAlwaysHitWorkload {
 }
 
 /// Workload whose third assertion only fires in roughly 1-in-5 seeds.
-/// `require_all_sometimes=true` should refuse to stop until it has hit.
+/// Saturation must refuse to stop until every sometimes has hit.
 struct RareGateWorkload;
 
 #[async_trait]
@@ -50,13 +52,13 @@ impl Workload for RareGateWorkload {
     }
 }
 
-/// With no exploration enabled, plateau detection should still fire because
-/// the assertion table is initialised unconditionally.
+/// With no exploration enabled, saturation should still fire because the
+/// assertion table is initialised unconditionally.
 #[test]
 fn test_plateau_no_exploration() {
     let report = run_simulation(
         SimulationBuilder::new()
-            .until_coverage_plateau(3, 100)
+            .until_coverage_stable(3, 100)
             .workload(ThreeAlwaysHitWorkload),
     );
 
@@ -91,7 +93,7 @@ fn test_plateau_with_exploration() {
                 adaptive: None,
                 parallelism: None,
             })
-            .until_coverage_plateau(3, 100)
+            .until_coverage_stable(3, 100)
             .workload(ThreeAlwaysHitWorkload),
     );
 
@@ -107,13 +109,13 @@ fn test_plateau_with_exploration() {
     assert_eq!(report.failed_runs, 0);
 }
 
-/// With `require_all_sometimes=true`, the runner must keep going until the
+/// All-sometimes is always required, so the runner must keep going until the
 /// rare gate has fired even if the other two assertions plateaued early.
 #[test]
 fn test_plateau_requires_all_sometimes() {
     let report = run_simulation(
         SimulationBuilder::new()
-            .until_coverage_plateau_with(2, true, 200)
+            .until_coverage_stable(2, 200)
             .workload(RareGateWorkload),
     );
 

--- a/moonpool-transport-sim/src/bin/sim/transport.rs
+++ b/moonpool-transport-sim/src/bin/sim/transport.rs
@@ -28,7 +28,9 @@ fn main() {
         // defeating passive/active suppression.
         .enable_chaos([Chaos::Network(ChaosMode::Swarm)])
         .swarm_operations()
-        .set_iterations(20)
+        // No fixed seed count: run adaptively until every sometimes/reachable
+        // has fired and code coverage plateaus (real sancov edges under
+        // `cargo xtask sim run`; assertion-coverage fallback otherwise).
         .seed_warning_timeout(Duration::from_secs(15))
         .run();
 


### PR DESCRIPTION
Closes #135.

## What

Replaces the two adaptive stop conditions (`IterationControl::UntilConverged` and `CoveragePlateau`) with a single `UntilCoverageStable { plateau_seeds, max_iterations }`, now the `SimulationBuilder::new()` default (was `FixedCount(1)`).

It stops when **every observed `assert_sometimes!`/`assert_reachable!` has fired AND code coverage has not grown for `plateau_seeds` consecutive seeds** — stop on a signal, not a hand-picked count.

## How

- **Real code coverage when available**: new fork-free `sancov_edges_covered_live()` reads the LLVM sancov BSS counters in-process (no fork, no `SANCOV_HISTORY`). Under `cargo xtask sim run` the binaries are instrumented, so the plateau signal is **real edge coverage**; under plain `cargo nextest run` it falls back to assertion-slot coverage. The report **names which signal it used**, so the fallback is never silent.
- **Fork is now orthogonal**: `enable_exploration()` stays a separate flag, OFF by default. `UntilCoverageStable` works with or without it; no fork unless explicitly enabled. The old `until_converged` precondition/coupling is removed.
- **API consolidation**: `until_converged` / `until_coverage_plateau` / `until_coverage_plateau_with` → single `until_coverage_stable(plateau_seeds, max_iterations)`. "All sometimes hit" is now always required (no `require_all_sometimes` flag).

### Subtle bug caught during implementation

A first cut counted raw non-zero 8-bit counters. Those counters **wrap at 256** and aren't reset between seeds in the sequential path, so the count **oscillated** (±20 around 750) and never plateaued — the sim ran the full cap. Fixed by folding the BSS into a persistent "seen" union (`SANCOV_SEEN`), making the signal monotonic and wraparound-robust.

## Acceptance criteria

- [x] `cargo xtask sim run transport` stops on real code-coverage plateau + all-sometimes, no fixed count; report names the signal and edge counts — **saturates at seed 41**: `Saturated · 10/10 sometimes hit · code coverage stable at 753 / 2,677 edges for 10 seeds`.
- [x] Default `SimulationBuilder::new()` runs adaptively; tests that set iterations explicitly are unaffected.
- [x] Under `cargo nextest run` (no instrumentation) it falls back to the assertion signal and the report says so (`coverage_plateau` tests exercise this path).
- [x] `enable_exploration()` stays OFF by default; works with and without it; no fork unless enabled.
- [x] `UntilConverged`, `CoveragePlateau`, `until_converged`, `until_coverage_plateau*` removed.
- [x] `fmt`, `clippy` (pedantic, `-D warnings`), `nextest` (587 pass), wasm + `--no-default-features` portability checks, and `mdbook build` all pass.

## Docs

CLAUDE.md, `moonpool-sim/README.md`, `chaos/mod.rs`, `moonpool-assertions`, and the book stop-condition chapters updated; the non-existent `UntilAllSometimesReached` references are corrected to the real `UntilCoverageStable` default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
