### PR TITLE
fix(moonpool-core): gate named-task Builder behind cfg(tokio_unstable)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,9 @@ edition = "2024"
 
 [workspace.lints.rust]
 async_fn_in_trait = "allow"
+# `tokio_unstable` is set via .cargo/config.toml for named-task / tokio-console
+# support; declare it so `#[cfg(tokio_unstable)]` does not trip `unexpected_cfgs`.
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }
 
 [workspace.lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/moonpool-core/src/task.rs
+++ b/moonpool-core/src/task.rs
@@ -93,14 +93,23 @@ impl TaskProvider for TokioTaskProvider {
         F: Future<Output = ()> + Send + 'static,
     {
         let task_name = name.to_string();
+        let fut = async move {
+            tracing::trace!("Task {} starting", task_name);
+            future.await;
+            tracing::trace!("Task {} completed", task_name);
+        };
+        // `tokio::task::Builder` gives the task a name for tokio-console, but it is
+        // only available under `--cfg tokio_unstable`. Gate it so the crate still
+        // builds on stable toolchains without requiring that flag workspace-wide
+        // (which would force every downstream consumer to set it too). The task
+        // name is preserved in the trace spans above regardless of the runtime.
+        #[cfg(tokio_unstable)]
         let inner = tokio::task::Builder::new()
             .name(name)
-            .spawn(async move {
-                tracing::trace!("Task {} starting", task_name);
-                future.await;
-                tracing::trace!("Task {} completed", task_name);
-            })
+            .spawn(fut)
             .expect("Failed to spawn task");
+        #[cfg(not(tokio_unstable))]
+        let inner = tokio::spawn(fut);
         TokioJoinHandle(inner)
     }
 


### PR DESCRIPTION
## Problem

`TokioTaskProvider::spawn_task` (`moonpool-core/src/task.rs`) builds tasks with
`tokio::task::Builder::new().name(..)`, which is only available under
`--cfg tokio_unstable`. moonpool sets that flag in its own `.cargo/config.toml`,
so the requirement is invisible in-repo — but it propagates to every downstream
consumer: a crate depending on `moonpool-core` fails to compile unless it *also*
sets `--cfg tokio_unstable` workspace-wide.

(Context: evaluating `moonpool-sim` for deterministic UDP simulation in
[Sōzu](https://github.com/sozu-proxy/sozu), an AGPL reverse proxy pinned to
stable Rust — a workspace-wide unstable flag is a real adoption barrier.)

## Change

- Gate the named-task `Builder` behind `#[cfg(tokio_unstable)]`, falling back to
  `tokio::spawn` on stable. Behaviour under `tokio_unstable` is unchanged
  (named tasks for tokio-console); on stable the task name is still emitted in
  the surrounding `tracing::trace!` spans, so observability is preserved.
- Declare `unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }`
  in the workspace lints so the new `#[cfg]` does not trip the lint.

## Scope / honesty note

This is **not**, by itself, a complete "builds on stable without `tokio_unstable`"
fix. `moonpool-sim/src/runner/builder.rs::build_local_runtime_for_seed` still
uses `tokio::runtime::RngSeed` + `Builder::rng_seed()` (also `tokio_unstable`-only),
which is load-bearing for per-seed scheduler determinism and deserves a separate
design discussion. This PR removes the **cosmetic** unstable dependency so the
remaining requirement is the single, intentional, determinism-critical one.

## Validation

- `RUSTFLAGS="" cargo +1.91.1 build -p moonpool-sim` and `+1.95.0` — the
  `task::Builder` (`E0433`) error is gone; only the `RngSeed` requirement remains.
- `RUSTFLAGS="--cfg tokio_unstable" cargo +1.95.0 build -p moonpool-sim` — clean,
  no regression, no new `unexpected_cfgs` warning.
