### PR TITLE
feat(moonpool-sim): dynamic disk stall/throttle episodes (#126)

### DIFF
--- a/book/src/appendix/04-fault-reference.md
+++ b/book/src/appendix/04-fault-reference.md
@@ -98,6 +98,16 @@ Storage also simulates realistic performance characteristics independent of faul
 | Write latency | `write_latency` | `Uniform` 100-500us | Per-write operation delay (a `LatencyDistribution`) |
 | Sync latency | `sync_latency` | `Uniform` 1-5ms | Per-sync/flush delay (a `LatencyDistribution`) |
 
+### Dynamic Disk Degradation Episodes
+
+Episodic degradation layered on top of steady-state timing (FoundationDB's `DiskFailureInjector`). Off by default and scoped per file. While disabled, the episode state machine never draws from the RNG stream, so steady-state runs stay deterministic.
+
+| Episode | Config Field | Default | While active |
+|---------|-------------|---------|--------------|
+| Stall | `disk_stall_probability` / `disk_stall_duration` | 0%, 0ms | Disk frozen until expiry; I/O waits out the window |
+| Throttle | `disk_throttle_probability` / `disk_throttle_duration` | 0%, 0ms | Effective IOPS/bandwidth divided by the multipliers |
+| Throttle factor | `disk_throttle_iops_multiplier` / `disk_throttle_bandwidth_multiplier` | 1.0 | Divisor applied to IOPS / bandwidth during a throttle |
+
 ## Process Lifecycle Faults
 
 Configured via [`Attrition`](../part3-building/attrition.md) (built-in) or custom [`FaultInjector`](../part3-building/chaos.md) implementations.

--- a/book/src/part3-building/11-storage-faults.md
+++ b/book/src/part3-building/11-storage-faults.md
@@ -70,6 +70,30 @@ Beyond faults, moonpool simulates realistic storage performance characteristics:
 
 These parameters ensure that storage-heavy code paths experience realistic timing, which is important for testing timeout logic and concurrent I/O patterns.
 
+## Dynamic Disk Degradation Episodes
+
+Steady-state timing is a lie of a different kind. Real disks do not degrade at a fixed rate. They degrade **episodically**: a garbage-collection pause freezes I/O for 100-500ms, a thermal event throttles throughput for seconds, firmware stalls under load. These episodes are what trigger the interesting failures: timeout cascades, backpressure collapse, and recovery bottlenecks that a constant 150 MB/s never produces. FoundationDB models this with its `DiskFailureInjector`, and moonpool borrows the idea.
+
+Two episode kinds sit on top of the steady-state formula, both off by default and scoped per file:
+
+| Episode | Config | While active |
+|---------|--------|--------------|
+| Stall | `disk_stall_probability` / `disk_stall_duration` | The disk is frozen until the window expires. Any I/O scheduled during the stall waits out the remaining time, then takes its normal latency. |
+| Throttle | `disk_throttle_probability` / `disk_throttle_duration` | Effective IOPS and bandwidth are divided by `disk_throttle_iops_multiplier` and `disk_throttle_bandwidth_multiplier`. |
+
+Before each read, write, or sync, the file's episode state machine runs: an expired episode clears, an active one stays, and an idle disk rolls the dice to enter a new episode. A stall makes the next handful of operations all complete at roughly the same moment the freeze lifts, which is exactly the backpressure spike that overflows queues in real systems.
+
+```rust
+// A disk that stalls on every operation for 50ms
+let stalling = StorageConfiguration {
+    disk_stall_probability: 1.0,
+    disk_stall_duration: Duration::from_millis(50),
+    ..StorageConfiguration::fast_local()
+};
+```
+
+The key property is that **a disabled disk never touches the random number stream**. When both probabilities are zero, the state machine returns before drawing any randomness, so steady-state runs stay byte-for-byte deterministic. Chaos runs enable low-rate episodes through `random_for_seed()`, swarm masking, and buggify knob spikes, the same machinery every other storage fault family uses.
+
 ## The Step Loop Pattern
 
 Storage operations in moonpool differ from network operations in one critical way: **storage operations return `Poll::Pending` and require simulation stepping**. Network operations buffer data and return `Poll::Ready` immediately. Storage operations need the simulation engine to advance time and process the I/O.

--- a/moonpool-sim/src/sim/state.rs
+++ b/moonpool-sim/src/sim/state.rs
@@ -399,6 +399,31 @@ pub struct PendingStorageOp {
     pub data: Option<Vec<u8>>,
 }
 
+/// Kind of dynamic disk-degradation episode currently affecting a file.
+///
+/// Models `FoundationDB`'s `DiskFailureInjector` (`getDiskDelay()`): real disks
+/// degrade episodically rather than at a fixed steady-state rate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiskEpisodeKind {
+    /// Disk is frozen until the episode expires; I/O waits out the remaining window.
+    Stall,
+    /// Effective IOPS/bandwidth are reduced for the duration of the episode.
+    Throttle,
+}
+
+/// Active disk-degradation episode on a file (stall or throttle), with expiry.
+///
+/// Per-file state, evaluated before each latency calculation in
+/// `schedule_{read,write,sync}`. Mirrors the existing [`ClogState`] /
+/// [`PartitionState`] expiry pattern.
+#[derive(Debug, Clone, Copy)]
+pub struct DiskDegradationState {
+    /// Which kind of degradation is active.
+    pub kind: DiskEpisodeKind,
+    /// When the episode expires (in simulation time).
+    pub expires_at: Duration,
+}
+
 /// State of an individual simulated file.
 #[derive(Debug)]
 pub struct StorageFileState {
@@ -420,6 +445,8 @@ pub struct StorageFileState {
     pub next_op_seq: u64,
     /// IP address of the process that owns this file.
     pub owner_ip: IpAddr,
+    /// Active dynamic disk-degradation episode, if any.
+    pub disk_episode: Option<DiskDegradationState>,
 }
 
 impl StorageFileState {
@@ -442,6 +469,7 @@ impl StorageFileState {
             pending_ops: BTreeMap::new(),
             next_op_seq: 0,
             owner_ip,
+            disk_episode: None,
         }
     }
 }

--- a/moonpool-sim/src/sim/storage_ops.rs
+++ b/moonpool-sim/src/sim/storage_ops.rs
@@ -9,6 +9,7 @@ use std::task::Waker;
 use std::time::Duration;
 use tracing::instrument;
 
+use crate::assert_reachable;
 use crate::storage::StorageError;
 
 use crate::chaos::fault_events::SimFaultEvent;
@@ -16,7 +17,10 @@ use crate::chaos::fault_events::SimFaultEvent;
 use super::{
     events::{Event, ScheduledEvent, StorageOperation},
     rng::{sim_random, sim_random_range},
-    state::{FileId, PendingOpType, PendingStorageOp},
+    state::{
+        DiskDegradationState, DiskEpisodeKind, FileId, PendingOpType, PendingStorageOp,
+        StorageFileState,
+    },
     world::{SimInner, SimWorld},
 };
 
@@ -42,6 +46,75 @@ fn take_pending_op(
 
     let op = file_state.pending_ops.remove(&op_seq)?;
     Some((op_seq, op))
+}
+
+/// Advance a file's disk-degradation episode state machine and return the
+/// episode (if any) active for the operation now being scheduled.
+///
+/// On each call: expire an episode whose window has elapsed, keep an episode
+/// that is still active, or — when none is active and a family is enabled —
+/// probabilistically enter a stall or throttle episode (stall takes precedence).
+///
+/// **Off-by-default guarantee:** when both probabilities are zero this returns
+/// without drawing any simulation RNG, keeping the RNG stream byte-identical to
+/// steady-state runs (so existing latency/determinism tests are unaffected).
+fn update_disk_episode(
+    file_state: &mut StorageFileState,
+    now: Duration,
+    stall_probability: f64,
+    stall_duration: Duration,
+    throttle_probability: f64,
+    throttle_duration: Duration,
+) -> Option<DiskDegradationState> {
+    // Expire an episode whose window has elapsed.
+    if let Some(episode) = file_state.disk_episode
+        && now >= episode.expires_at
+    {
+        file_state.disk_episode = None;
+    }
+
+    // An episode is still active: keep it, drawing no new randomness.
+    if let Some(episode) = file_state.disk_episode {
+        return Some(episode);
+    }
+
+    // Off by default: never perturb the RNG stream when both families are disabled.
+    if stall_probability <= 0.0 && throttle_probability <= 0.0 {
+        return None;
+    }
+
+    // Probabilistically enter a new episode using a single draw.
+    let roll = sim_random::<f64>();
+    let episode = if roll < stall_probability {
+        assert_reachable!("disk: stall episode entered");
+        Some(DiskDegradationState {
+            kind: DiskEpisodeKind::Stall,
+            expires_at: now + stall_duration,
+        })
+    } else if roll < stall_probability + throttle_probability {
+        assert_reachable!("disk: throttle episode entered");
+        Some(DiskDegradationState {
+            kind: DiskEpisodeKind::Throttle,
+            expires_at: now + throttle_duration,
+        })
+    } else {
+        None
+    };
+    file_state.disk_episode = episode;
+    episode
+}
+
+/// Read the disk-episode knobs for a file's owning process into a copyable
+/// tuple, so the borrow of `inner.storage` ends before `file_state` is
+/// re-borrowed mutably for the episode update.
+fn disk_episode_knobs(inner: &SimInner, owner_ip: IpAddr) -> (f64, Duration, f64, Duration) {
+    let config = inner.storage.config_for(owner_ip);
+    (
+        config.disk_stall_probability,
+        config.disk_stall_duration,
+        config.disk_throttle_probability,
+        config.disk_throttle_duration,
+    )
 }
 
 /// Handle storage I/O events.
@@ -523,11 +596,25 @@ impl SimWorld {
             },
         );
 
-        // Calculate latency using per-process config
+        // Advance the disk-degradation episode, then compute latency.
         let owner_ip = file_state.owner_ip;
+        let now = inner.current_time;
+        let (stall_p, stall_dur, throttle_p, throttle_dur) = disk_episode_knobs(&inner, owner_ip);
+        let episode = update_disk_episode(
+            inner
+                .storage
+                .files
+                .get_mut(&file_id)
+                .ok_or(StorageError::InvalidFileHandle { file_id })?,
+            now,
+            stall_p,
+            stall_dur,
+            throttle_p,
+            throttle_dur,
+        );
         let config = inner.storage.config_for(owner_ip);
-        let latency = Self::calculate_storage_latency(config, len, false);
-        let scheduled_time = inner.current_time + latency;
+        let latency = Self::calculate_storage_latency(config, len, false, episode, now);
+        let scheduled_time = now + latency;
         let sequence = inner.next_sequence;
         inner.next_sequence += 1;
 
@@ -591,11 +678,25 @@ impl SimWorld {
             },
         );
 
-        // Calculate latency using per-process config
+        // Advance the disk-degradation episode, then compute latency.
         let owner_ip = file_state.owner_ip;
+        let now = inner.current_time;
+        let (stall_p, stall_dur, throttle_p, throttle_dur) = disk_episode_knobs(&inner, owner_ip);
+        let episode = update_disk_episode(
+            inner
+                .storage
+                .files
+                .get_mut(&file_id)
+                .ok_or(StorageError::InvalidFileHandle { file_id })?,
+            now,
+            stall_p,
+            stall_dur,
+            throttle_p,
+            throttle_dur,
+        );
         let config = inner.storage.config_for(owner_ip);
-        let latency = Self::calculate_storage_latency(config, len, true);
-        let scheduled_time = inner.current_time + latency;
+        let latency = Self::calculate_storage_latency(config, len, true, episode, now);
+        let scheduled_time = now + latency;
         let sequence = inner.next_sequence;
         inner.next_sequence += 1;
 
@@ -653,11 +754,34 @@ impl SimWorld {
             },
         );
 
-        // Use sync latency from per-process config
+        // Advance the disk-degradation episode, then compute sync latency. Sync
+        // is affected by stalls (the disk is frozen until expiry); a throttle
+        // scales IOPS/bandwidth, which sync latency does not use.
         let owner_ip = file_state.owner_ip;
+        let now = inner.current_time;
+        let (stall_p, stall_dur, throttle_p, throttle_dur) = disk_episode_knobs(&inner, owner_ip);
+        let episode = update_disk_episode(
+            inner
+                .storage
+                .files
+                .get_mut(&file_id)
+                .ok_or(StorageError::InvalidFileHandle { file_id })?,
+            now,
+            stall_p,
+            stall_dur,
+            throttle_p,
+            throttle_dur,
+        );
         let config = inner.storage.config_for(owner_ip);
-        let latency = crate::network::sample_latency(&config.sync_latency);
-        let scheduled_time = inner.current_time + latency;
+        let mut latency = crate::network::sample_latency(&config.sync_latency);
+        if let Some(DiskDegradationState {
+            kind: DiskEpisodeKind::Stall,
+            expires_at,
+        }) = episode
+        {
+            latency += expires_at.saturating_sub(now);
+        }
+        let scheduled_time = now + latency;
         let sequence = inner.next_sequence;
         inner.next_sequence += 1;
 
@@ -855,13 +979,19 @@ impl SimWorld {
             .ok_or(StorageError::InvalidFileHandle { file_id })
     }
 
-    /// Calculate storage latency using FDB formula.
+    /// Calculate storage latency using FDB formula, adjusted for any active
+    /// disk-degradation episode.
     ///
-    /// Latency = `base_latency` + `iops_overhead` + `transfer_time`
+    /// Latency = `base_latency` + `iops_overhead` + `transfer_time`, where a
+    /// **throttle** episode divides effective IOPS/bandwidth by the configured
+    /// multipliers and a **stall** episode adds the time remaining until the
+    /// stall expires (the disk is frozen until then).
     fn calculate_storage_latency(
         config: &crate::storage::StorageConfiguration,
         size: usize,
         is_write: bool,
+        episode: Option<DiskDegradationState>,
+        now: Duration,
     ) -> Duration {
         // Sample base latency from config range
         let base_range = if is_write {
@@ -871,18 +1001,41 @@ impl SimWorld {
         };
         let base = crate::network::sample_latency(base_range);
 
-        // IOPS overhead: 1/iops seconds per operation.
+        // During a throttle episode, effective IOPS/bandwidth are divided by the
+        // configured multipliers (>= 1.0); otherwise the divisors are 1.0.
+        let (iops_divisor, bandwidth_divisor) = match episode {
+            Some(DiskDegradationState {
+                kind: DiskEpisodeKind::Throttle,
+                ..
+            }) => (
+                config.disk_throttle_iops_multiplier.max(1.0),
+                config.disk_throttle_bandwidth_multiplier.max(1.0),
+            ),
+            _ => (1.0, 1.0),
+        };
+
+        // IOPS overhead: divisor/iops seconds per operation.
         // Precision loss is acceptable: iops is typically << 2^52.
         let iops_f64 = u32::try_from(config.iops).map_or(f64::from(u32::MAX), f64::from);
-        let iops_overhead = Duration::from_secs_f64(1.0 / iops_f64);
+        let iops_overhead = Duration::from_secs_f64(iops_divisor / iops_f64);
 
-        // Transfer time: size / bandwidth seconds.
+        // Transfer time: size * divisor / bandwidth seconds.
         // Precision loss is acceptable: simulated sizes/bandwidths fit in 2^52.
         let size_f64 = u32::try_from(size).map_or(f64::from(u32::MAX), f64::from);
         let bandwidth_f64 = u32::try_from(config.bandwidth).map_or(f64::from(u32::MAX), f64::from);
-        let transfer = Duration::from_secs_f64(size_f64 / bandwidth_f64);
+        let transfer = Duration::from_secs_f64(size_f64 * bandwidth_divisor / bandwidth_f64);
 
-        base + iops_overhead + transfer
+        let steady = base + iops_overhead + transfer;
+
+        // During a stall the disk is frozen until expiry: the op waits out the
+        // remaining window, then takes its normal steady-state latency.
+        match episode {
+            Some(DiskDegradationState {
+                kind: DiskEpisodeKind::Stall,
+                expires_at,
+            }) => steady + expires_at.saturating_sub(now),
+            _ => steady,
+        }
     }
 
     /// Simulate a crash affecting storage for a specific process.

--- a/moonpool-sim/src/storage/config.rs
+++ b/moonpool-sim/src/storage/config.rs
@@ -26,6 +26,20 @@
 //! | Phantom write | `phantom_write_probability` | 0% | Write appears to succeed but doesn't persist |
 //! | Sync failure | `sync_failure_probability` | 0% | fsync fails |
 //!
+//! ## Dynamic Disk Degradation Episodes
+//!
+//! Real disks degrade *episodically* rather than at a fixed steady-state rate.
+//! These knobs are off by default (probabilities 0, no-op multipliers); when
+//! enabled they make a file enter a stall or throttle episode for a duration,
+//! surfacing timeout cascades and backpressure collapse. FDB ref:
+//! `DiskFailureInjector` / `getDiskDelay()`.
+//!
+//! | Episode | Config Field | Default | Effect while active |
+//! |---------|--------------|---------|---------------------|
+//! | Stall | `disk_stall_probability` / `disk_stall_duration` | 0% | Disk frozen until expiry; I/O waits out the window |
+//! | Throttle | `disk_throttle_probability` / `disk_throttle_duration` | 0% | Effective IOPS/bandwidth divided by the multipliers |
+//! | Throttle factor | `disk_throttle_iops_multiplier` / `disk_throttle_bandwidth_multiplier` | 1.0 | Divisor applied to IOPS / bandwidth |
+//!
 //! ## Configuration Examples
 //!
 //! ### Fast Local Testing (No Chaos)
@@ -152,6 +166,40 @@ pub struct StorageConfiguration {
     /// Simulates fsync failures which can indicate serious storage issues.
     /// Tests error handling in durability-critical code paths.
     pub sync_failure_probability: f64,
+
+    // =========================================================================
+    // Dynamic Disk Degradation Episodes
+    // =========================================================================
+    // Real disks degrade *episodically* rather than at a fixed steady-state rate:
+    // brief full stalls (GC/thermal/firmware pauses) and longer throttle periods
+    // (reduced IOPS/bandwidth). These surface timeout cascades and backpressure
+    // collapse that steady-state timing never produces. Off by default (all 0).
+    // FDB ref: `DiskFailureInjector` / `getDiskDelay()`.
+    /// Per-operation probability of entering a *stall* episode (0.0 - 1.0).
+    ///
+    /// During a stall the disk is frozen until the episode expires; any I/O
+    /// scheduled in that window waits out the remaining time before completing.
+    pub disk_stall_probability: f64,
+
+    /// How long a stall episode freezes the disk once entered.
+    pub disk_stall_duration: Duration,
+
+    /// Per-operation probability of entering a *throttle* episode (0.0 - 1.0).
+    ///
+    /// During a throttle the effective IOPS/bandwidth are divided by the
+    /// configured multipliers for the duration of the episode.
+    pub disk_throttle_probability: f64,
+
+    /// How long a throttle episode reduces throughput once entered.
+    pub disk_throttle_duration: Duration,
+
+    /// Divisor applied to effective IOPS during a throttle episode (>= 1.0).
+    ///
+    /// E.g. `10.0` makes the disk handle one tenth its normal IOPS.
+    pub disk_throttle_iops_multiplier: f64,
+
+    /// Divisor applied to effective bandwidth during a throttle episode (>= 1.0).
+    pub disk_throttle_bandwidth_multiplier: f64,
 }
 
 impl Default for StorageConfiguration {
@@ -181,6 +229,14 @@ impl Default for StorageConfiguration {
             misdirect_read_probability: 0.0,
             phantom_write_probability: 0.0,
             sync_failure_probability: 0.0,
+
+            // Dynamic disk degradation - disabled by default (no-op multipliers)
+            disk_stall_probability: 0.0,
+            disk_stall_duration: Duration::ZERO,
+            disk_throttle_probability: 0.0,
+            disk_throttle_duration: Duration::ZERO,
+            disk_throttle_iops_multiplier: 1.0,
+            disk_throttle_bandwidth_multiplier: 1.0,
         }
     }
 }
@@ -227,6 +283,15 @@ impl StorageConfiguration {
             misdirect_read_probability: f64::from(sim_random_range(0..10)) / 100_000.0,
             phantom_write_probability: f64::from(sim_random_range(0..20)) / 100_000.0,
             sync_failure_probability: f64::from(sim_random_range(0..50)) / 100_000.0,
+
+            // Low-rate disk-degradation episodes (drawn after the faults so the
+            // existing per-field RNG sub-sequence is unchanged).
+            disk_stall_probability: f64::from(sim_random_range(0..100)) / 100_000.0,
+            disk_stall_duration: Duration::from_millis(sim_random_range(50..500)),
+            disk_throttle_probability: f64::from(sim_random_range(0..100)) / 100_000.0,
+            disk_throttle_duration: Duration::from_millis(sim_random_range(500..5000)),
+            disk_throttle_iops_multiplier: f64::from(sim_random_range(2..20)),
+            disk_throttle_bandwidth_multiplier: f64::from(sim_random_range(2..20)),
         }
     }
 
@@ -248,7 +313,8 @@ impl StorageConfiguration {
     /// Disable each fault family with ~50% probability using the `CONFIG_RNG`
     /// stream (see [`swarm_for_seed`](Self::swarm_for_seed)).
     ///
-    /// Draws exactly seven `config_random_bool` values (one per family) so the
+    /// Draws exactly nine `config_random_bool` values (one per family: the seven
+    /// per-op faults plus the stall and throttle episode families) so the
     /// `CONFIG_RNG` call sequence is fixed and reproducible per seed. Performance
     /// parameters (IOPS, bandwidth, latencies) stay as sampled — only the fault
     /// families are masked.
@@ -274,6 +340,12 @@ impl StorageConfiguration {
         if !config_random_bool(0.5) {
             self.sync_failure_probability = 0.0;
         }
+        if !config_random_bool(0.5) {
+            self.disk_stall_probability = 0.0;
+        }
+        if !config_random_bool(0.5) {
+            self.disk_throttle_probability = 0.0;
+        }
     }
 
     /// Spike selected disk knob *magnitudes* under buggify (FDB's
@@ -290,6 +362,17 @@ impl StorageConfiguration {
         self.bandwidth = crate::buggify_knob!(self.bandwidth, 1_000_000..20_000_000);
         self.sync_failure_probability =
             crate::buggify_knob!(self.sync_failure_probability, 0.05..0.2);
+        self.disk_stall_probability = crate::buggify_knob!(self.disk_stall_probability, 0.1..0.5);
+        self.disk_stall_duration = crate::buggify_knob!(
+            self.disk_stall_duration,
+            Duration::from_millis(100)..Duration::from_millis(500)
+        );
+        self.disk_throttle_probability =
+            crate::buggify_knob!(self.disk_throttle_probability, 0.1..0.5);
+        self.disk_throttle_duration = crate::buggify_knob!(
+            self.disk_throttle_duration,
+            Duration::from_secs(1)..Duration::from_secs(5)
+        );
     }
 
     /// Create a configuration optimized for fast local testing.
@@ -318,6 +401,14 @@ impl StorageConfiguration {
             misdirect_read_probability: 0.0,
             phantom_write_probability: 0.0,
             sync_failure_probability: 0.0,
+
+            // Disk degradation disabled (no-op multipliers)
+            disk_stall_probability: 0.0,
+            disk_stall_duration: Duration::ZERO,
+            disk_throttle_probability: 0.0,
+            disk_throttle_duration: Duration::ZERO,
+            disk_throttle_iops_multiplier: 1.0,
+            disk_throttle_bandwidth_multiplier: 1.0,
         }
     }
 }
@@ -328,7 +419,7 @@ mod swarm_tests {
     use crate::sim::rng::{reset_sim_rng, set_config_seed, set_sim_seed};
 
     /// The on/off state of each swarmed fault family, in mask order.
-    fn enabled_families(config: &StorageConfiguration) -> [bool; 7] {
+    fn enabled_families(config: &StorageConfiguration) -> [bool; 9] {
         [
             config.read_fault_probability > 0.0,
             config.write_fault_probability > 0.0,
@@ -337,6 +428,8 @@ mod swarm_tests {
             config.misdirect_write_probability > 0.0,
             config.phantom_write_probability > 0.0,
             config.sync_failure_probability > 0.0,
+            config.disk_stall_probability > 0.0,
+            config.disk_throttle_probability > 0.0,
         ]
     }
 
@@ -401,6 +494,8 @@ mod swarm_tests {
         assert_zero(config.misdirect_write_probability);
         assert_zero(config.phantom_write_probability);
         assert_zero(config.sync_failure_probability);
+        assert_zero(config.disk_stall_probability);
+        assert_zero(config.disk_throttle_probability);
     }
 
     /// Assert an f64 is exactly `+0.0` (bit-exact, avoiding the float-cmp lint).
@@ -421,8 +516,8 @@ mod buggify_knob_tests {
 
     /// Sample the buggify-spiked knobs the way the runner does: seed both RNG
     /// streams and enable buggify before perturbing. Returns the spiked knobs
-    /// (`sync_failure_probability` as bits for exact comparison).
-    fn buggified_knobs(seed: u64) -> (u64, u64, u64) {
+    /// (f64/`Duration` knobs as bits/nanos for exact comparison).
+    fn buggified_knobs(seed: u64) -> [u64; 5] {
         reset_sim_rng();
         set_sim_seed(seed);
         set_config_seed(seed);
@@ -430,11 +525,13 @@ mod buggify_knob_tests {
         let mut config = StorageConfiguration::swarm_for_seed();
         config.apply_buggify_knobs();
         buggify_reset();
-        (
+        [
             config.iops,
             config.bandwidth,
             config.sync_failure_probability.to_bits(),
-        )
+            config.disk_stall_probability.to_bits(),
+            u64::try_from(config.disk_throttle_duration.as_nanos()).unwrap_or(u64::MAX),
+        ]
     }
 
     #[test]

--- a/moonpool-sim/tests/storage/config.rs
+++ b/moonpool-sim/tests/storage/config.rs
@@ -246,6 +246,7 @@ fn test_custom_configuration() {
         misdirect_read_probability: 0.0005,
         phantom_write_probability: 0.001,
         sync_failure_probability: 0.005,
+        ..StorageConfiguration::default()
     };
 
     // Verify all fields are set correctly
@@ -302,6 +303,7 @@ fn test_hdd_like_configuration() {
         misdirect_read_probability: 0.0,
         phantom_write_probability: 0.0,
         sync_failure_probability: 0.0,
+        ..StorageConfiguration::default()
     };
 
     assert_eq!(hdd_config.iops, 150);
@@ -328,6 +330,7 @@ fn test_nvme_like_configuration() {
         misdirect_read_probability: 0.0,
         phantom_write_probability: 0.0,
         sync_failure_probability: 0.0,
+        ..StorageConfiguration::default()
     };
 
     assert_eq!(nvme_config.iops, 500_000);

--- a/moonpool-sim/tests/storage/latency.rs
+++ b/moonpool-sim/tests/storage/latency.rs
@@ -122,6 +122,7 @@ fn test_custom_latency_ranges() {
             misdirect_read_probability: 0.0,
             phantom_write_probability: 0.0,
             sync_failure_probability: 0.0,
+            ..StorageConfiguration::default()
         };
 
         let mut sim = SimWorld::new();
@@ -170,6 +171,7 @@ fn test_latency_formula() {
             misdirect_read_probability: 0.0,
             phantom_write_probability: 0.0,
             sync_failure_probability: 0.0,
+            ..StorageConfiguration::default()
         };
 
         let mut sim = SimWorld::new();
@@ -223,6 +225,7 @@ fn test_read_latency_scales_with_size() {
             misdirect_read_probability: 0.0,
             phantom_write_probability: 0.0,
             sync_failure_probability: 0.0,
+            ..StorageConfiguration::default()
         };
 
         // First, write test data
@@ -324,6 +327,7 @@ fn test_write_latency_scales_with_size() {
             misdirect_read_probability: 0.0,
             phantom_write_probability: 0.0,
             sync_failure_probability: 0.0,
+            ..StorageConfiguration::default()
         };
 
         let sizes = [100, 1000, 5000];
@@ -360,6 +364,98 @@ fn test_write_latency_scales_with_size() {
         assert!(
             write_times[2].1 > write_times[1].1,
             "5KB write should take longer than 1KB write"
+        );
+    });
+}
+
+// =============================================================================
+// Dynamic disk stall/throttle episodes (issue #126)
+// =============================================================================
+
+/// Workload: open a file and perform `n` write+sync cycles.
+async fn write_sync_workload(
+    provider: moonpool_sim::SimStorageProvider,
+    n: usize,
+) -> std::io::Result<()> {
+    let mut file = provider
+        .open("episodes.txt", OpenOptions::create_write())
+        .await?;
+    for _ in 0..n {
+        file.write_all(b"x").await?;
+        file.sync_all().await?;
+    }
+    Ok(())
+}
+
+/// Disk stalls during an episode should freeze I/O and inflate elapsed time,
+/// surfacing the backpressure that steady-state timing never produces.
+#[test]
+fn test_disk_stall_inflates_elapsed_time() {
+    local_runtime().block_on(async {
+        // Baseline: episodes off (fast_local), the same workload is negligible.
+        let mut baseline_sim = SimWorld::new();
+        baseline_sim.set_storage_config(StorageConfiguration::fast_local());
+        let baseline = run_and_measure_time(baseline_sim, |p| write_sync_workload(p, 5)).await;
+
+        // A stall on every I/O: each op waits out a 50ms freeze window.
+        let stall_config = StorageConfiguration {
+            disk_stall_probability: 1.0,
+            disk_stall_duration: Duration::from_millis(50),
+            ..StorageConfiguration::fast_local()
+        };
+        let mut sim = SimWorld::new();
+        sim.set_storage_config(stall_config);
+        let stalled = run_and_measure_time(sim, |p| write_sync_workload(p, 5)).await;
+
+        assert!(
+            baseline < Duration::from_millis(10),
+            "fast_local baseline should be negligible, got {baseline:?}"
+        );
+        assert!(
+            stalled >= Duration::from_millis(200),
+            "disk stalls should inflate elapsed time (backpressure), got {stalled:?}"
+        );
+        assert!(
+            stalled > baseline * 50,
+            "stalled run ({stalled:?}) should dwarf baseline ({baseline:?})"
+        );
+    });
+}
+
+/// Stall timing is deterministic: the same seed replays the same episodes.
+#[test]
+fn test_disk_stall_deterministic_per_seed() {
+    local_runtime().block_on(async {
+        let make_config = || StorageConfiguration {
+            disk_stall_probability: 0.5,
+            disk_stall_duration: Duration::from_millis(30),
+            ..StorageConfiguration::fast_local()
+        };
+
+        let mut sim_a = SimWorld::new_with_seed(12_345);
+        sim_a.set_storage_config(make_config());
+        let a = run_and_measure_time(sim_a, |p| write_sync_workload(p, 8)).await;
+
+        let mut sim_b = SimWorld::new_with_seed(12_345);
+        sim_b.set_storage_config(make_config());
+        let b = run_and_measure_time(sim_b, |p| write_sync_workload(p, 8)).await;
+
+        assert_eq!(a, b, "same seed must produce identical stall timing");
+    });
+}
+
+/// With episodes disabled (the default), no stall inflation occurs and the RNG
+/// stream is untouched — the workload stays in steady-state timing.
+#[test]
+fn test_disk_episodes_off_by_default() {
+    local_runtime().block_on(async {
+        let mut sim = SimWorld::new();
+        sim.set_storage_config(StorageConfiguration::fast_local());
+        let elapsed = run_and_measure_time(sim, |p| write_sync_workload(p, 10)).await;
+
+        assert!(
+            elapsed < Duration::from_millis(10),
+            "disabled episodes should not inflate timing, got {elapsed:?}"
         );
     });
 }


### PR DESCRIPTION
Closes #126.

## What

Model **episodic disk degradation** on top of moonpool's static steady-state storage timing — the kind of degradation that surfaces timeout cascades and backpressure collapse, which constant IOPS/bandwidth never produces. FDB reference: `DiskFailureInjector` / `getDiskDelay()`.

Two episode kinds, per file, off by default:

- **Stall** — the disk is frozen until the episode expires; any I/O scheduled in that window waits out the remaining time, then takes its normal latency.
- **Throttle** — effective IOPS/bandwidth are divided by `disk_throttle_iops_multiplier` / `disk_throttle_bandwidth_multiplier` for the episode's duration.

## How

- **`state.rs`** — `DiskEpisodeKind { Stall, Throttle }` + `DiskDegradationState { kind, expires_at }`; `disk_episode: Option<…>` on `StorageFileState` (mirrors the existing `ClogState`/`PartitionState` expiry pattern).
- **`config.rs`** — six new `StorageConfiguration` knobs, wired through `Default`/`fast_local` (off), `random_for_seed` (low-rate), `apply_swarm_mask` (two new family gates), and `apply_buggify_knobs` (spikes) — the same machinery every other storage fault family uses. Determinism tests + module-doc tables extended.
- **`storage_ops.rs`** — `update_disk_episode` state machine, `calculate_storage_latency` extended for stall/throttle, the three `schedule_*` functions reordered for the borrow checker, `assert_reachable!` coverage on episode entry.
- **tests + book** — stall-backpressure / determinism / off-by-default tests; storage-faults chapter + fault-reference appendix.

## Determinism guarantee

The episode state machine **never draws from the RNG stream when both probabilities are zero**, so steady-state runs stay byte-identical. Confirmed by all 102 exact-timing storage tests passing unchanged.

## Validation

- `cargo fmt`, workspace `cargo clippy --all-targets -- -D warnings` (pedantic, no `#[allow]`)
- `cargo nextest run` — 590 passed
- `moonpool-sim --no-default-features` clippy + `wasm32-unknown-unknown` check
- `mdbook build`

Follow-up tracked in a separate issue: episodes are currently per-file; correlating them across a machine's disks (composing with topology / fault-atlas) is the natural next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)