### PR TITLE
feat!: deterministic executor and seeded select!, drop the tokio_unstable requirement

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,2 @@
-[build]
-rustflags = ["--cfg", "tokio_unstable"]
-
 [alias]
 xtask = "run --package xtask --"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -60,6 +60,12 @@ jobs:
         run: |
           nix develop --command cargo check --target wasm32-unknown-unknown -p moonpool-assertions
           nix develop --command cargo check --target wasm32-unknown-unknown -p moonpool-sim --no-default-features
+          nix develop --command cargo check --target wasm32-unknown-unknown -p moonpool-transport --no-default-features
+      - name: Build without any rustflags (no tokio_unstable required)
+        run: |
+          # Issue #151 acceptance: a consumer on stable with no .cargo/config.toml
+          # rustflags must be able to build every published crate.
+          RUSTFLAGS="" nix develop --command cargo check -p moonpool-core -p moonpool-sim -p moonpool-transport
       - name: Lean production dependency tree excludes sim/explorer
         run: |
           tree=$(nix develop --command cargo tree -p moonpool --no-default-features --features tokio,transport -e no-dev)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,9 +45,12 @@ Format: `<type>(<crate>): <description>`
 Types: `fix` (bugfix), `feat` (new feature), `build`, `chore`, `ci`, `docs`, `style`, `refactor`, `perf`, `test`
 
 ## Core Constraints
-- Single-thread execution via `tokio::runtime::Builder::new_current_thread().build()`,
-  but traits are Send-bounded so customer code can use `Arc<RwLock<…>>`, `DashMap`,
-  `Arc<AtomicBool>`, and `tokio::spawn` naturally
+- Single-thread execution via the moonpool deterministic executor
+  (`moonpool_sim::executor::Executor`, seeded-random task scheduling), but traits
+  are Send-bounded so customer code can use `Arc<RwLock<…>>`, `DashMap`, and
+  `Arc<AtomicBool>` naturally. There is NO tokio runtime inside a simulation:
+  a bare `tokio::spawn` panics at runtime — spawn via `ctx.task().spawn_task()`
+  or `moonpool_sim::executor::spawn()`
 - No `unwrap()` - use `Result<T, E>` with `?`; for `RwLock` poison, use
   `.expect("RwLock poisoned: prior task panicked")` (poisoning means a prior panic)
 - Document all public items
@@ -57,10 +60,11 @@ Types: `fix` (bugfix), `feat` (new feature), `build`, `chore`, `ci`, `docs`, `st
   use `#[async_trait]` (no `?Send`) with `Send + Sync + 'static` supertraits
 - Use traits, not concrete types
 - KISS principle
-- **No LocalSet, no `spawn_local`, no `build_local`**: the sim runtime uses
-  `new_current_thread().build()` — single OS thread, but futures must be `Send + 'static`
+- **No LocalSet, no `spawn_local`, no `build_local`**: the executor runs on a
+  single OS thread, but futures must be `Send + 'static`
 - **No direct tokio calls**: Use Provider traits
-  - Forbidden: `tokio::time::sleep()`, `tokio::time::timeout()`, `tokio::spawn()`
+  - Forbidden: `tokio::time::sleep()`, `tokio::time::timeout()`, `tokio::spawn()`,
+    `tokio::select!` (entropy branch offsets — use `moonpool_sim::select!`)
   - Required: `time.sleep()`, `time.timeout()`, `task_provider.spawn_task()`
 
 ## Crate Architecture

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,6 @@ edition = "2024"
 
 [workspace.lints.rust]
 async_fn_in_trait = "allow"
-# moonpool never requires `tokio_unstable`, but production users may opt into
-# it themselves (named tasks for tokio-console; see TokioTaskProvider). Declare
-# the cfg so `#[cfg(tokio_unstable)]` does not trip `unexpected_cfgs`.
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }
 
 [workspace.lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,9 @@ edition = "2024"
 
 [workspace.lints.rust]
 async_fn_in_trait = "allow"
-# `tokio_unstable` is set via .cargo/config.toml for named-task / tokio-console
-# support; declare it so `#[cfg(tokio_unstable)]` does not trip `unexpected_cfgs`.
+# moonpool never requires `tokio_unstable`, but production users may opt into
+# it themselves (named tasks for tokio-console; see TokioTaskProvider). Declare
+# the cfg so `#[cfg(tokio_unstable)]` does not trip `unexpected_cfgs`.
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }
 
 [workspace.lints.clippy]

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -24,6 +24,7 @@
 - [Determinism as a Foundation](./part2-foundations/01-determinism.md)
   - [The Single-Core Constraint](./part2-foundations/02-single-core.md)
   - [Seed-Driven Reproducibility](./part2-foundations/03-seeds.md)
+  - [The Deterministic Executor](./part2-foundations/11-executor.md)
 - [The Provider Pattern](./part2-foundations/04-provider-pattern.md)
   - [Quick Start: Swapping Implementations](./part2-foundations/05-providers-quickstart.md)
   - [Deep Dive: Why Providers Exist](./part2-foundations/06-providers-deepdive.md)

--- a/book/src/appendix/06-sim-compatibility.md
+++ b/book/src/appendix/06-sim-compatibility.md
@@ -19,9 +19,12 @@ The `TimeProvider` trait gives us a single seam. In simulation `sleep` advances 
 |-----------|-------------|
 | `std::thread::spawn`, raw OS threads | `task.spawn_task(name, fut)` |
 | `tokio::task::spawn_local`, `tokio::task::LocalSet` | `task.spawn_task(name, fut)` (Send-bounded) |
-| Untracked `tokio::spawn` that bypasses `TaskProvider` | `task.spawn_task(name, fut)` |
+| `tokio::spawn` | `task.spawn_task(name, fut)`, or `moonpool_sim::executor::spawn(name, fut)` in sim-only code |
+| Bare `tokio::select!` | `moonpool_sim::select!` / `moonpool::select!` (same grammar) |
 
-`tokio::spawn` directly is acceptable only when we genuinely need a `Send + 'static` driver task and we accept that it does not flow through `TaskProvider` (no naming, no fault injection seam). Default to `spawn_task` so the simulation can see the work.
+There is no tokio runtime inside a simulation: everything runs on the [moonpool deterministic executor](../part2-foundations/11-executor.md), so a direct `tokio::spawn` panics. `moonpool_sim::executor::spawn(name, fut)` is the escape hatch when we genuinely need a raw driver task, but default to `spawn_task` so the same code runs against production providers.
+
+The same goes for branch selection. Bare `tokio::select!` draws its polling offset from OS entropy off a tokio runtime, which breaks seed replay. Moonpool's `select!` keeps the exact tokio grammar but draws the offset from the seed. Write guard-style selects (work vs shutdown or timeout) as `select! { biased; ... }` with the work branch first, and leave peer races (two data sources that can be ready together) in the default form so the seed explores both orders.
 
 ## 3. Network
 
@@ -64,7 +67,7 @@ Every random decision must be seeded by the simulation. A single ungoverned `thr
 
 ## 7. Type bounds
 
-- Trait-crossing futures must be **`Send + 'static`**. The sim runtime is `new_current_thread().build()` but spawned futures are Send-bounded.
+- Trait-crossing futures must be **`Send + 'static`**. The sim runs on the single-threaded moonpool executor, but spawned futures are Send-bounded.
 - Shared mutable state: **`Arc<RwLock<…>>`**, `Arc<AtomicBool>`, `DashMap`, and similar. Not `Rc<RefCell<…>>`.
 - `Process`, `Workload`, `FaultInjector`, and `#[service]` handlers are dyn-stored. Use `#[async_trait]` with `Send + Sync + 'static` supertraits.
 - Provider traits (`TimeProvider`, `TaskProvider`, `NetworkProvider`, `RandomProvider`, `StorageProvider`) use native AFIT with `-> impl Future<…> + Send`. No `#[async_trait]`.

--- a/book/src/index.md
+++ b/book/src/index.md
@@ -31,7 +31,7 @@ A sitemap of every chapter in the Moonpool book. Each entry links to a chapter w
 ## Part II: Foundations
 
 - [Determinism as a Foundation](./part2-foundations/01-determinism.md) — Three non-determinism sources: threads, I/O, randomness; why reproducibility matters
-- [The Single-Core Constraint](./part2-foundations/02-single-core.md) — Single-threaded execution guarantees one legal ordering; tokio local runtime
+- [The Single-Core Constraint](./part2-foundations/02-single-core.md) — Single-threaded execution guarantees one legal ordering; the moonpool executor
 - [Seed-Driven Reproducibility](./part2-foundations/03-seeds.md) — One u64 seed controls entire simulation; ChaCha8Rng; cross-platform determinism
 - [The Deterministic Executor](./part2-foundations/11-executor.md) — Moonpool's own single-threaded executor; seeded-random task scheduling; no reactor needed
 - [The Provider Pattern](./part2-foundations/04-provider-pattern.md) — Five traits (Time, Network, Task, Random, Storage) abstract all I/O; swap real vs simulated

--- a/book/src/index.md
+++ b/book/src/index.md
@@ -33,6 +33,7 @@ A sitemap of every chapter in the Moonpool book. Each entry links to a chapter w
 - [Determinism as a Foundation](./part2-foundations/01-determinism.md) — Three non-determinism sources: threads, I/O, randomness; why reproducibility matters
 - [The Single-Core Constraint](./part2-foundations/02-single-core.md) — Single-threaded execution guarantees one legal ordering; tokio local runtime
 - [Seed-Driven Reproducibility](./part2-foundations/03-seeds.md) — One u64 seed controls entire simulation; ChaCha8Rng; cross-platform determinism
+- [The Deterministic Executor](./part2-foundations/11-executor.md) — Moonpool's own single-threaded executor; seeded-random task scheduling; no reactor needed
 - [The Provider Pattern](./part2-foundations/04-provider-pattern.md) — Five traits (Time, Network, Task, Random, Storage) abstract all I/O; swap real vs simulated
 - [Quick Start: Swapping Implementations](./part2-foundations/05-providers-quickstart.md) — Practical example: generic function running against TokioProviders or SimProviders
 - [Deep Dive: Why Providers Exist](./part2-foundations/06-providers-deepdive.md) — Problems with `#[cfg(test)]` and mocks; providers eliminate both

--- a/book/src/part2-foundations/02-single-core.md
+++ b/book/src/part2-foundations/02-single-core.md
@@ -12,18 +12,18 @@ With a single thread, there is exactly one legal execution order for any given s
 
 ## How We Get There
 
-Moonpool uses tokio's **current-thread runtime**:
+Moonpool runs every simulation on its own **deterministic executor**:
 
-```rust
-tokio::runtime::Builder::new_current_thread()
-    .enable_io()
-    .enable_time()
-    .build()
+```rust,ignore
+let mut executor = moonpool_sim::executor::Executor::new(seed);
+executor.block_on(async move {
+    // the entire simulation runs here
+});
 ```
 
-One OS thread drives the entire simulation. No work-stealing pool. No preemption between yield points. When a future resumes, it resumes on the same thread that suspended it, in an order our scheduler chose deterministically from the seed.
+One OS thread drives the entire simulation. No work-stealing pool. No preemption between yield points. When a future resumes, it resumes on the same thread that suspended it. And which ready task runs **next** is a seeded-random pick from the ready queue: same seed, same order, bit for bit, while a different seed explores a different task interleaving. A FIFO scheduler would run ready tasks in registration order on every seed forever, structurally hiding any race between them. [The Deterministic Executor](./11-executor.md) covers the machinery in depth.
 
-This is the **whole** mechanism. The runtime gives us determinism. Nothing fancier is needed.
+This is the **whole** mechanism. The executor gives us determinism. Nothing fancier is needed.
 
 ## Send-Bounded Traits
 
@@ -48,7 +48,7 @@ The runtime still runs on one thread. Futures and types are never actually moved
 - `Arc<RwLock<State>>` for shared state
 - `DashMap` for concurrent maps
 - `Arc<AtomicBool>` for flags
-- `tokio::spawn` to fan out work
+- Send-bounded spawning to fan out work: `task.spawn_task(...)` in the sim, plain `tokio::spawn` in production
 
 A team adopting moonpool to test an existing service should not have to rewrite their type hierarchy. If their production code uses `Arc<RwLock<…>>` (it does), moonpool wraps it without contortions. The simulation runtime drives those types on one thread, but the types themselves look exactly like the production ones.
 

--- a/book/src/part2-foundations/07-provider-traits.md
+++ b/book/src/part2-foundations/07-provider-traits.md
@@ -102,7 +102,7 @@ pub trait TaskProvider: Clone + Send + Sync + 'static {
 
 Spawned futures are **`Send + 'static`**. The runtime still pins everything to one OS thread for determinism, but the bound matches what `tokio::spawn` expects, so customer code reads exactly like normal tokio code. The `name` parameter shows up in event logs so you can trace which task generated which event.
 
-**Production**: `TokioTaskProvider` uses `tokio::task::Builder::new().name(...).spawn(...)`, which is plain `tokio::spawn` with a name attached.
+**Production**: `TokioTaskProvider` uses plain `tokio::spawn`. The name only feeds the trace spans around the task.
 
 **Simulation**: `SimTaskProvider` spawns onto the [deterministic executor](./11-executor.md), so scheduling order is a seeded-random, fully reproducible function of the iteration seed.
 

--- a/book/src/part2-foundations/07-provider-traits.md
+++ b/book/src/part2-foundations/07-provider-traits.md
@@ -4,7 +4,7 @@
 
 Moonpool abstracts every interaction between your code and the outside world into five provider traits. Each trait covers one category of I/O. Together, they form a complete boundary around your application, giving the simulator full control over every source of non-determinism.
 
-The sim runtime is single-threaded (`tokio::runtime::Builder::new_current_thread().build()`), but every provider trait is **`Send + Sync + 'static`**. One OS thread runs everything for determinism, yet the **types** are Send-bounded so customer code stays normal: `Arc<RwLock<…>>`, `DashMap`, `Arc<AtomicBool>`, and plain `tokio::spawn` all just work. The async methods use **native AFIT** (`async fn` in trait) with explicit `-> impl Future<…> + Send` desugarings to propagate the Send bound, so no `#[async_trait]` and no `?Send` anywhere in the provider layer.
+The sim runs single-threaded on the [moonpool deterministic executor](./11-executor.md), but every provider trait is **`Send + Sync + 'static`**. One OS thread runs everything for determinism, yet the **types** are Send-bounded so customer code stays normal: `Arc<RwLock<…>>`, `DashMap`, `Arc<AtomicBool>`, and Send-bounded task spawning all just work. The async methods use **native AFIT** (`async fn` in trait) with explicit `-> impl Future<…> + Send` desugarings to propagate the Send bound, so no `#[async_trait]` and no `?Send` anywhere in the provider layer.
 
 ## TimeProvider
 
@@ -104,7 +104,7 @@ Spawned futures are **`Send + 'static`**. The runtime still pins everything to o
 
 **Production**: `TokioTaskProvider` uses `tokio::task::Builder::new().name(...).spawn(...)`, which is plain `tokio::spawn` with a name attached.
 
-**Simulation**: The simulator controls task scheduling order, making it deterministic and seed-dependent.
+**Simulation**: `SimTaskProvider` spawns onto the [deterministic executor](./11-executor.md), so scheduling order is a seeded-random, fully reproducible function of the iteration seed.
 
 ## RandomProvider
 

--- a/book/src/part2-foundations/11-executor.md
+++ b/book/src/part2-foundations/11-executor.md
@@ -109,7 +109,7 @@ through `TaskProvider`) already expected from tokio:
 | dropping a `JoinHandle` | same: detaches, task keeps running |
 | task panics | caught, handle yields `Err(JoinError::Panicked)`, siblings unaffected |
 | dropping the `Runtime` | dropping the `Executor` cancels every live task |
-| `tokio::select!` | `moonpool::select!` (seeded rotation, see the select chapter) |
+| `tokio::select!` | `moonpool::select!` (tokio's own expansion, seeded start offset) |
 
 Spawned futures stay `Send + 'static`, exactly as before: execution is one
 OS thread, but the bounds let application code use `Arc<RwLock<...>>`,

--- a/book/src/part2-foundations/11-executor.md
+++ b/book/src/part2-foundations/11-executor.md
@@ -26,11 +26,11 @@ way it explores message latencies and fault timings.
 
 ## Randomized AND deterministic
 
-Those two properties sound contradictory; they are not. Deterministic means
-"same seed, same execution, bit for bit", not "one fixed schedule". The
-executor keeps its ready tasks in a `Vec` and picks the next one with a
-`swap_remove` at a seeded-random index (madsim uses the same distribution;
-FoundationDB's sim2 randomizes the same way):
+Those two properties sound contradictory, but they are not. Deterministic
+means "same seed, same execution, bit for bit", not "one fixed schedule".
+The executor keeps its ready tasks in a `Vec` and picks the next one with a
+`swap_remove` at a seeded-random index. madsim uses the same distribution,
+and FoundationDB's sim2 randomizes the same way:
 
 ```text
 seed 42:  task-3, task-0, task-2, task-1, ...
@@ -80,14 +80,21 @@ crate::executor::until_stalled().await;  // let every woken task run
 Because the driver is only re-polled after a complete drain, resuming from
 `until_stalled().await` guarantees that every task that was runnable has
 been polled to `Pending` or completion. Under tokio this guarantee was
-approximated by `yield_now` plus FIFO ordering; under randomized scheduling
+approximated by `yield_now` plus FIFO ordering. Under randomized scheduling
 "the back of the queue" does not exist, so the executor provides the
 contract directly.
 
 Inside a task, use `executor::yield_now()` instead: it reschedules the task
-at a seeded-random position. `until_stalled()` is driver-only and
-debug-asserted, a task awaiting "run until nothing is runnable" would be
-waiting for itself.
+at a seeded-random position. `until_stalled()` is driver-only and asserts
+it, in every build profile, because a task awaiting "run until nothing is
+runnable" would be waiting for itself.
+
+One consequence deserves a warning sign: a task must not busy-wait on
+progress only the driver can make. A `loop { yield_now().await }` polling
+for a flag that a simulation event sets keeps the ready queue non-empty
+forever, so the drain never finishes and `sim.step()` never runs. The
+executor kills such a loop with a poll-bound panic naming the task and the
+seed. Park on a real wake instead: a sleep, a `Notify`, a channel.
 
 ## Coming from tokio
 
@@ -100,7 +107,7 @@ through `TaskProvider`) already expected from tokio:
 | `JoinHandle::is_finished()` | same |
 | `JoinHandle::abort()` | same (await yields `Err(JoinError::Cancelled)`) |
 | dropping a `JoinHandle` | same: detaches, task keeps running |
-| task panics | caught; handle yields `Err(JoinError::Panicked)`, siblings unaffected |
+| task panics | caught, handle yields `Err(JoinError::Panicked)`, siblings unaffected |
 | dropping the `Runtime` | dropping the `Executor` cancels every live task |
 | `tokio::select!` | `moonpool::select!` (seeded rotation, see the select chapter) |
 
@@ -108,19 +115,21 @@ Spawned futures stay `Send + 'static`, exactly as before: execution is one
 OS thread, but the bounds let application code use `Arc<RwLock<...>>`,
 `DashMap`, and friends without contortion.
 
-Two behaviors are deliberately *better* than tokio's:
+Two behaviors are deliberately **better** than tokio's:
 
 - A genuine deadlock (driver not woken, nothing runnable) panics with the
   seed in the message instead of parking the thread forever.
-- In debug builds, a task that busy-yields forever trips a poll-bound panic
-  naming the task, instead of hanging the drain loop.
+- A task that stays runnable forever, whether a busy-yield loop or a select
+  over a source it synchronously re-readies (something tokio's cooperative
+  budget used to interrupt), trips a poll-bound panic naming the task and
+  the seed, in every build profile, instead of hanging the drain loop.
 
 ## Kill-on-drop
 
 Simulation iterations must be hermetic: a task leaked by seed N must never
 run during seed N+1. Dropping the per-iteration tokio runtime used to
-guarantee that; the executor replicates it with a waker registry (the same
-pattern `async-executor` uses). Every live task registers one waker;
+guarantee that, and the executor replicates it with a waker registry (the
+same pattern `async-executor` uses). Every live task registers one waker.
 `Drop` wakes them all, which schedules every parked task, then pops and
 drops `Runnable`s until the queue is empty. Dropping a `Runnable` cancels
 the task and drops its future, and any tasks that drop wakes land in the

--- a/book/src/part2-foundations/11-executor.md
+++ b/book/src/part2-foundations/11-executor.md
@@ -1,0 +1,144 @@
+# The Deterministic Executor
+
+<!-- toc -->
+
+Moonpool simulations do not run on tokio. They run on a purpose-built,
+single-threaded executor whose every scheduling decision derives from the
+iteration seed. This chapter explains why it exists, how it works, and what
+changes if you are used to tokio.
+
+## Why not tokio?
+
+Two reasons, one practical and one fundamental.
+
+The practical one: seeding tokio's runtime randomness requires the unstable
+`RngSeed` API, which forces `--cfg tokio_unstable` onto every crate in every
+consumer's workspace. For stable-pinned projects that is a hard adoption
+barrier (issue #151).
+
+The fundamental one: tokio's current-thread scheduler is a FIFO queue, and
+that is the *wrong* policy for a bug-finding simulator. When one event makes
+two tasks runnable, FIFO runs them in registration order, on every seed,
+forever. Any race between those tasks is structurally unexplorable: no
+amount of seeds will ever try the other order. A simulation executor should
+treat "which runnable task goes next" as a *decision to explore*, the same
+way it explores message latencies and fault timings.
+
+## Randomized AND deterministic
+
+Those two properties sound contradictory; they are not. Deterministic means
+"same seed, same execution, bit for bit", not "one fixed schedule". The
+executor keeps its ready tasks in a `Vec` and picks the next one with a
+`swap_remove` at a seeded-random index (madsim uses the same distribution;
+FoundationDB's sim2 randomizes the same way):
+
+```text
+seed 42:  task-3, task-0, task-2, task-1, ...
+seed 42:  task-3, task-0, task-2, task-1, ...   (always)
+seed 43:  task-1, task-3, task-0, task-2, ...
+```
+
+Each seed replays exactly. The *population* of seeds covers the ordering
+space. Ordering bugs, the kind that survive code review because both orders
+look fine locally, live exactly there.
+
+The scheduling RNG is a private ChaCha8 stream salted from the iteration
+seed. It is deliberately not the counted `SIM_RNG` stream: scheduling
+decisions never shift the fork explorer's `count@seed` replay bookkeeping.
+
+## Where is the reactor?
+
+There is none, and that is the deep reason this executor is small. A
+production runtime pairs its executor with a reactor (epoll, timers) that
+turns OS events into waker calls. In the simulation, `SimWorld`'s event
+queue plays that role: virtual time, network delivery, and storage
+completions are queue entries whose processing wakes the parked task through
+its ordinary `Waker`. The executor only answers one question: of the tasks
+that are runnable *right now*, which runs next?
+
+## The drive loop
+
+`Executor::block_on(main)` pins the orchestrator future on the stack as the
+*driver*. It never enters the ready queue and is never scheduled randomly:
+
+```text
+loop {
+    poll driver ── Ready? ─────────────► return
+    run_until_stalled()   // poll ready tasks in seeded-random order
+                          // until none is runnable
+    (driver not woken AND queue empty) ► panic: deadlock (with the seed)
+}
+```
+
+The orchestrator's step loops interleave the simulation with the task pool:
+
+```rust,ignore
+sim.step();                              // process one virtual event
+crate::executor::until_stalled().await;  // let every woken task run
+```
+
+Because the driver is only re-polled after a complete drain, resuming from
+`until_stalled().await` guarantees that every task that was runnable has
+been polled to `Pending` or completion. Under tokio this guarantee was
+approximated by `yield_now` plus FIFO ordering; under randomized scheduling
+"the back of the queue" does not exist, so the executor provides the
+contract directly.
+
+Inside a task, use `executor::yield_now()` instead: it reschedules the task
+at a seeded-random position. `until_stalled()` is driver-only and
+debug-asserted, a task awaiting "run until nothing is runnable" would be
+waiting for itself.
+
+## Coming from tokio
+
+The task API mirrors what the orchestrator (and your process/workload code,
+through `TaskProvider`) already expected from tokio:
+
+| tokio | moonpool executor |
+|---|---|
+| `tokio::spawn(fut)` | `executor::spawn("name", fut)` (named, for seed debugging) |
+| `JoinHandle::is_finished()` | same |
+| `JoinHandle::abort()` | same (await yields `Err(JoinError::Cancelled)`) |
+| dropping a `JoinHandle` | same: detaches, task keeps running |
+| task panics | caught; handle yields `Err(JoinError::Panicked)`, siblings unaffected |
+| dropping the `Runtime` | dropping the `Executor` cancels every live task |
+| `tokio::select!` | `moonpool::select!` (seeded rotation, see the select chapter) |
+
+Spawned futures stay `Send + 'static`, exactly as before: execution is one
+OS thread, but the bounds let application code use `Arc<RwLock<...>>`,
+`DashMap`, and friends without contortion.
+
+Two behaviors are deliberately *better* than tokio's:
+
+- A genuine deadlock (driver not woken, nothing runnable) panics with the
+  seed in the message instead of parking the thread forever.
+- In debug builds, a task that busy-yields forever trips a poll-bound panic
+  naming the task, instead of hanging the drain loop.
+
+## Kill-on-drop
+
+Simulation iterations must be hermetic: a task leaked by seed N must never
+run during seed N+1. Dropping the per-iteration tokio runtime used to
+guarantee that; the executor replicates it with a waker registry (the same
+pattern `async-executor` uses). Every live task registers one waker;
+`Drop` wakes them all, which schedules every parked task, then pops and
+drops `Runnable`s until the queue is empty. Dropping a `Runnable` cancels
+the task and drops its future, and any tasks that drop wakes land in the
+same queue and are consumed by the same loop.
+
+## Fork safety
+
+The multiverse explorer forks the process *while tasks are being polled*
+(assertion macros are fork points). Two rules keep that sound: everything is
+single-threaded, and the ready-queue lock is never held across a task poll,
+so a forked child never inherits a held lock.
+
+## Verifying it yourself
+
+The executor's contracts are enforced by `moonpool-sim/tests/executor.rs`
+(join/abort/detach/panic/kill-on-drop, same-seed replay, cross-seed
+diversity) and `moonpool-sim/tests/determinism.rs`, an end-to-end tripwire:
+two full `SimulationBuilder` runs of racing workloads on the same seed must
+produce byte-identical execution traces. If any component, executor,
+`select!`, providers, ever consults an unseeded randomness source, that test
+fails.

--- a/book/src/part3-building/05-running.md
+++ b/book/src/part3-building/05-running.md
@@ -16,7 +16,7 @@ cargo xtask sim run-all      # Run everything
 
 The `run` subcommand matches against binary names. `cargo xtask sim run transport` would run both `sim-transport-e2e` and `sim-transport-messaging`.
 
-Each simulation binary is a standalone Rust binary that constructs a `SimulationBuilder`, calls `.run().await`, and prints the report. A typical `main` function:
+Each simulation binary is a standalone Rust binary that constructs a `SimulationBuilder`, calls `.run()`, and prints the report. A typical `main` function:
 
 ```rust
 fn main() {
@@ -24,21 +24,12 @@ fn main() {
         .with_max_level(tracing::Level::WARN)
         .try_init();
 
-    let runtime = tokio::runtime::Builder::new_current_thread()
-        .enable_io()
-        .enable_time()
-        .build()
-        .expect("Failed to build runtime");
-
-    let report = runtime.block_on(async move {
-        SimulationBuilder::new()
-            .processes(3, || Box::new(KvServer))
-            .workload(KvWorkload::new(200, keys))
-            .set_iterations(100)
-            .enable_chaos([Chaos::Network(ChaosMode::Random)])
-            .run()
-            .await
-    });
+    let report = SimulationBuilder::new()
+        .processes(3, || Box::new(KvServer))
+        .workload(KvWorkload::new(200, keys))
+        .set_iterations(100)
+        .enable_chaos([Chaos::Network(ChaosMode::Random)])
+        .run();
 
     report.eprint();
 
@@ -48,7 +39,7 @@ fn main() {
 }
 ```
 
-Notice `new_current_thread().build()`. Determinism still demands a single OS thread, so we keep the current-thread scheduler. What changed is that every moonpool trait and future is now `Send + 'static`, which means the standard `.build()` is the correct API. Customer code can hold `Arc<RwLock<…>>`, `DashMap`, and call `tokio::spawn` naturally, while the runtime still polls everything on one thread for reproducibility.
+Notice what is missing: there is no runtime to build. `run()` drives each iteration on a fresh [moonpool deterministic executor](../part2-foundations/11-executor.md), `Executor::new(seed)` plus `executor.block_on(...)` under the hood. Determinism still demands a single OS thread, and every moonpool trait and future is still `Send + 'static`, so customer code can hold `Arc<RwLock<…>>` and `DashMap` naturally while the executor polls everything on one thread. Which ready task runs next is a seeded-random pick, so each seed also explores a different task interleaving. And because nothing here needs a tokio runtime, simulation binaries build on plain stable Rust with no special rustflags.
 
 ## Reading the SimulationReport
 

--- a/book/src/part3-building/23-pitfalls.md
+++ b/book/src/part3-building/23-pitfalls.md
@@ -45,9 +45,9 @@ Calling `tokio::time::sleep()`, `tokio::time::timeout()`, or `tokio::spawn()` by
 
 ## Wrong Runtime Flavor
 
-Moonpool runs on a **single OS thread** for determinism. Building a `new_multi_thread()` runtime or using `#[tokio::main]` (which defaults to multi-thread) introduces real parallelism and destroys reproducibility, even though traits are `Send`-bounded.
+Moonpool runs on a **single OS thread** for determinism. Wrapping a simulation in `#[tokio::main]` or building a tokio runtime around it hands scheduling to tokio: at best redundant, at worst (multi-thread) real parallelism that destroys reproducibility, even though traits are `Send`-bounded.
 
-**Fix**: Build the runtime with `tokio::runtime::Builder::new_current_thread().build()`. Do not use `LocalSet`, `spawn_local`, or `build_local()` — they are gone from the model.
+**Fix**: Drive the simulation with the moonpool executor. `SimulationBuilder::run()` does this for you, and standalone code uses `Executor::new(seed)` plus `executor.block_on(...)` (see [The Deterministic Executor](../part2-foundations/11-executor.md)). Do not use `LocalSet`, `spawn_local`, or `build_local()`: they are gone from the model.
 
 ## Using `?Send` on Dyn Traits
 

--- a/book/src/part4-integration/01-standalone-sim.md
+++ b/book/src/part4-integration/01-standalone-sim.md
@@ -36,7 +36,10 @@ impl Process for HyperServer {
     async fn run(&mut self, ctx: &SimContext) -> SimulationResult<()> {
         let listener = ctx.network().bind(ctx.my_ip()).await?;
 
-        let (stream, _addr) = tokio::select! {
+        // moonpool's select!, not tokio's: `biased;` because shutdown is a
+        // guard on the accept work, not a peer racing it.
+        let (stream, _addr) = moonpool_sim::select! {
+            biased;
             result = listener.accept() => result?,
             _ = ctx.shutdown().cancelled() => return Ok(()),
         };
@@ -60,22 +63,22 @@ The client side follows the same pattern. Connect via `ctx.network().connect()`,
 
 ## Spawning Inside a Simulation
 
-The sim runtime is **single-threaded by construction**. We build it with `tokio::runtime::Builder::new_current_thread().build()`, so every spawned task runs on the one OS thread that drives simulation events. Determinism depends on it.
+The sim is **single-threaded by construction**. Every iteration runs on the [moonpool deterministic executor](../part2-foundations/11-executor.md), so every spawned task runs on the one OS thread that drives simulation events. Determinism depends on it.
 
-What changed compared to earlier moonpool versions: the types crossing trait boundaries are now `Send + 'static`. Provider traits, `SimTcpStream`, `Process`, `Workload`, the `SimContext` you get handed, all of them. That means **`tokio::spawn` is the right tool** when you want to spawn a task from inside simulated code, and customer state can use `Arc<RwLock<…>>`, `DashMap`, `Arc<AtomicBool>` without ceremony.
+What changed compared to earlier moonpool versions: the types crossing trait boundaries are now `Send + 'static`. Provider traits, `SimTcpStream`, `Process`, `Workload`, the `SimContext` you get handed, all of them. Spawning goes through the executor, either directly with **`moonpool_sim::executor::spawn`** (named tasks, the name shows up when debugging a seed) or through the provider seam, and customer state can use `Arc<RwLock<…>>`, `DashMap`, `Arc<AtomicBool>` without ceremony.
 
 ```rust
-// Works: SimTcpStream is Send, the future is Send, tokio::spawn accepts it.
-let handle = tokio::spawn(async move {
+// Works: SimTcpStream is Send, the future is Send, the executor accepts it.
+let handle = moonpool_sim::executor::spawn("serve-one", async move {
     serve_one(stream).await
 });
 ```
 
-If you want to keep the provider seam (so the same code runs against a real tokio runtime later), reach for `TaskProvider::spawn_task` from `ctx.task()` instead. Same semantics, an injectable interface.
+If you want to keep the provider seam (so the same code runs against a real tokio runtime later), reach for `TaskProvider::spawn_task` from `ctx.task()` instead. Same semantics, an injectable interface, and inside the sim it lands on the same executor.
 
-**Do not use `tokio::task::spawn_local` or build a `LocalSet`**. The simulation runtime is `new_current_thread().build()`, not `build_local()`, so there is no `LocalSet` for `spawn_local` to attach to and the spawn would never poll. Whenever you reach for a `!Send` workaround, you have probably wandered off the supported path.
+**Do not use `tokio::task::spawn_local` or build a `LocalSet`**. There is no tokio runtime inside a simulation, so there is no `LocalSet` for `spawn_local` to attach to and the spawn would never poll. Whenever you reach for a `!Send` workaround, you have probably wandered off the supported path.
 
-The one case that still bites people: some third-party connection futures (hyper's `Connection` is the canonical example) are themselves `!Send` for reasons unrelated to moonpool. They hold internal state that isn't `Send`. You cannot `tokio::spawn` *those* either, regardless of runtime. The fix is to **drive them inline** alongside your other work:
+The one case that still bites people: some third-party connection futures (hyper's `Connection` is the canonical example) are themselves `!Send` for reasons unrelated to moonpool. They hold internal state that isn't `Send`. You cannot spawn *those* on any Send-bounded executor, moonpool's included. The fix is to **drive them inline** alongside your other work:
 
 ```rust
 let (mut sender, conn) = hyper::client::conn::http1::handshake(io).await?;
@@ -86,7 +89,8 @@ let driver = async move {
     let _ = conn.await;
 };
 
-tokio::select! {
+moonpool_sim::select! {
+    biased;
     result = send_requests(&mut sender) => result?,
     _ = driver => {}
     _ = ctx.shutdown().cancelled() => {}

--- a/book/src/part4-integration/02-mock-boundaries.md
+++ b/book/src/part4-integration/02-mock-boundaries.md
@@ -63,7 +63,7 @@ Not every dependency needs full simulation. Think of fakes on a spectrum:
 
 **BTreeMap, not HashMap**. Deterministic iteration order matters for reproducibility. A HashMap iterating in different order across runs makes your simulation non-deterministic.
 
-**Send + Sync for axum State**. Axum requires `State` to be `Send + Sync`. Reach for `Arc<RwLock<BTreeMap<...>>>`, not `Rc<RefCell<...>>`. Everything in moonpool is Send-bounded now, so `Arc<RwLock<…>>` is the natural shape and plugs straight into axum without contortions. The runtime still happens to be a single OS thread (`new_current_thread().build()`), so in practice the lock is never contended, but it's the Send bounds that make the type fit, not the thread count.
+**Send + Sync for axum State**. Axum requires `State` to be `Send + Sync`. Reach for `Arc<RwLock<BTreeMap<...>>>`, not `Rc<RefCell<...>>`. Everything in moonpool is Send-bounded now, so `Arc<RwLock<…>>` is the natural shape and plugs straight into axum without contortions. Execution still happens on a single OS thread (the moonpool deterministic executor), so in practice the lock is never contended, but it's the Send bounds that make the type fit, not the thread count.
 
 **The Oxide convention**. Oxide's [omicron](https://github.com/oxidecomputer/omicron) and [crucible](https://github.com/oxidecomputer/crucible) projects keep fakes in a `fakes/` module alongside the real implementation. The trait and the fake ship together. When you change the trait, you update the fake in the same PR. This keeps fakes from drifting.
 

--- a/book/src/part4-integration/03-wiring-a-web-service.md
+++ b/book/src/part4-integration/03-wiring-a-web-service.md
@@ -85,20 +85,21 @@ impl Process for WebProcess {
     fn name(&self) -> &str { "web" }
 
     async fn run(&mut self, ctx: &SimContext) -> SimulationResult<()> {
-        use futures::stream::{FuturesUnordered, StreamExt};
+        use futures::{FutureExt, stream::{FuturesUnordered, StreamExt}};
 
         let store = InMemoryStore::new();
         let app = build_router(store);
         let listener = ctx.network().bind(ctx.my_ip()).await?;
 
         // hyper's serve_connection future is !Send (the HTTP1 state machine
-        // holds internal Rc<…>), so it cannot be handed to tokio::spawn on
-        // the Send-bounded sim runtime. Drive multiple in-flight connections
-        // inline via FuturesUnordered instead.
+        // holds internal Rc<…>), so no Send-bounded spawn will accept it.
+        // Drive multiple in-flight connections inline via FuturesUnordered.
         let mut connections = FuturesUnordered::new();
 
         loop {
-            tokio::select! {
+            // Deliberately NOT `biased;`: accept and connection progress are
+            // peer data sources, so the seed picks which branch wins.
+            moonpool_sim::select! {
                 accept = listener.accept() => {
                     let (stream, _addr) = accept?;
 
@@ -109,14 +110,20 @@ impl Process for WebProcess {
                     // TowerToHyperService bridges axum's tower::Service to hyper's Service
                     let service = TowerToHyperService::new(app.clone());
 
-                    connections.push(async move {
-                        if let Err(e) = hyper::server::conn::http1::Builder::new()
-                            .serve_connection(io, service)
-                            .await
-                        {
-                            tracing::debug!("hyper error (expected under chaos): {e}");
+                    // .boxed(): select! duplicates this handler once per rotation,
+                    // and each copy's async block is a distinct anonymous type.
+                    // Boxing gives `connections` one named element type.
+                    connections.push(
+                        async move {
+                            if let Err(e) = hyper::server::conn::http1::Builder::new()
+                                .serve_connection(io, service)
+                                .await
+                            {
+                                tracing::debug!("hyper error (expected under chaos): {e}");
+                            }
                         }
-                    });
+                        .boxed(),
+                    );
                 }
                 Some(()) = connections.next(), if !connections.is_empty() => {}
                 _ = ctx.shutdown().cancelled() => return Ok(()),
@@ -128,7 +135,7 @@ impl Process for WebProcess {
 
 Two things to note. First, we use `hyper::server::conn::http1::serve_connection`, **not** `axum::serve()`. `axum::serve` takes `tokio::net::TcpListener` directly, so it can't accept our simulated listener. `serve_connection` takes any tokio `AsyncRead + AsyncWrite`. `SimTcpStream` implements `futures::io::AsyncRead + AsyncWrite` (the runtime-agnostic traits) and is itself `Send + Sync`, so we route it through `tokio_util::compat::Compat` via `.compat()` before handing it to `TokioIo`.
 
-Second, **`FuturesUnordered` instead of `tokio::spawn`**. Customer code on the sim runtime is `Send + Sync`, and `SimTcpStream` is `Send`. The blocker is **hyper itself**: `http1::serve_connection` returns a future that is `!Send` because the HTTP1 state machine holds internal `Rc<…>` cells. That future cannot cross `tokio::spawn`, but it polls perfectly well from the accept loop. `FuturesUnordered` lets one task drive any number of in-flight connections concurrently. The accept loop pushes new connections in, the `connections.next()` arm drains completed ones, and shutdown cancels both.
+Second, **`FuturesUnordered` instead of spawning**. Customer code in the sim is `Send + Sync`, and `SimTcpStream` is `Send`. The blocker is **hyper itself**: `http1::serve_connection` returns a future that is `!Send` because the HTTP1 state machine holds internal `Rc<…>` cells. That future cannot cross any Send-bounded spawn, but it polls perfectly well from the accept loop. `FuturesUnordered` lets one task drive any number of in-flight connections concurrently. The accept loop pushes new connections in, the `connections.next()` arm drains completed ones, and shutdown cancels both. The `select!` is moonpool's and stays in its **default form** on purpose: accepting a new connection and progressing an in-flight one are peers that can be ready in the same simulation step, so the seed decides which branch wins and different seeds explore both orders.
 
 ## Step 5: The Workload
 
@@ -170,10 +177,10 @@ let driver = async move {
         tracing::warn!("client conn driver error: {e}");
     }
 };
-tokio::pin!(driver);
+let driver = std::pin::pin!(driver);
 
-// sender.send_request(...) below — the surrounding tokio::select!
-// in send_round polls `driver` concurrently.
+// sender.send_request(...) runs below. The surrounding moonpool
+// select! in send_round polls `driver` concurrently.
 ```
 
 Assertions split into two kinds:

--- a/book/src/part4-integration/03-wiring-a-web-service.md
+++ b/book/src/part4-integration/03-wiring-a-web-service.md
@@ -110,20 +110,14 @@ impl Process for WebProcess {
                     // TowerToHyperService bridges axum's tower::Service to hyper's Service
                     let service = TowerToHyperService::new(app.clone());
 
-                    // .boxed(): select! duplicates this handler once per rotation,
-                    // and each copy's async block is a distinct anonymous type.
-                    // Boxing gives `connections` one named element type.
-                    connections.push(
-                        async move {
-                            if let Err(e) = hyper::server::conn::http1::Builder::new()
-                                .serve_connection(io, service)
-                                .await
-                            {
-                                tracing::debug!("hyper error (expected under chaos): {e}");
-                            }
+                    connections.push(async move {
+                        if let Err(e) = hyper::server::conn::http1::Builder::new()
+                            .serve_connection(io, service)
+                            .await
+                        {
+                            tracing::debug!("hyper error (expected under chaos): {e}");
                         }
-                        .boxed(),
-                    );
+                    });
                 }
                 Some(()) = connections.next(), if !connections.is_empty() => {}
                 _ = ctx.shutdown().cancelled() => return Ok(()),

--- a/book/src/part4-integration/07-wasm.md
+++ b/book/src/part4-integration/07-wasm.md
@@ -15,20 +15,21 @@ In simulation the network and the disk are not devices. `SimNetwork` is an
 in-memory state machine that schedules "deliver this packet at logical time T"
 events on a queue. `SimStorage` is the same idea for reads and writes. Time is a
 counter the engine advances. Randomness is a seeded ChaCha8 stream. The scheduler
-is tokio's current-thread runtime. Add those up and there is no syscall anywhere
-on the path.
+is the [moonpool deterministic executor](../part2-foundations/11-executor.md),
+plain library code. Add those up and there is no syscall anywhere on the path.
 
 The production providers are the opposite. `TokioProviders` is real TCP, real
 files, and OS randomness, every one of them a trip into the kernel. That single
 difference is why the simulator crosses over to `wasm32-unknown-unknown` and the
 production backend does not.
 
-One piece is shared rather than derived, and it is the key to the whole thing.
-`SimProviders` spawns tasks through the real `TokioTaskProvider`, not a simulated
-one, so the executor primitive is literally tokio in both worlds. tokio's `rt`,
-`sync`, and `macros` features compile to wasm. Its `net` and `fs` features do
-not. The simulator brings the half of tokio that crosses over and leaves the
-half that cannot.
+One piece used to be borrowed rather than owned. `SimProviders` once spawned
+tasks through the real `TokioTaskProvider`, which meant shipping tokio's `rt`
+feature to the browser. Not anymore: `SimTaskProvider` spawns onto the moonpool
+deterministic executor, so the wasm build no longer needs core's `tokio-task`
+feature at all. What remains of tokio in the graph is a thin, syscall-free
+slice: `sync` for shutdown tokens and `macros` for the `select!` expansion.
+The `net` and `fs` halves never cross over.
 
 ## What had to change
 
@@ -39,24 +40,25 @@ Getting there was four narrow fixes, not a rewrite.
 - Three wall-clock call sites the harness uses for reporting got a shim, because
   `Instant::now()` and `SystemTime::now()` compile on wasm and then **panic the
   moment you call them**.
-- The `tokio` dependency narrowed to `rt`, `sync`, and `macros`.
+- The `tokio` dependency narrowed to `sync` and `macros`. The deterministic
+  executor owns the scheduling, so not even `rt` crosses over.
 - `rand` dropped its default features so it never reaches for `getrandom` and the
   OS entropy that a browser has no answer for. The sim never needed it: its RNG
   is seeded ChaCha8.
 
 ## Does `block_on` park?
 
-Compiling is necessary, not sufficient. A current-thread runtime that runs out of
+Compiling is necessary, not sufficient. A conventional runtime that runs out of
 ready work tries to **park** the thread, and parking panics on
 `wasm32-unknown-unknown`. So the real question was whether `block_on` ever parks
 while driving a simulation.
 
-It does not. The simulation is ready-driven. Every wakeup fires inline as the
-orchestrator steps the event queue, and there is no external reactor sitting on a
-socket or a timer to wake the thread later. The runtime always has the next step
-in front of it until the run ends. (If an engine change ever broke that, the
-fallback is a hand-rolled poll loop with a no-op waker in place of `block_on`. We
-have not needed it.)
+It does not. The moonpool executor never parks at all: the simulation is
+ready-driven, every wakeup fires inline as the orchestrator steps the event
+queue, and there is no external reactor sitting on a socket or a timer to wake
+the thread later. The executor always has the next step in front of it until
+the run ends, and if nothing is runnable it treats that as a genuine deadlock
+and panics with the seed instead of parking.
 
 ## Building a wasm-able crate
 

--- a/book/src/part4-networking/06-defining-service.md
+++ b/book/src/part4-networking/06-defining-service.md
@@ -64,7 +64,7 @@ impl Calculator for CalculatorImpl {
 }
 ```
 
-Note the `#[async_trait]` attribute on the `impl` block. Service handler traits are dyn-stored, so the macro emits `#[async_trait]` with `Send + Sync + 'static` supertraits on the generated trait. The simulation runtime still uses a single OS thread via `new_current_thread().build()`, but our handlers are **Send-bounded** so customer code can hold `Arc<RwLock<…>>`, `DashMap`, or any other `Send + Sync` state naturally. You re-apply `#[async_trait]` (without `?Send`) on the `impl`, and the compiler enforces that your handler state stays `Send + Sync + 'static`.
+Note the `#[async_trait]` attribute on the `impl` block. Service handler traits are dyn-stored, so the macro emits `#[async_trait]` with `Send + Sync + 'static` supertraits on the generated trait. The simulation still runs on a single OS thread (the [moonpool deterministic executor](../part2-foundations/11-executor.md)), but our handlers are **Send-bounded** so customer code can hold `Arc<RwLock<…>>`, `DashMap`, or any other `Send + Sync` state naturally. You re-apply `#[async_trait]` (without `?Send`) on the `impl`, and the compiler enforces that your handler state stays `Send + Sync + 'static`.
 
 ## Serialization
 

--- a/book/src/part4-networking/07-server-client-endpoints.md
+++ b/book/src/part4-networking/07-server-client-endpoints.md
@@ -127,7 +127,7 @@ reply.send(AddResponse { result: req.a + req.b });
 
 `ReplyFuture` implements `Drop` to close its queue when the future is cancelled or goes out of scope. This prevents leaked wakers and ensures the temporary endpoint is cleaned up even if the caller abandons the request. Without this, a killed process would leave orphaned reply queues that hang forever.
 
-Both types are `Send + Sync + 'static`. Internally they hold `Arc<RwLock<...>>` (or `Arc<NetNotifiedQueue<...>>` for the future's reply channel), so you can move them across `tokio::spawn` boundaries, store them in `Arc`-shared state, and compose them with the broader Rust async ecosystem without contortions. The simulation runtime still runs on a single OS thread for determinism (`new_current_thread().build()`), but the **Send bounds are a compile-time API contract, not a runtime cost**. With only one task ever holding a given lock at a time on a single-thread runtime, there is no measurable contention.
+Both types are `Send + Sync + 'static`. Internally they hold `Arc<RwLock<...>>` (or `Arc<NetNotifiedQueue<...>>` for the future's reply channel), so you can move them across `tokio::spawn` boundaries, store them in `Arc`-shared state, and compose them with the broader Rust async ecosystem without contortions. The simulation still runs on a single OS thread for determinism (the [moonpool deterministic executor](../part2-foundations/11-executor.md)), but the **Send bounds are a compile-time API contract, not a runtime cost**. With only one task ever holding a given lock at a time on a single-thread runtime, there is no measurable contention.
 
 ## ReplyError
 

--- a/book/src/part4-networking/08-delivery-modes.md
+++ b/book/src/part4-networking/08-delivery-modes.md
@@ -38,10 +38,11 @@ let response = iface.balance
     .await?;
 ```
 
-Under the hood, this is a `tokio::select!`:
+Under the hood, this is a moonpool `select!`, written `biased;` with the reply branch first. The disconnect signal is a guard, not a peer: if both are ready, the reply wins, matching FDB's reply-wins-if-resolved semantics.
 
 ```rust
 select! {
+    biased;
     result = reply_future => result,
     () = failure_monitor.on_disconnect_or_failure(&endpoint) => Err(MaybeDelivered),
 }

--- a/moonpool-core/Cargo.toml
+++ b/moonpool-core/Cargo.toml
@@ -25,9 +25,9 @@ tokio-fs = ["dep:tokio", "tokio/fs", "tokio/io-util", "dep:tokio-util"]
 tokio-random = ["rand/thread_rng"]
 # `moonpool_core::select!` as a verbatim re-export of tokio's macro (production).
 select = ["dep:tokio", "tokio/macros"]
-# Deterministic `select!`: replaces the passthrough with the seeded rotation
-# combinator. Enabled by moonpool-sim; production graphs without moonpool-sim
-# keep tokio's macro verbatim via `select`.
+# Deterministic `select!`: replaces the passthrough with tokio's expansion
+# driven by a seeded start offset. Enabled by moonpool-sim; production graphs
+# without moonpool-sim keep tokio's macro verbatim via `select`.
 deterministic-select = ["select"]
 
 [dependencies]

--- a/moonpool-core/Cargo.toml
+++ b/moonpool-core/Cargo.toml
@@ -14,7 +14,7 @@ rustdoc-args = ["--cfg", "tokio_unstable"]
 rustc-args = ["--cfg", "tokio_unstable"]
 
 [features]
-default = ["tokio-providers"]
+default = ["tokio-providers", "select"]
 # Umbrella: the full production bundle (TokioProviders needs all five slots).
 tokio-providers = ["tokio-task", "tokio-time", "tokio-net", "tokio-fs", "tokio-random"]
 # Granular per-provider features. A consumer that only needs one provider (e.g.
@@ -27,6 +27,12 @@ tokio-net = ["dep:tokio", "tokio/net", "tokio/io-util", "dep:tokio-util"]
 tokio-fs = ["dep:tokio", "tokio/fs", "tokio/io-util", "dep:tokio-util"]
 # TokioRandomProvider uses rand's ThreadRng; no tokio involved.
 tokio-random = ["rand/thread_rng"]
+# `moonpool_core::select!` as a verbatim re-export of tokio's macro (production).
+select = ["dep:tokio", "tokio/macros"]
+# Deterministic `select!`: replaces the passthrough with the seeded rotation
+# combinator. Enabled by moonpool-sim; production graphs without moonpool-sim
+# keep tokio's macro verbatim via `select`.
+deterministic-select = ["select"]
 
 [dependencies]
 futures = "0.3"
@@ -39,6 +45,7 @@ tokio-util = { version = "0.7", features = ["compat"], optional = true }
 tracing = "0.1"
 
 [dev-dependencies]
+futures = "0.3"
 
 [lints]
 workspace = true

--- a/moonpool-core/Cargo.toml
+++ b/moonpool-core/Cargo.toml
@@ -9,10 +9,6 @@ description = "Core abstractions for the moonpool simulation framework"
 documentation = "https://docs.rs/moonpool-core"
 readme = "README.md"
 
-[package.metadata.docs.rs]
-rustdoc-args = ["--cfg", "tokio_unstable"]
-rustc-args = ["--cfg", "tokio_unstable"]
-
 [features]
 default = ["tokio-providers", "select"]
 # Umbrella: the full production bundle (TokioProviders needs all five slots).

--- a/moonpool-core/src/lib.rs
+++ b/moonpool-core/src/lib.rs
@@ -74,8 +74,9 @@ mod well_known;
 /// `select!` as tokio's macro, verbatim (production passthrough).
 ///
 /// With the `deterministic-select` feature enabled (moonpool-sim does this),
-/// this re-export is replaced by the seeded rotation combinator defined in
-/// [`select`](crate::select!); the grammar is identical either way.
+/// this re-export is replaced by the seeded-offset macro defined in
+/// [`select`](crate::select!); both are tokio's expansion, so the grammar
+/// and limits are identical either way.
 #[cfg(all(feature = "select", not(feature = "deterministic-select")))]
 pub use tokio::select;
 

--- a/moonpool-core/src/lib.rs
+++ b/moonpool-core/src/lib.rs
@@ -61,11 +61,29 @@ mod error;
 mod network;
 mod providers;
 mod random;
+#[cfg(feature = "deterministic-select")]
+mod select;
+#[cfg(feature = "deterministic-select")]
+pub mod select_support;
 mod storage;
 mod task;
 mod time;
 mod types;
 mod well_known;
+
+/// `select!` as tokio's macro, verbatim (production passthrough).
+///
+/// With the `deterministic-select` feature enabled (moonpool-sim does this),
+/// this re-export is replaced by the seeded rotation combinator defined in
+/// [`select`](crate::select!); the grammar is identical either way.
+#[cfg(all(feature = "select", not(feature = "deterministic-select")))]
+pub use tokio::select;
+
+/// tokio re-export used by `select!` expansions so downstream crates never
+/// need a direct tokio dependency for the macro to resolve. Not public API.
+#[cfg(feature = "select")]
+#[doc(hidden)]
+pub use tokio as __tokio;
 
 // Codec exports
 pub use codec::{CodecError, JsonCodec, MessageCodec};

--- a/moonpool-core/src/select.rs
+++ b/moonpool-core/src/select.rs
@@ -45,6 +45,19 @@
 //!   feeds such a value into a container whose element type is inferred
 //!   (e.g. `FuturesUnordered`), name the type instead: `.boxed()` /
 //!   `.boxed_local()` the future, or construct it through a shared `fn`.
+//!
+//! ## The build-vs-test asymmetry
+//!
+//! Which macro you get is decided by cargo feature unification, not by the
+//! code you compile. Without `deterministic-select` this crate re-exports
+//! tokio's `select!` verbatim (64 branches, no duplication). The moment
+//! moonpool-sim enters the build graph, even as a dev-dependency, the
+//! combinator replaces it for EVERY crate in that graph, including your
+//! library code compiled for tests. Code that only compiles under the
+//! passthrough (17+ branches, or handlers relying on anonymous-type
+//! identity) therefore passes `cargo build` and fails `cargo test`. Write
+//! selects within the combinator's limits everywhere to stay portable
+//! across both worlds.
 
 /// Waits on multiple concurrent branches, returning when the **first**
 /// completes, with a deterministic, seed-controlled polling order.
@@ -119,7 +132,7 @@ macro_rules! __select_split {
         compile_error!("select! must contain at least one branch besides `else`")
     };
     // Input exhausted: rotate with no else branch. The branch groups double
-    // as unary counters (`remaining`, `total`): each group is one token tree.
+    // as a unary counter (`remaining`): each group is one token tree.
     (acc = [$($branch:tt)+] ; ) => {
         $crate::__select_rotate! {
             index = []
@@ -127,7 +140,6 @@ macro_rules! __select_split {
             order = [$($branch)+]
             arms = []
             els = []
-            total = [$($branch)+]
         }
     };
     // Trailing `else` (block or expression handler): must be last.
@@ -138,7 +150,6 @@ macro_rules! __select_split {
             order = [$($branch)+]
             arms = []
             els = [$handler]
-            total = [$($branch)+]
         }
     };
     (acc = [$($branch:tt)+] ; else => $handler:expr $(,)?) => {
@@ -148,7 +159,6 @@ macro_rules! __select_split {
             order = [$($branch)+]
             arms = []
             els = [{ $handler }]
-            total = [$($branch)+]
         }
     };
 
@@ -200,7 +210,6 @@ macro_rules! __select_rotate {
         order = [$first:tt $($rest:tt)*]
         arms = [$($arms:tt)*]
         els = [$($els:tt)*]
-        total = [$($total:tt)*]
     ) => {
         $crate::__select_rotate! {
             index = [$($i)* _]
@@ -212,7 +221,6 @@ macro_rules! __select_rotate {
                     $crate::__select_emit! { branches = [$first $($rest)*] els = [$($els)*] },
             ]
             els = [$($els)*]
-            total = [$($total)*]
         }
     };
     // Last rotation: close with the wildcard arm and emit the dispatch.
@@ -222,9 +230,10 @@ macro_rules! __select_rotate {
         order = [$($order:tt)*]
         arms = [$($arms:tt)*]
         els = [$($els:tt)*]
-        total = [$($total:tt)*]
     ) => {
-        match $crate::select_support::select_offset($crate::__select_count!($($total)*)) {
+        // `order` always holds all N branch groups (left rotation preserves
+        // count), so it doubles as the branch-count source for the draw.
+        match $crate::select_support::select_offset($crate::__select_count!($($order)*)) {
             $($arms)*
             _ => $crate::__select_emit! { branches = [$($order)*] els = [$($els)*] },
         }

--- a/moonpool-core/src/select.rs
+++ b/moonpool-core/src/select.rs
@@ -40,6 +40,11 @@
 //!   iteration) draws fresh.
 //! - At most 16 branches (the expansion emits one rotated copy per branch);
 //!   tokio allows 64.
+//! - Handler code is duplicated once per rotation, and no two copies of an
+//!   anonymous type (async block, closure) are the same type. If a handler
+//!   feeds such a value into a container whose element type is inferred
+//!   (e.g. `FuturesUnordered`), name the type instead: `.boxed()` /
+//!   `.boxed_local()` the future, or construct it through a shared `fn`.
 
 /// Waits on multiple concurrent branches, returning when the **first**
 /// completes, with a deterministic, seed-controlled polling order.

--- a/moonpool-core/src/select.rs
+++ b/moonpool-core/src/select.rs
@@ -1,63 +1,145 @@
-//! Deterministic `select!`: a seeded rotation combinator over `tokio::select!`.
+//! Deterministic `select!`: tokio's own expansion, driven by a seeded offset.
 //!
-//! ## Why this exists
+//! This file is short on code and long on explanation, on purpose: the
+//! mechanism fits in one macro rule, but it leans on how `tokio::select!`
+//! is built internally. Read this doc top to bottom once and the macro at
+//! the bottom will look obvious.
 //!
-//! `tokio::select!` randomizes which branch it polls first so that no branch
-//! starves. That random start offset comes from tokio's thread-local RNG,
-//! which is only seedable through the unstable `tokio_unstable` runtime API;
-//! outside a tokio runtime it silently falls back to OS entropy. For a
-//! deterministic simulation that must replay a seed bit-for-bit, that is a
-//! correctness hole: the same seed picks different branch winners on every
-//! process run.
+//! ## The problem
 //!
-//! ## How it works
+//! `select!` waits on several futures at once and runs the handler of the
+//! first one that completes. When two branches become ready at the same
+//! moment, SOMETHING has to decide which handler runs. In tokio that
+//! decision is the polling order: every time the select future is polled,
+//! tokio picks a start index and polls the branches in the order
+//! `start, start+1, ... (mod N)`. The first branch found ready wins.
 //!
-//! tokio's "fair" mode is exactly its `biased;` mode started at a random
-//! index: it polls branch `(start + i) % N`. Polling the branch list rotated
-//! left by `start`, in order, is the same schedule. So this macro draws
-//! `start` from a moonpool-controlled source and dispatches over the `N`
-//! rotations of a *biased* tokio select:
+//! The start index is random so that no branch can starve the others. That
+//! randomness comes from tokio's thread-local RNG (`thread_rng_n`), which
+//! is:
+//!
+//! - seedable only through the unstable `tokio_unstable` runtime API, and
+//! - seeded from process entropy when there is no tokio runtime at all,
+//!   which is exactly the moonpool situation: there is NO tokio runtime
+//!   inside a simulation.
+//!
+//! For a simulation that must replay a seed bit-for-bit this is a
+//! correctness hole: the same seed would pick different branch winners on
+//! every run of the test binary.
+//!
+//! ## How tokio's macro is built (the part we reuse)
+//!
+//! `tokio::select!` is a `macro_rules!` macro organized as a three-stage
+//! pipeline (see tokio's `src/macros/select.rs`):
 //!
 //! ```text
-//! match select_offset(3) {
-//!     0 => tokio::select! { biased; A, B, C },
-//!     1 => tokio::select! { biased; B, C, A },
-//!     _ => tokio::select! { biased; C, A, B },
-//! }
+//! stage 1: entry rules      recognize the overall shape of the call
+//! stage 2: normalize rules  munch the branches one by one (tagged with @)
+//! stage 3: transform rule   emit the real code: the polling loop
 //! ```
 //!
-//! Every polling mechanic (branch disabling, `if` preconditions, refutable
-//! patterns, `else`, cooperative budgeting) is inherited from the real
-//! `tokio::select!` expansion; nothing is reimplemented here.
+//! The line that matters is tokio's own fair-mode ENTRY rule (abridged):
 //!
-//! ## Divergences from `tokio::select!`
+//! ```text
+//! ($p:pat = $($t:tt)*) => {
+//!     $crate::select!(@{ start={ thread_rng_n(BRANCHES) }; () } $p = $($t)*)
+//! };
+//! ```
 //!
-//! - Future *expressions* are evaluated in rotated order, not source order.
-//!   This only matters if constructing a future has side effects whose order
-//!   is observable.
-//! - The offset is drawn once per `select!` *execution*; tokio redraws on
-//!   every poll of the same execution. Each new execution (e.g. each loop
-//!   iteration) draws fresh.
-//! - At most 16 branches (the expansion emits one rotated copy per branch);
-//!   tokio allows 64.
-//! - Handler code is duplicated once per rotation, and no two copies of an
-//!   anonymous type (async block, closure) are the same type. If a handler
-//!   feeds such a value into a container whose element type is inferred
-//!   (e.g. `FuturesUnordered`), name the type instead: `.boxed()` /
-//!   `.boxed_local()` the future, or construct it through a shared `fn`.
+//! Notice what it does NOT do: it does not call the RNG. Macros only move
+//! tokens around; the RNG call is written, unevaluated, into a slot named
+//! `start`, and everything is forwarded to stage 2. Stages 2 and 3 carry
+//! the slot along untouched (they match it as `start=$start:expr`), and
+//! stage 3 finally pastes it INSIDE the polling closure it emits:
+//!
+//! ```text
+//! poll_fn(|cx| {
+//!     // ...
+//!     let start = $start;               // evaluated HERE, on EVERY poll
+//!     for i in 0..BRANCHES {
+//!         let branch = (start + i) % BRANCHES;
+//!         // ... poll that branch, first Ready wins ...
+//!     }
+//! })
+//! ```
+//!
+//! So the randomness source is not baked into the machinery at all. It is
+//! a plug-in expression chosen by whoever writes the entry rule. tokio's
+//! entry rule plugs in `thread_rng_n(BRANCHES)`. Nothing stops a different
+//! entry rule from plugging in something else, because `macro_rules!` has
+//! no private rules: the stage-2 and stage-3 rules live in the same
+//! `#[macro_export]`ed `select!` macro, so `tokio::select!(@{ ... } ...)`
+//! is callable from any crate.
+//!
+//! ## What moonpool's `select!` does
+//!
+//! The macro below IS that different entry rule. For the default (fair)
+//! form it jumps straight into tokio's stage 2, plugging moonpool's seeded
+//! source into the `start` slot:
+//!
+//! ```text
+//! tokio::select!(@{ start={ select_support::select_offset(BRANCHES) }; () } ...)
+//! ```
+//!
+//! Everything after the entry rule is tokio's machinery, byte for byte:
+//! branch polling, the disabled-branch mask, `if` preconditions, refutable
+//! patterns, `else`, cooperative budgeting, the 64-branch cap, source-order
+//! evaluation of the future expressions, and the per-poll redraw of the
+//! offset. We copied none of it and we maintain none of it. The ONLY thing
+//! that changes is where the number comes from.
+//!
+//! ## Why the `BRANCHES` token resolves (macro hygiene)
+//!
+//! `BRANCHES` is a `const` holding the branch count, defined by stage 3
+//! inside the block it emits. Our entry rule writes the token `BRANCHES`
+//! into the `start` expression BEFORE that const exists anywhere. Two
+//! macro-hygiene facts make this sound:
+//!
+//! - `macro_rules!` hygiene only isolates local variables (`let` bindings
+//!   and labels). Items are not isolated, and a `const` is an item: any
+//!   code that ends up inside its scope can name it, no matter which macro
+//!   wrote which token.
+//! - tokio itself depends on exactly this. Its own entry rule writes the
+//!   `BRANCHES` token in one macro expansion, and the const is defined by
+//!   a later, separate expansion (stage 3). Our token rides through the
+//!   identical path, so it resolves the same way tokio's own token does.
+//!
+//! ## Where the offset comes from at runtime
+//!
+//! [`select_support::select_offset`](crate::select_support) is the number
+//! source:
+//!
+//! - **Simulation**: moonpool-sim installs a seeded stream per iteration
+//!   ([`set_select_offset_override`](crate::select_support::set_select_offset_override)),
+//!   so the same seed replays the same winners exactly and different seeds
+//!   explore different orderings.
+//! - **Production** (no override installed): a thread-local entropy-seeded
+//!   RNG, behaviorally what tokio's fair mode does.
+//!
+//! ## The internal-format dependency (the price)
+//!
+//! The `@{ start=...; () }` entry shape is tokio's `#[doc(hidden)]` macro
+//! plumbing, not covered by semver. Two facts make that acceptable:
+//!
+//! - The shape has been stable since tokio 1.4 (2021, when `biased;`
+//!   landed) and is identical in every release since.
+//! - The failure mode is loud. If a future tokio changes the shape, every
+//!   fair-mode `select!` call site stops compiling with a macro-match error
+//!   on the upgrade commit. It can not drift silently; winner-selection and
+//!   determinism tests pin the semantics on top.
+//!
+//! If it ever breaks, the fallbacks are to vendor tokio's `select.rs` or to
+//! resurrect the rotation combinator this macro replaced (git history).
 //!
 //! ## The build-vs-test asymmetry
 //!
 //! Which macro you get is decided by cargo feature unification, not by the
 //! code you compile. Without `deterministic-select` this crate re-exports
-//! tokio's `select!` verbatim (64 branches, no duplication). The moment
-//! moonpool-sim enters the build graph, even as a dev-dependency, the
-//! combinator replaces it for EVERY crate in that graph, including your
-//! library code compiled for tests. Code that only compiles under the
-//! passthrough (17+ branches, or handlers relying on anonymous-type
-//! identity) therefore passes `cargo build` and fails `cargo test`. Write
-//! selects within the combinator's limits everywhere to stay portable
-//! across both worlds.
+//! tokio's `select!` verbatim. The moment moonpool-sim enters the build
+//! graph, even as a dev-dependency, this macro replaces it for EVERY crate
+//! in that graph, including your library code compiled for tests. Both forms
+//! are tokio's own expansion with identical grammar and limits, so the swap
+//! changes nothing but the offset source.
 
 /// Waits on multiple concurrent branches, returning when the **first**
 /// completes, with a deterministic, seed-controlled polling order.
@@ -72,11 +154,12 @@
 /// }
 /// ```
 ///
-/// By default the branch polled first is chosen by a rotation offset drawn
-/// from [`select_support::select_offset`](crate::select_support): inside a
-/// moonpool simulation that source is seeded (same seed, same choices, exact
-/// replay; different seeds explore different orderings), and outside a
-/// simulation it is entropy-based, matching tokio's production behavior.
+/// By default the branch polled first is chosen, on every poll, by an offset
+/// drawn from [`select_support::select_offset`](crate::select_support):
+/// inside a moonpool simulation that source is seeded (same seed, same
+/// choices, exact replay; different seeds explore different orderings), and
+/// outside a simulation it is entropy-based, matching tokio's production
+/// behavior.
 ///
 /// `select! { biased; ... }` skips the draw entirely and forwards verbatim to
 /// `tokio::select! { biased; ... }`: branches are polled top to bottom, which
@@ -97,220 +180,72 @@
 /// # });
 /// ```
 ///
-/// See the [module docs](crate::select) for the rotation strategy and the
-/// documented divergences from `tokio::select!`.
+/// See the [module docs](crate::select) for the full walkthrough of how the
+/// offset is injected into tokio's own expansion.
 #[macro_export]
 macro_rules! select {
-    // `biased;`: source-order priority, no randomness anywhere. Forward verbatim.
+    // ------------------------------------------------------------------
+    // Rule 1: `biased;` mode.
+    //
+    // The caller asked for source-order polling, which involves no
+    // randomness anywhere (tokio hard-codes start=0 for it). There is
+    // nothing to make deterministic, so forward the whole call verbatim
+    // to the real tokio macro.
+    // ------------------------------------------------------------------
     (biased; $($branches:tt)*) => {
         $crate::__tokio::select! { biased; $($branches)* }
     };
-    // Empty input: forward so tokio emits its own diagnostic.
+
+    // ------------------------------------------------------------------
+    // Rule 2: `else`-only input, e.g. `select! { else => 42 }`.
+    //
+    // No branches means no polling order and no draw. Forward verbatim so
+    // tokio applies its own rule (it evaluates the handler directly) or
+    // emits its own diagnostic for malformed input.
+    //
+    // This rule must be tried before rule 3: `else` is a keyword, so it
+    // can never start the `$p:pat` fragment below, but keeping it first
+    // makes the priority explicit.
+    // ------------------------------------------------------------------
+    (else => $($rest:tt)*) => {
+        $crate::__tokio::select! { else => $($rest)* }
+    };
+
+    // ------------------------------------------------------------------
+    // Rule 3: the default (fair) mode. THE interesting rule.
+    //
+    // `$p:pat = $($t:tt)*` matches the same shape as tokio's own fair-mode
+    // entry rule: the first branch's pattern, then everything else as raw
+    // tokens. Instead of letting tokio's entry rule run (it would plug its
+    // entropy RNG into the `start` slot), we invoke tokio's stage-2 rules
+    // directly, with moonpool's offset source in the slot:
+    //
+    // - `@{ ... }` is tokio's internal marker for "input already passed
+    //   the entry rule, start normalizing branches".
+    // - `start={ ... }` is the polling-order expression. It travels through
+    //   the pipeline as unevaluated tokens and is pasted inside the
+    //   `poll_fn` closure that tokio's stage 3 emits, so it is re-evaluated
+    //   on EVERY poll of the select (exactly like tokio's fair mode).
+    // - `BRANCHES` is the branch-count const that stage 3 defines in the
+    //   scope where this expression lands. Items are unhygienic across
+    //   macro_rules expansions, and tokio's own entry rule relies on the
+    //   very same cross-expansion resolution (see the module docs).
+    // - `()` is stage 2's branch counter, empty at the start.
+    //
+    // `select_offset` receives the branch count and returns the index to
+    // poll first (already reduced modulo the count).
+    // ------------------------------------------------------------------
+    ($p:pat = $($t:tt)*) => {
+        $crate::__tokio::select!(
+            @{ start={ $crate::select_support::select_offset(BRANCHES) }; () } $p = $($t)*
+        )
+    };
+
+    // ------------------------------------------------------------------
+    // Rule 4: empty input. Forward so tokio emits its own diagnostic
+    // ("select! requires at least one branch").
+    // ------------------------------------------------------------------
     () => {
         $crate::__tokio::select! {}
-    };
-    // Fair mode: split the branches, then dispatch over seeded rotations.
-    ($($input:tt)*) => {
-        $crate::__select_split! { acc = [] ; $($input)* }
-    };
-}
-
-/// Splits `select!` input into branch groups plus an optional trailing
-/// `else`, then hands off to `__select_rotate!`.
-///
-/// Each branch is stored as a single `{ ... }` token group holding its source
-/// tokens (`pat = future`, optional `, if cond`, `=> handler`). Expression
-/// handlers are normalized into blocks (`=> h` becomes `=> { h }`): a
-/// captured `:expr` fragment cannot re-match tokio's `:block` matchers, so
-/// every handler must reach `tokio::select!` as a block.
-#[doc(hidden)]
-#[macro_export]
-macro_rules! __select_split {
-    // -- terminal states ----------------------------------------------------
-    // No branches at all (else-only input): tokio also rejects this.
-    (acc = [] ; else => $($rest:tt)*) => {
-        compile_error!("select! must contain at least one branch besides `else`")
-    };
-    // Input exhausted: rotate with no else branch. The branch groups double
-    // as a unary counter (`remaining`): each group is one token tree.
-    (acc = [$($branch:tt)+] ; ) => {
-        $crate::__select_rotate! {
-            index = []
-            remaining = [$($branch)+]
-            order = [$($branch)+]
-            arms = []
-            els = []
-        }
-    };
-    // Trailing `else` (block or expression handler): must be last.
-    (acc = [$($branch:tt)+] ; else => $handler:block $(,)?) => {
-        $crate::__select_rotate! {
-            index = []
-            remaining = [$($branch)+]
-            order = [$($branch)+]
-            arms = []
-            els = [$handler]
-        }
-    };
-    (acc = [$($branch:tt)+] ; else => $handler:expr $(,)?) => {
-        $crate::__select_rotate! {
-            index = []
-            remaining = [$($branch)+]
-            order = [$($branch)+]
-            arms = []
-            els = [{ $handler }]
-        }
-    };
-
-    // -- branch munchers (comma variants before comma-less ones) ------------
-    // Precondition + block handler.
-    (acc = [$($acc:tt)*] ; $p:pat = $f:expr, if $c:expr => $h:block , $($rest:tt)*) => {
-        $crate::__select_split! { acc = [$($acc)* { $p = $f, if $c => $h }] ; $($rest)* }
-    };
-    (acc = [$($acc:tt)*] ; $p:pat = $f:expr, if $c:expr => $h:block $($rest:tt)*) => {
-        $crate::__select_split! { acc = [$($acc)* { $p = $f, if $c => $h }] ; $($rest)* }
-    };
-    // Precondition + expression handler (comma required unless last).
-    (acc = [$($acc:tt)*] ; $p:pat = $f:expr, if $c:expr => $h:expr , $($rest:tt)*) => {
-        $crate::__select_split! { acc = [$($acc)* { $p = $f, if $c => { $h } }] ; $($rest)* }
-    };
-    (acc = [$($acc:tt)*] ; $p:pat = $f:expr, if $c:expr => $h:expr) => {
-        $crate::__select_split! { acc = [$($acc)* { $p = $f, if $c => { $h } }] ; }
-    };
-    // No precondition + block handler.
-    (acc = [$($acc:tt)*] ; $p:pat = $f:expr => $h:block , $($rest:tt)*) => {
-        $crate::__select_split! { acc = [$($acc)* { $p = $f => $h }] ; $($rest)* }
-    };
-    (acc = [$($acc:tt)*] ; $p:pat = $f:expr => $h:block $($rest:tt)*) => {
-        $crate::__select_split! { acc = [$($acc)* { $p = $f => $h }] ; $($rest)* }
-    };
-    // No precondition + expression handler (comma required unless last).
-    (acc = [$($acc:tt)*] ; $p:pat = $f:expr => $h:expr , $($rest:tt)*) => {
-        $crate::__select_split! { acc = [$($acc)* { $p = $f => { $h } }] ; $($rest)* }
-    };
-    (acc = [$($acc:tt)*] ; $p:pat = $f:expr => $h:expr) => {
-        $crate::__select_split! { acc = [$($acc)* { $p = $f => { $h } }] ; }
-    };
-}
-
-/// Emits the `match select_offset(N) { ... }` dispatch, one arm per rotation.
-///
-/// Token-counter recursion: `index` (unary `_`s) numbers the arm being
-/// emitted, `remaining` (the branch groups themselves, one token tree each)
-/// counts down by one per step, and `order` is rotated left by one branch
-/// between arms. The final rotation becomes the `_` arm so the match is
-/// exhaustive.
-#[doc(hidden)]
-#[macro_export]
-macro_rules! __select_rotate {
-    // More than one rotation left: emit a literal-index arm, rotate, recurse.
-    (
-        index = [$($i:tt)*]
-        remaining = [$rhead:tt $($rrest:tt)+]
-        order = [$first:tt $($rest:tt)*]
-        arms = [$($arms:tt)*]
-        els = [$($els:tt)*]
-    ) => {
-        $crate::__select_rotate! {
-            index = [$($i)* _]
-            remaining = [$($rrest)+]
-            order = [$($rest)* $first]
-            arms = [
-                $($arms)*
-                $crate::__select_count!($($i)*) =>
-                    $crate::__select_emit! { branches = [$first $($rest)*] els = [$($els)*] },
-            ]
-            els = [$($els)*]
-        }
-    };
-    // Last rotation: close with the wildcard arm and emit the dispatch.
-    (
-        index = [$($i:tt)*]
-        remaining = [$rlast:tt]
-        order = [$($order:tt)*]
-        arms = [$($arms:tt)*]
-        els = [$($els:tt)*]
-    ) => {
-        // `order` always holds all N branch groups (left rotation preserves
-        // count), so it doubles as the branch-count source for the draw.
-        match $crate::select_support::select_offset($crate::__select_count!($($order)*)) {
-            $($arms)*
-            _ => $crate::__select_emit! { branches = [$($order)*] els = [$($els)*] },
-        }
-    };
-}
-
-/// Emits one rotation as a real `tokio::select! { biased; ... }`.
-#[doc(hidden)]
-#[macro_export]
-macro_rules! __select_emit {
-    (branches = [$( { $($branch:tt)* } )+] els = []) => {
-        $crate::__tokio::select! { biased; $( $($branch)* , )+ }
-    };
-    (branches = [$( { $($branch:tt)* } )+] els = [$handler:tt]) => {
-        $crate::__tokio::select! { biased; $( $($branch)* , )+ else => $handler }
-    };
-}
-
-/// Counts token trees (0..=16) into a `u32` literal, usable in both
-/// expression and match-pattern position. The inputs are either unary `_`
-/// counters (`index`) or whole branch groups (`total`), one token tree each.
-/// The fallback arm enforces the 16-branch cap.
-#[doc(hidden)]
-#[macro_export]
-macro_rules! __select_count {
-    () => {
-        0u32
-    };
-    ($a:tt) => {
-        1u32
-    };
-    ($a:tt $b:tt) => {
-        2u32
-    };
-    ($a:tt $b:tt $c:tt) => {
-        3u32
-    };
-    ($a:tt $b:tt $c:tt $d:tt) => {
-        4u32
-    };
-    ($a:tt $b:tt $c:tt $d:tt $e:tt) => {
-        5u32
-    };
-    ($a:tt $b:tt $c:tt $d:tt $e:tt $f:tt) => {
-        6u32
-    };
-    ($a:tt $b:tt $c:tt $d:tt $e:tt $f:tt $g:tt) => {
-        7u32
-    };
-    ($a:tt $b:tt $c:tt $d:tt $e:tt $f:tt $g:tt $h:tt) => {
-        8u32
-    };
-    ($a:tt $b:tt $c:tt $d:tt $e:tt $f:tt $g:tt $h:tt $i:tt) => {
-        9u32
-    };
-    ($a:tt $b:tt $c:tt $d:tt $e:tt $f:tt $g:tt $h:tt $i:tt $j:tt) => {
-        10u32
-    };
-    ($a:tt $b:tt $c:tt $d:tt $e:tt $f:tt $g:tt $h:tt $i:tt $j:tt $k:tt) => {
-        11u32
-    };
-    ($a:tt $b:tt $c:tt $d:tt $e:tt $f:tt $g:tt $h:tt $i:tt $j:tt $k:tt $l:tt) => {
-        12u32
-    };
-    ($a:tt $b:tt $c:tt $d:tt $e:tt $f:tt $g:tt $h:tt $i:tt $j:tt $k:tt $l:tt $m:tt) => {
-        13u32
-    };
-    ($a:tt $b:tt $c:tt $d:tt $e:tt $f:tt $g:tt $h:tt $i:tt $j:tt $k:tt $l:tt $m:tt $n:tt) => {
-        14u32
-    };
-    ($a:tt $b:tt $c:tt $d:tt $e:tt $f:tt $g:tt $h:tt $i:tt $j:tt $k:tt $l:tt $m:tt $n:tt $o:tt) => {
-        15u32
-    };
-    ($a:tt $b:tt $c:tt $d:tt $e:tt $f:tt $g:tt $h:tt $i:tt $j:tt $k:tt $l:tt $m:tt $n:tt $o:tt $p:tt) => {
-        16u32
-    };
-    ($($too_many:tt)*) => {
-        compile_error!("moonpool select! supports at most 16 branches")
     };
 }

--- a/moonpool-core/src/select.rs
+++ b/moonpool-core/src/select.rs
@@ -1,0 +1,302 @@
+//! Deterministic `select!`: a seeded rotation combinator over `tokio::select!`.
+//!
+//! ## Why this exists
+//!
+//! `tokio::select!` randomizes which branch it polls first so that no branch
+//! starves. That random start offset comes from tokio's thread-local RNG,
+//! which is only seedable through the unstable `tokio_unstable` runtime API;
+//! outside a tokio runtime it silently falls back to OS entropy. For a
+//! deterministic simulation that must replay a seed bit-for-bit, that is a
+//! correctness hole: the same seed picks different branch winners on every
+//! process run.
+//!
+//! ## How it works
+//!
+//! tokio's "fair" mode is exactly its `biased;` mode started at a random
+//! index: it polls branch `(start + i) % N`. Polling the branch list rotated
+//! left by `start`, in order, is the same schedule. So this macro draws
+//! `start` from a moonpool-controlled source and dispatches over the `N`
+//! rotations of a *biased* tokio select:
+//!
+//! ```text
+//! match select_offset(3) {
+//!     0 => tokio::select! { biased; A, B, C },
+//!     1 => tokio::select! { biased; B, C, A },
+//!     _ => tokio::select! { biased; C, A, B },
+//! }
+//! ```
+//!
+//! Every polling mechanic (branch disabling, `if` preconditions, refutable
+//! patterns, `else`, cooperative budgeting) is inherited from the real
+//! `tokio::select!` expansion; nothing is reimplemented here.
+//!
+//! ## Divergences from `tokio::select!`
+//!
+//! - Future *expressions* are evaluated in rotated order, not source order.
+//!   This only matters if constructing a future has side effects whose order
+//!   is observable.
+//! - The offset is drawn once per `select!` *execution*; tokio redraws on
+//!   every poll of the same execution. Each new execution (e.g. each loop
+//!   iteration) draws fresh.
+//! - At most 16 branches (the expansion emits one rotated copy per branch);
+//!   tokio allows 64.
+
+/// Waits on multiple concurrent branches, returning when the **first**
+/// completes, with a deterministic, seed-controlled polling order.
+///
+/// Drop-in replacement for [`tokio::select!`] with the same grammar:
+///
+/// ```text
+/// select! {
+///     <pattern> = <async expression> (, if <precondition>)? => <handler>,
+///     ...
+///     (else => <handler>)?
+/// }
+/// ```
+///
+/// By default the branch polled first is chosen by a rotation offset drawn
+/// from [`select_support::select_offset`](crate::select_support): inside a
+/// moonpool simulation that source is seeded (same seed, same choices, exact
+/// replay; different seeds explore different orderings), and outside a
+/// simulation it is entropy-based, matching tokio's production behavior.
+///
+/// `select! { biased; ... }` skips the draw entirely and forwards verbatim to
+/// `tokio::select! { biased; ... }`: branches are polled top to bottom, which
+/// is already fully deterministic. Use it when branches have a natural
+/// priority (shutdown or timeout guards); use the default form when branches
+/// are peers racing for the same wake (message queues, notify channels), so
+/// the simulation can explore both winners across seeds.
+///
+/// # Examples
+///
+/// ```
+/// # futures::executor::block_on(async {
+/// let winner = moonpool_core::select! {
+///     x = async { 1 } => x,
+///     _ = std::future::pending::<()>() => unreachable!(),
+/// };
+/// assert_eq!(winner, 1);
+/// # });
+/// ```
+///
+/// See the [module docs](crate::select) for the rotation strategy and the
+/// documented divergences from `tokio::select!`.
+#[macro_export]
+macro_rules! select {
+    // `biased;`: source-order priority, no randomness anywhere. Forward verbatim.
+    (biased; $($branches:tt)*) => {
+        $crate::__tokio::select! { biased; $($branches)* }
+    };
+    // Empty input: forward so tokio emits its own diagnostic.
+    () => {
+        $crate::__tokio::select! {}
+    };
+    // Fair mode: split the branches, then dispatch over seeded rotations.
+    ($($input:tt)*) => {
+        $crate::__select_split! { acc = [] ; $($input)* }
+    };
+}
+
+/// Splits `select!` input into branch groups plus an optional trailing
+/// `else`, then hands off to `__select_rotate!`.
+///
+/// Each branch is stored as a single `{ ... }` token group holding its source
+/// tokens (`pat = future`, optional `, if cond`, `=> handler`). Expression
+/// handlers are normalized into blocks (`=> h` becomes `=> { h }`): a
+/// captured `:expr` fragment cannot re-match tokio's `:block` matchers, so
+/// every handler must reach `tokio::select!` as a block.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __select_split {
+    // -- terminal states ----------------------------------------------------
+    // No branches at all (else-only input): tokio also rejects this.
+    (acc = [] ; else => $($rest:tt)*) => {
+        compile_error!("select! must contain at least one branch besides `else`")
+    };
+    // Input exhausted: rotate with no else branch. The branch groups double
+    // as unary counters (`remaining`, `total`): each group is one token tree.
+    (acc = [$($branch:tt)+] ; ) => {
+        $crate::__select_rotate! {
+            index = []
+            remaining = [$($branch)+]
+            order = [$($branch)+]
+            arms = []
+            els = []
+            total = [$($branch)+]
+        }
+    };
+    // Trailing `else` (block or expression handler): must be last.
+    (acc = [$($branch:tt)+] ; else => $handler:block $(,)?) => {
+        $crate::__select_rotate! {
+            index = []
+            remaining = [$($branch)+]
+            order = [$($branch)+]
+            arms = []
+            els = [$handler]
+            total = [$($branch)+]
+        }
+    };
+    (acc = [$($branch:tt)+] ; else => $handler:expr $(,)?) => {
+        $crate::__select_rotate! {
+            index = []
+            remaining = [$($branch)+]
+            order = [$($branch)+]
+            arms = []
+            els = [{ $handler }]
+            total = [$($branch)+]
+        }
+    };
+
+    // -- branch munchers (comma variants before comma-less ones) ------------
+    // Precondition + block handler.
+    (acc = [$($acc:tt)*] ; $p:pat = $f:expr, if $c:expr => $h:block , $($rest:tt)*) => {
+        $crate::__select_split! { acc = [$($acc)* { $p = $f, if $c => $h }] ; $($rest)* }
+    };
+    (acc = [$($acc:tt)*] ; $p:pat = $f:expr, if $c:expr => $h:block $($rest:tt)*) => {
+        $crate::__select_split! { acc = [$($acc)* { $p = $f, if $c => $h }] ; $($rest)* }
+    };
+    // Precondition + expression handler (comma required unless last).
+    (acc = [$($acc:tt)*] ; $p:pat = $f:expr, if $c:expr => $h:expr , $($rest:tt)*) => {
+        $crate::__select_split! { acc = [$($acc)* { $p = $f, if $c => { $h } }] ; $($rest)* }
+    };
+    (acc = [$($acc:tt)*] ; $p:pat = $f:expr, if $c:expr => $h:expr) => {
+        $crate::__select_split! { acc = [$($acc)* { $p = $f, if $c => { $h } }] ; }
+    };
+    // No precondition + block handler.
+    (acc = [$($acc:tt)*] ; $p:pat = $f:expr => $h:block , $($rest:tt)*) => {
+        $crate::__select_split! { acc = [$($acc)* { $p = $f => $h }] ; $($rest)* }
+    };
+    (acc = [$($acc:tt)*] ; $p:pat = $f:expr => $h:block $($rest:tt)*) => {
+        $crate::__select_split! { acc = [$($acc)* { $p = $f => $h }] ; $($rest)* }
+    };
+    // No precondition + expression handler (comma required unless last).
+    (acc = [$($acc:tt)*] ; $p:pat = $f:expr => $h:expr , $($rest:tt)*) => {
+        $crate::__select_split! { acc = [$($acc)* { $p = $f => { $h } }] ; $($rest)* }
+    };
+    (acc = [$($acc:tt)*] ; $p:pat = $f:expr => $h:expr) => {
+        $crate::__select_split! { acc = [$($acc)* { $p = $f => { $h } }] ; }
+    };
+}
+
+/// Emits the `match select_offset(N) { ... }` dispatch, one arm per rotation.
+///
+/// Token-counter recursion: `index` (unary `_`s) numbers the arm being
+/// emitted, `remaining` (the branch groups themselves, one token tree each)
+/// counts down by one per step, and `order` is rotated left by one branch
+/// between arms. The final rotation becomes the `_` arm so the match is
+/// exhaustive.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __select_rotate {
+    // More than one rotation left: emit a literal-index arm, rotate, recurse.
+    (
+        index = [$($i:tt)*]
+        remaining = [$rhead:tt $($rrest:tt)+]
+        order = [$first:tt $($rest:tt)*]
+        arms = [$($arms:tt)*]
+        els = [$($els:tt)*]
+        total = [$($total:tt)*]
+    ) => {
+        $crate::__select_rotate! {
+            index = [$($i)* _]
+            remaining = [$($rrest)+]
+            order = [$($rest)* $first]
+            arms = [
+                $($arms)*
+                $crate::__select_count!($($i)*) =>
+                    $crate::__select_emit! { branches = [$first $($rest)*] els = [$($els)*] },
+            ]
+            els = [$($els)*]
+            total = [$($total)*]
+        }
+    };
+    // Last rotation: close with the wildcard arm and emit the dispatch.
+    (
+        index = [$($i:tt)*]
+        remaining = [$rlast:tt]
+        order = [$($order:tt)*]
+        arms = [$($arms:tt)*]
+        els = [$($els:tt)*]
+        total = [$($total:tt)*]
+    ) => {
+        match $crate::select_support::select_offset($crate::__select_count!($($total)*)) {
+            $($arms)*
+            _ => $crate::__select_emit! { branches = [$($order)*] els = [$($els)*] },
+        }
+    };
+}
+
+/// Emits one rotation as a real `tokio::select! { biased; ... }`.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __select_emit {
+    (branches = [$( { $($branch:tt)* } )+] els = []) => {
+        $crate::__tokio::select! { biased; $( $($branch)* , )+ }
+    };
+    (branches = [$( { $($branch:tt)* } )+] els = [$handler:tt]) => {
+        $crate::__tokio::select! { biased; $( $($branch)* , )+ else => $handler }
+    };
+}
+
+/// Counts token trees (0..=16) into a `u32` literal, usable in both
+/// expression and match-pattern position. The inputs are either unary `_`
+/// counters (`index`) or whole branch groups (`total`), one token tree each.
+/// The fallback arm enforces the 16-branch cap.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __select_count {
+    () => {
+        0u32
+    };
+    ($a:tt) => {
+        1u32
+    };
+    ($a:tt $b:tt) => {
+        2u32
+    };
+    ($a:tt $b:tt $c:tt) => {
+        3u32
+    };
+    ($a:tt $b:tt $c:tt $d:tt) => {
+        4u32
+    };
+    ($a:tt $b:tt $c:tt $d:tt $e:tt) => {
+        5u32
+    };
+    ($a:tt $b:tt $c:tt $d:tt $e:tt $f:tt) => {
+        6u32
+    };
+    ($a:tt $b:tt $c:tt $d:tt $e:tt $f:tt $g:tt) => {
+        7u32
+    };
+    ($a:tt $b:tt $c:tt $d:tt $e:tt $f:tt $g:tt $h:tt) => {
+        8u32
+    };
+    ($a:tt $b:tt $c:tt $d:tt $e:tt $f:tt $g:tt $h:tt $i:tt) => {
+        9u32
+    };
+    ($a:tt $b:tt $c:tt $d:tt $e:tt $f:tt $g:tt $h:tt $i:tt $j:tt) => {
+        10u32
+    };
+    ($a:tt $b:tt $c:tt $d:tt $e:tt $f:tt $g:tt $h:tt $i:tt $j:tt $k:tt) => {
+        11u32
+    };
+    ($a:tt $b:tt $c:tt $d:tt $e:tt $f:tt $g:tt $h:tt $i:tt $j:tt $k:tt $l:tt) => {
+        12u32
+    };
+    ($a:tt $b:tt $c:tt $d:tt $e:tt $f:tt $g:tt $h:tt $i:tt $j:tt $k:tt $l:tt $m:tt) => {
+        13u32
+    };
+    ($a:tt $b:tt $c:tt $d:tt $e:tt $f:tt $g:tt $h:tt $i:tt $j:tt $k:tt $l:tt $m:tt $n:tt) => {
+        14u32
+    };
+    ($a:tt $b:tt $c:tt $d:tt $e:tt $f:tt $g:tt $h:tt $i:tt $j:tt $k:tt $l:tt $m:tt $n:tt $o:tt) => {
+        15u32
+    };
+    ($a:tt $b:tt $c:tt $d:tt $e:tt $f:tt $g:tt $h:tt $i:tt $j:tt $k:tt $l:tt $m:tt $n:tt $o:tt $p:tt) => {
+        16u32
+    };
+    ($($too_many:tt)*) => {
+        compile_error!("moonpool select! supports at most 16 branches")
+    };
+}

--- a/moonpool-core/src/select_support.rs
+++ b/moonpool-core/src/select_support.rs
@@ -1,8 +1,8 @@
 //! Runtime support for the deterministic [`select!`](crate::select) macro.
 //!
-//! The rotation combinator emitted by `select!` draws one branch offset per
-//! execution from [`select_offset`]. Where that offset comes from decides the
-//! determinism story:
+//! The expansion emitted by `select!` draws a branch offset from
+//! [`select_offset`] on every poll, exactly like tokio's fair mode. Where
+//! that offset comes from decides the determinism story:
 //!
 //! - **Simulation**: moonpool-sim installs an override per iteration via
 //!   [`set_select_offset_override`], backed by a seeded RNG stream. Same seed,

--- a/moonpool-core/src/select_support.rs
+++ b/moonpool-core/src/select_support.rs
@@ -1,0 +1,106 @@
+//! Runtime support for the deterministic [`select!`](crate::select) macro.
+//!
+//! The rotation combinator emitted by `select!` draws one branch offset per
+//! execution from [`select_offset`]. Where that offset comes from decides the
+//! determinism story:
+//!
+//! - **Simulation**: moonpool-sim installs an override per iteration via
+//!   [`set_select_offset_override`], backed by a seeded RNG stream. Same seed,
+//!   same offsets, exact replay; different seeds explore different branch
+//!   orderings.
+//! - **Production** (no override installed): a thread-local xorshift64* lazily
+//!   seeded from [`std::collections::hash_map::RandomState`] (the same entropy
+//!   trick tokio's own `FastRand` uses). Behaviorally equivalent to tokio's
+//!   fair `select!`, and wasm-clean: no `getrandom`, no OS calls beyond what
+//!   `std` already does for hashers.
+//!
+//! The hook detects the *simulation*, not tokio: the expansion is identical
+//! everywhere, only the number source changes.
+
+use std::cell::Cell;
+
+/// A branch-offset source for [`select!`](crate::select): receives the branch
+/// count `n` and returns the index of the branch to poll first (values are
+/// reduced modulo `n`).
+pub type SelectOffsetFn = fn(u32) -> u32;
+
+thread_local! {
+    /// Offset source installed by the simulation runtime (None in production).
+    static OFFSET_OVERRIDE: Cell<Option<SelectOffsetFn>> = const { Cell::new(None) };
+    /// Lazily seeded xorshift64* state for the entropy fallback (0 = unseeded).
+    static FALLBACK_STATE: Cell<u64> = const { Cell::new(0) };
+}
+
+/// Install (or clear, with `None`) the branch-offset source used by
+/// [`select!`](crate::select) on the current thread.
+///
+/// moonpool-sim installs a seeded source per simulation iteration; leaving it
+/// uninstalled gives entropy-based offsets, which is the correct production
+/// behavior.
+pub fn set_select_offset_override(source: Option<SelectOffsetFn>) {
+    OFFSET_OVERRIDE.with(|cell| cell.set(source));
+}
+
+/// Draw the branch start offset for one `select!` execution.
+///
+/// Not part of the public API: only `select!` expansions call this.
+#[doc(hidden)]
+pub fn select_offset(branches: u32) -> u32 {
+    if branches <= 1 {
+        return 0;
+    }
+    match OFFSET_OVERRIDE.with(Cell::get) {
+        Some(source) => source(branches) % branches,
+        None => entropy_offset(branches),
+    }
+}
+
+/// Entropy fallback: xorshift64* over a `RandomState`-seeded thread-local.
+fn entropy_offset(branches: u32) -> u32 {
+    FALLBACK_STATE.with(|state| {
+        let mut s = state.get();
+        if s == 0 {
+            use std::hash::{BuildHasher, Hasher};
+            let hasher = std::collections::hash_map::RandomState::new().build_hasher();
+            // `| 1` keeps the state nonzero (xorshift's fixed point is 0).
+            s = hasher.finish() | 1;
+        }
+        s ^= s >> 12;
+        s ^= s << 25;
+        s ^= s >> 27;
+        state.set(s);
+        let value = (s.wrapping_mul(0x2545_F491_4F6C_DD1D) >> 32) % u64::from(branches);
+        u32::try_from(value).expect("value is < branches, which is a u32")
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zero_and_one_branch_are_always_offset_zero() {
+        assert_eq!(select_offset(0), 0);
+        assert_eq!(select_offset(1), 0);
+    }
+
+    #[test]
+    fn fallback_stays_in_range() {
+        set_select_offset_override(None);
+        for _ in 0..1000 {
+            let offset = select_offset(7);
+            assert!(offset < 7);
+        }
+    }
+
+    #[test]
+    fn override_wins_and_is_reduced_modulo_branches() {
+        fn always_five(_branches: u32) -> u32 {
+            5
+        }
+        set_select_offset_override(Some(always_five));
+        assert_eq!(select_offset(8), 5);
+        assert_eq!(select_offset(3), 2); // 5 % 3
+        set_select_offset_override(None);
+    }
+}

--- a/moonpool-core/src/select_support.rs
+++ b/moonpool-core/src/select_support.rs
@@ -8,16 +8,19 @@
 //!   [`set_select_offset_override`], backed by a seeded RNG stream. Same seed,
 //!   same offsets, exact replay; different seeds explore different branch
 //!   orderings.
-//! - **Production** (no override installed): a thread-local xorshift64* lazily
-//!   seeded from [`std::collections::hash_map::RandomState`] (the same entropy
-//!   trick tokio's own `FastRand` uses). Behaviorally equivalent to tokio's
-//!   fair `select!`, and wasm-clean: no `getrandom`, no OS calls beyond what
-//!   `std` already does for hashers.
+//! - **Production** (no override installed): a thread-local [`SmallRng`]
+//!   lazily seeded from [`std::collections::hash_map::RandomState`] (the same
+//!   entropy trick tokio's own `FastRand` uses). Behaviorally equivalent to
+//!   tokio's fair `select!`, and wasm-clean: seeding from a `u64` pulls no
+//!   `getrandom`, no OS calls beyond what `std` already does for hashers.
 //!
 //! The hook detects the *simulation*, not tokio: the expansion is identical
 //! everywhere, only the number source changes.
 
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
+
+use rand::rngs::SmallRng;
+use rand::{RngExt, SeedableRng};
 
 /// A branch-offset source for [`select!`](crate::select): receives the branch
 /// count `n` and returns the index of the branch to poll first (values are
@@ -27,8 +30,8 @@ pub type SelectOffsetFn = fn(u32) -> u32;
 thread_local! {
     /// Offset source installed by the simulation runtime (None in production).
     static OFFSET_OVERRIDE: Cell<Option<SelectOffsetFn>> = const { Cell::new(None) };
-    /// Lazily seeded xorshift64* state for the entropy fallback (0 = unseeded).
-    static FALLBACK_STATE: Cell<u64> = const { Cell::new(0) };
+    /// Lazily seeded entropy fallback (None until first fair-mode draw).
+    static FALLBACK_RNG: RefCell<Option<SmallRng>> = const { RefCell::new(None) };
 }
 
 /// Install (or clear, with `None`) the branch-offset source used by
@@ -55,22 +58,18 @@ pub fn select_offset(branches: u32) -> u32 {
     }
 }
 
-/// Entropy fallback: xorshift64* over a `RandomState`-seeded thread-local.
+/// Entropy fallback: a `RandomState`-seeded thread-local [`SmallRng`].
 fn entropy_offset(branches: u32) -> u32 {
-    FALLBACK_STATE.with(|state| {
-        let mut s = state.get();
-        if s == 0 {
+    FALLBACK_RNG.with(|cell| {
+        let mut rng = cell.borrow_mut();
+        let rng = rng.get_or_insert_with(|| {
             use std::hash::{BuildHasher, Hasher};
-            let hasher = std::collections::hash_map::RandomState::new().build_hasher();
-            // `| 1` keeps the state nonzero (xorshift's fixed point is 0).
-            s = hasher.finish() | 1;
-        }
-        s ^= s >> 12;
-        s ^= s << 25;
-        s ^= s >> 27;
-        state.set(s);
-        let value = (s.wrapping_mul(0x2545_F491_4F6C_DD1D) >> 32) % u64::from(branches);
-        u32::try_from(value).expect("value is < branches, which is a u32")
+            let seed = std::collections::hash_map::RandomState::new()
+                .build_hasher()
+                .finish();
+            SmallRng::seed_from_u64(seed)
+        });
+        rng.random_range(0..branches)
     })
 }
 

--- a/moonpool-core/src/task.rs
+++ b/moonpool-core/src/task.rs
@@ -49,10 +49,9 @@ pub trait TaskProvider: Clone + Send + Sync + 'static {
 
 /// Tokio-based task provider.
 ///
-/// This provider creates tasks via `tokio::task::Builder::spawn`. When used
-/// inside the sim runtime (`new_current_thread().build()`) the runtime runs
-/// every task on a single OS thread, preserving determinism while still
-/// requiring `Send + 'static` futures.
+/// This provider creates tasks via `tokio::spawn`. The task name is emitted
+/// in `tracing::trace!` spans around the future rather than attached to the
+/// tokio task itself.
 #[cfg(feature = "tokio-task")]
 #[derive(Clone, Debug)]
 pub struct TokioTaskProvider;
@@ -98,19 +97,7 @@ impl TaskProvider for TokioTaskProvider {
             future.await;
             tracing::trace!("Task {} completed", task_name);
         };
-        // `tokio::task::Builder` gives the task a name for tokio-console, but it is
-        // only available under `--cfg tokio_unstable`. Gate it so the crate still
-        // builds on stable toolchains without requiring that flag workspace-wide
-        // (which would force every downstream consumer to set it too). The task
-        // name is preserved in the trace spans above regardless of the runtime.
-        #[cfg(tokio_unstable)]
-        let inner = tokio::task::Builder::new()
-            .name(name)
-            .spawn(fut)
-            .expect("Failed to spawn task");
-        #[cfg(not(tokio_unstable))]
-        let inner = tokio::spawn(fut);
-        TokioJoinHandle(inner)
+        TokioJoinHandle(tokio::spawn(fut))
     }
 
     async fn yield_now(&self) {

--- a/moonpool-core/tests/select.rs
+++ b/moonpool-core/tests/select.rs
@@ -1,0 +1,229 @@
+//! Behavior tests for the deterministic `select!` rotation combinator.
+//!
+//! These run WITHOUT any async runtime (`futures::executor::block_on`), which
+//! is itself part of the proof: the combinator must work on a foreign
+//! executor, where tokio's own fair `select!` would fall back to OS entropy.
+#![cfg(feature = "deterministic-select")]
+
+use std::cell::Cell;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use futures::executor::block_on;
+use moonpool_core::select_support::set_select_offset_override;
+
+/// Three always-ready branches returning their own index: with rotation
+/// offset `k`, branch `k` is polled first and wins.
+fn three_way() -> u32 {
+    block_on(async {
+        moonpool_core::select! {
+            a = async { 0_u32 } => a,
+            b = async { 1_u32 } => b,
+            c = async { 2_u32 } => c,
+        }
+    })
+}
+
+static THREE_WAY_OFFSET: AtomicU32 = AtomicU32::new(0);
+
+fn three_way_offset(_branches: u32) -> u32 {
+    THREE_WAY_OFFSET.load(Ordering::Relaxed)
+}
+
+#[test]
+fn rotation_offset_picks_the_winner() {
+    set_select_offset_override(Some(three_way_offset));
+    for k in 0..3 {
+        THREE_WAY_OFFSET.store(k, Ordering::Relaxed);
+        assert_eq!(three_way(), k, "offset {k} must make branch {k} win");
+    }
+    set_select_offset_override(None);
+}
+
+#[test]
+fn biased_mode_polls_in_source_order() {
+    // No override installed: biased mode must not draw an offset at all.
+    let winner = block_on(async {
+        moonpool_core::select! {
+            biased;
+            a = async { 1_u32 } => a,
+            b = async { 2_u32 } => b,
+        }
+    });
+    assert_eq!(winner, 1);
+}
+
+fn offset_zero(_branches: u32) -> u32 {
+    0
+}
+
+#[test]
+fn precondition_disables_a_branch() {
+    set_select_offset_override(Some(offset_zero));
+    let winner = block_on(async {
+        moonpool_core::select! {
+            a = async { 1_u32 }, if false => a,
+            b = async { 2_u32 } => b,
+        }
+    });
+    assert_eq!(
+        winner, 2,
+        "disabled branch must be skipped even when polled first"
+    );
+    set_select_offset_override(None);
+}
+
+#[test]
+fn refutable_pattern_falls_through() {
+    set_select_offset_override(Some(offset_zero));
+    let winner = block_on(async {
+        moonpool_core::select! {
+            Some(v) = async { None::<u32> } => v,
+            w = async { 7_u32 } => w,
+        }
+    });
+    assert_eq!(winner, 7);
+    set_select_offset_override(None);
+}
+
+static ELSE_OFFSET: AtomicU32 = AtomicU32::new(0);
+
+fn else_offset(_branches: u32) -> u32 {
+    ELSE_OFFSET.load(Ordering::Relaxed)
+}
+
+#[test]
+fn else_fires_when_all_branches_are_disabled() {
+    // The else handler must be present (and last) in EVERY rotation.
+    set_select_offset_override(Some(else_offset));
+    for k in 0..2 {
+        ELSE_OFFSET.store(k, Ordering::Relaxed);
+        let winner = block_on(async {
+            moonpool_core::select! {
+                a = async { 1_u32 }, if false => a,
+                b = async { 2_u32 }, if false => b,
+                else => 42_u32,
+            }
+        });
+        assert_eq!(winner, 42, "offset {k}");
+    }
+    set_select_offset_override(None);
+}
+
+#[test]
+fn single_branch_without_trailing_comma() {
+    let winner = block_on(async {
+        moonpool_core::select! { x = async { 5_u32 } => x }
+    });
+    assert_eq!(winner, 5);
+}
+
+#[test]
+fn borrowed_future_branch() {
+    // Mirrors the delivery.rs idiom: polling a pinned future by `&mut` reference.
+    let winner = block_on(async {
+        let mut signal = std::future::pending::<()>();
+        moonpool_core::select! {
+            r = async { 1_u32 } => r,
+            () = &mut signal => 0_u32,
+        }
+    });
+    assert_eq!(winner, 1);
+}
+
+#[test]
+fn loop_control_flow_in_handlers() {
+    let mut hits = 0_u32;
+    block_on(async {
+        loop {
+            moonpool_core::select! {
+                () = async {} => {
+                    hits += 1;
+                    if hits == 3 {
+                        break;
+                    }
+                },
+                () = std::future::pending::<()>() => {},
+            }
+        }
+    });
+    assert_eq!(hits, 3);
+}
+
+thread_local! {
+    static SEQ: Cell<u32> = const { Cell::new(0) };
+}
+
+fn sequenced_offset(branches: u32) -> u32 {
+    SEQ.with(|c| {
+        let v = c.get();
+        c.set(v.wrapping_add(1));
+        v
+    }) % branches
+}
+
+#[test]
+fn identical_offset_sequences_give_identical_winners() {
+    set_select_offset_override(Some(sequenced_offset));
+    let run = || -> Vec<u32> {
+        SEQ.with(|c| c.set(0));
+        (0..10).map(|_| three_way()).collect()
+    };
+    let first = run();
+    let second = run();
+    assert_eq!(first, second, "same offset stream must replay identically");
+    assert!(
+        first.iter().any(|&w| w != first[0]),
+        "a varying offset stream must produce varying winners"
+    );
+    set_select_offset_override(None);
+}
+
+static SIXTEEN_OFFSET: AtomicU32 = AtomicU32::new(0);
+
+fn sixteen_offset(_branches: u32) -> u32 {
+    SIXTEEN_OFFSET.load(Ordering::Relaxed)
+}
+
+#[test]
+fn sixteen_branches_at_every_offset() {
+    set_select_offset_override(Some(sixteen_offset));
+    for k in 0..16 {
+        SIXTEEN_OFFSET.store(k, Ordering::Relaxed);
+        let winner = block_on(async {
+            moonpool_core::select! {
+                v = async { 0_u32 } => v,
+                v = async { 1_u32 } => v,
+                v = async { 2_u32 } => v,
+                v = async { 3_u32 } => v,
+                v = async { 4_u32 } => v,
+                v = async { 5_u32 } => v,
+                v = async { 6_u32 } => v,
+                v = async { 7_u32 } => v,
+                v = async { 8_u32 } => v,
+                v = async { 9_u32 } => v,
+                v = async { 10_u32 } => v,
+                v = async { 11_u32 } => v,
+                v = async { 12_u32 } => v,
+                v = async { 13_u32 } => v,
+                v = async { 14_u32 } => v,
+                v = async { 15_u32 } => v,
+            }
+        });
+        assert_eq!(winner, k, "offset {k} must make branch {k} win");
+    }
+    set_select_offset_override(None);
+}
+
+#[test]
+fn entropy_fallback_still_completes() {
+    // No override: production behavior. One branch pending, so the winner is
+    // fixed regardless of the entropy-drawn offset.
+    set_select_offset_override(None);
+    let winner = block_on(async {
+        moonpool_core::select! {
+            r = async { 9_u32 } => r,
+            () = std::future::pending::<()>() => 0_u32,
+        }
+    });
+    assert_eq!(winner, 9);
+}

--- a/moonpool-core/tests/select.rs
+++ b/moonpool-core/tests/select.rs
@@ -1,8 +1,9 @@
-//! Behavior tests for the deterministic `select!` rotation combinator.
+//! Behavior tests for the deterministic `select!` macro (tokio's expansion
+//! with a moonpool-controlled start offset).
 //!
 //! These run WITHOUT any async runtime (`futures::executor::block_on`), which
-//! is itself part of the proof: the combinator must work on a foreign
-//! executor, where tokio's own fair `select!` would fall back to OS entropy.
+//! is itself part of the proof: the macro must work on a foreign executor,
+//! where tokio's own fair `select!` would fall back to OS entropy.
 #![cfg(feature = "deterministic-select")]
 
 use std::cell::Cell;
@@ -11,7 +12,7 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use futures::executor::block_on;
 use moonpool_core::select_support::set_select_offset_override;
 
-/// Three always-ready branches returning their own index: with rotation
+/// Three always-ready branches returning their own index: with start
 /// offset `k`, branch `k` is polled first and wins.
 fn three_way() -> u32 {
     block_on(async {
@@ -30,7 +31,7 @@ fn three_way_offset(_branches: u32) -> u32 {
 }
 
 #[test]
-fn rotation_offset_picks_the_winner() {
+fn start_offset_picks_the_winner() {
     set_select_offset_override(Some(three_way_offset));
     for k in 0..3 {
         THREE_WAY_OFFSET.store(k, Ordering::Relaxed);
@@ -93,7 +94,7 @@ fn else_offset(_branches: u32) -> u32 {
 
 #[test]
 fn else_fires_when_all_branches_are_disabled() {
-    // The else handler must be present (and last) in EVERY rotation.
+    // The else handler must fire whatever the drawn offset is.
     set_select_offset_override(Some(else_offset));
     for k in 0..2 {
         ELSE_OFFSET.store(k, Ordering::Relaxed);
@@ -211,6 +212,98 @@ fn sixteen_branches_at_every_offset() {
         });
         assert_eq!(winner, k, "offset {k} must make branch {k} win");
     }
+    set_select_offset_override(None);
+}
+
+static TWENTY_OFFSET: AtomicU32 = AtomicU32::new(0);
+
+fn twenty_offset(_branches: u32) -> u32 {
+    TWENTY_OFFSET.load(Ordering::Relaxed)
+}
+
+#[test]
+fn twenty_branches_beyond_the_former_cap() {
+    // The rotation combinator this macro replaced capped out at 16 branches;
+    // tokio's own expansion (which we now enter directly) allows 64.
+    set_select_offset_override(Some(twenty_offset));
+    for k in 0..20 {
+        TWENTY_OFFSET.store(k, Ordering::Relaxed);
+        let winner = block_on(async {
+            moonpool_core::select! {
+                v = async { 0_u32 } => v,
+                v = async { 1_u32 } => v,
+                v = async { 2_u32 } => v,
+                v = async { 3_u32 } => v,
+                v = async { 4_u32 } => v,
+                v = async { 5_u32 } => v,
+                v = async { 6_u32 } => v,
+                v = async { 7_u32 } => v,
+                v = async { 8_u32 } => v,
+                v = async { 9_u32 } => v,
+                v = async { 10_u32 } => v,
+                v = async { 11_u32 } => v,
+                v = async { 12_u32 } => v,
+                v = async { 13_u32 } => v,
+                v = async { 14_u32 } => v,
+                v = async { 15_u32 } => v,
+                v = async { 16_u32 } => v,
+                v = async { 17_u32 } => v,
+                v = async { 18_u32 } => v,
+                v = async { 19_u32 } => v,
+            }
+        });
+        assert_eq!(winner, k, "offset {k} must make branch {k} win");
+    }
+    set_select_offset_override(None);
+}
+
+/// Future that returns `Pending` (self-waking) a fixed number of times, then
+/// `Ready`.
+struct ReadyAfter {
+    pending_polls: u32,
+}
+
+impl std::future::Future for ReadyAfter {
+    type Output = ();
+
+    fn poll(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<()> {
+        if self.pending_polls == 0 {
+            std::task::Poll::Ready(())
+        } else {
+            self.pending_polls -= 1;
+            cx.waker().wake_by_ref();
+            std::task::Poll::Pending
+        }
+    }
+}
+
+static DRAW_COUNT: AtomicU32 = AtomicU32::new(0);
+
+fn counting_offset(_branches: u32) -> u32 {
+    DRAW_COUNT.fetch_add(1, Ordering::Relaxed);
+    0
+}
+
+#[test]
+fn offset_is_redrawn_on_every_poll() {
+    // tokio's fair mode redraws the start offset on each poll of the same
+    // select execution; the injected expression must inherit that.
+    set_select_offset_override(Some(counting_offset));
+    DRAW_COUNT.store(0, Ordering::Relaxed);
+    block_on(async {
+        moonpool_core::select! {
+            () = ReadyAfter { pending_polls: 2 } => {},
+            () = std::future::pending::<()>() => {},
+        }
+    });
+    assert_eq!(
+        DRAW_COUNT.load(Ordering::Relaxed),
+        3,
+        "three polls of one execution must draw three offsets"
+    );
     set_select_offset_override(None);
 }
 

--- a/moonpool-core/tests/select_passthrough.rs
+++ b/moonpool-core/tests/select_passthrough.rs
@@ -1,0 +1,30 @@
+//! With `select` but WITHOUT `deterministic-select`, `moonpool_core::select!`
+//! must be tokio's macro verbatim (the production passthrough).
+#![cfg(all(feature = "select", not(feature = "deterministic-select")))]
+
+use futures::executor::block_on;
+
+#[test]
+fn passthrough_biased_polls_in_source_order() {
+    let winner = block_on(async {
+        moonpool_core::select! {
+            biased;
+            a = async { 1_u32 } => a,
+            b = async { 2_u32 } => b,
+        }
+    });
+    assert_eq!(winner, 1);
+}
+
+#[test]
+fn passthrough_fair_mode_works_off_any_runtime() {
+    // tokio's fair select off-runtime draws an entropy offset; with a single
+    // ready branch the winner is fixed either way.
+    let winner = block_on(async {
+        moonpool_core::select! {
+            r = async { 3_u32 } => r,
+            () = std::future::pending::<()>() => 0_u32,
+        }
+    });
+    assert_eq!(winner, 3);
+}

--- a/moonpool-sim-examples/src/axum_web.rs
+++ b/moonpool-sim-examples/src/axum_web.rs
@@ -235,6 +235,7 @@ impl Process for WebProcess {
     }
 
     async fn run(&mut self, ctx: &SimContext) -> SimulationResult<()> {
+        use futures::FutureExt;
         use futures::stream::{FuturesUnordered, StreamExt};
 
         let store = InMemoryStore::new();
@@ -250,7 +251,11 @@ impl Process for WebProcess {
         let mut connections = FuturesUnordered::new();
 
         loop {
-            tokio::select! {
+            // Deliberately NOT `biased;`: accept (new connection) and
+            // connections.next() (progress on in-flight connections) are peer
+            // data sources; the seeded rotation lets different seeds explore
+            // both orderings when both are ready.
+            moonpool_sim::select! {
                 accept = listener.accept() => {
                     let (stream, addr) = accept?;
                     tracing::info!(%addr, "accepted connection");
@@ -261,16 +266,25 @@ impl Process for WebProcess {
                     let io = TokioIo::new(stream.compat());
                     let service = TowerToHyperService::new(app.clone());
 
-                    connections.push(async move {
-                        tracing::info!("serve_connection starting");
-                        if let Err(e) = hyper::server::conn::http1::Builder::new()
-                            .serve_connection(io, service)
-                            .await
-                        {
-                            tracing::warn!("hyper serve_connection error (expected under chaos): {e}");
+                    // boxed_local: select! duplicates this handler once per
+                    // rotation, and each copy's async block is a distinct
+                    // anonymous type; boxing gives `connections` one named
+                    // element type shared by all copies.
+                    connections.push(
+                        async move {
+                            tracing::info!("serve_connection starting");
+                            if let Err(e) = hyper::server::conn::http1::Builder::new()
+                                .serve_connection(io, service)
+                                .await
+                            {
+                                tracing::warn!(
+                                    "hyper serve_connection error (expected under chaos): {e}"
+                                );
+                            }
+                            tracing::info!("serve_connection finished");
                         }
-                        tracing::info!("serve_connection finished");
-                    });
+                        .boxed(),
+                    );
                 }
                 Some(()) = connections.next(), if !connections.is_empty() => {}
                 () = ctx.shutdown().cancelled() => {
@@ -308,7 +322,8 @@ impl Workload for WebWorkload {
         // a chaos-induced connect hang is detected as no-progress).
         for round in 0..5 {
             tracing::info!(round, "starting round");
-            let result = tokio::select! {
+            let result = moonpool_sim::select! {
+                biased;
                 result = self.send_round(ctx, &server_ip, round) => result,
                 () = ctx.shutdown().cancelled() => {
                     tracing::info!(round, "shutdown during round, exiting");
@@ -341,7 +356,8 @@ impl WebWorkload {
         round: u32,
     ) -> SimulationResult<()> {
         tracing::info!(round, "connecting to server");
-        let stream = tokio::select! {
+        let stream = moonpool_sim::select! {
+            biased;
             result = ctx.network().connect(server_ip) => result?,
             () = ctx.shutdown().cancelled() => return Ok(()),
         };
@@ -360,7 +376,7 @@ impl WebWorkload {
             }
             tracing::info!("client conn driver finished");
         };
-        tokio::pin!(driver);
+        let _driver = std::pin::pin!(driver);
 
         Self::check_health(&mut sender, server_ip, round).await?;
         Self::create_and_read_item(&mut sender, server_ip, round).await?;

--- a/moonpool-sim-examples/src/axum_web.rs
+++ b/moonpool-sim-examples/src/axum_web.rs
@@ -235,7 +235,6 @@ impl Process for WebProcess {
     }
 
     async fn run(&mut self, ctx: &SimContext) -> SimulationResult<()> {
-        use futures::FutureExt;
         use futures::stream::{FuturesUnordered, StreamExt};
 
         let store = InMemoryStore::new();
@@ -253,8 +252,8 @@ impl Process for WebProcess {
         loop {
             // Deliberately NOT `biased;`: accept (new connection) and
             // connections.next() (progress on in-flight connections) are peer
-            // data sources; the seeded rotation lets different seeds explore
-            // both orderings when both are ready.
+            // data sources; the seeded start offset lets different seeds
+            // explore both orderings when both are ready.
             moonpool_sim::select! {
                 accept = listener.accept() => {
                     let (stream, addr) = accept?;
@@ -266,25 +265,18 @@ impl Process for WebProcess {
                     let io = TokioIo::new(stream.compat());
                     let service = TowerToHyperService::new(app.clone());
 
-                    // boxed_local: select! duplicates this handler once per
-                    // rotation, and each copy's async block is a distinct
-                    // anonymous type; boxing gives `connections` one named
-                    // element type shared by all copies.
-                    connections.push(
-                        async move {
-                            tracing::info!("serve_connection starting");
-                            if let Err(e) = hyper::server::conn::http1::Builder::new()
-                                .serve_connection(io, service)
-                                .await
-                            {
-                                tracing::warn!(
-                                    "hyper serve_connection error (expected under chaos): {e}"
-                                );
-                            }
-                            tracing::info!("serve_connection finished");
+                    connections.push(async move {
+                        tracing::info!("serve_connection starting");
+                        if let Err(e) = hyper::server::conn::http1::Builder::new()
+                            .serve_connection(io, service)
+                            .await
+                        {
+                            tracing::warn!(
+                                "hyper serve_connection error (expected under chaos): {e}"
+                            );
                         }
-                        .boxed(),
-                    );
+                        tracing::info!("serve_connection finished");
+                    });
                 }
                 Some(()) = connections.next(), if !connections.is_empty() => {}
                 () = ctx.shutdown().cancelled() => {

--- a/moonpool-sim-examples/src/axum_web.rs
+++ b/moonpool-sim-examples/src/axum_web.rs
@@ -376,11 +376,22 @@ impl WebWorkload {
             }
             tracing::info!("client conn driver finished");
         };
-        let _driver = std::pin::pin!(driver);
 
-        Self::check_health(&mut sender, server_ip, round).await?;
-        Self::create_and_read_item(&mut sender, server_ip, round).await?;
-        Self::check_not_found(&mut sender, server_ip, round).await?;
+        // hyper's SendRequest only makes progress while the Connection future
+        // is polled, so the driver MUST be raced alongside the requests (a
+        // merely pinned-but-never-polled driver leaves every request pending
+        // forever). Same idiom as the hyper_http integration test.
+        moonpool_sim::select! {
+            biased;
+            result = async {
+                Self::check_health(&mut sender, server_ip, round).await?;
+                Self::create_and_read_item(&mut sender, server_ip, round).await?;
+                Self::check_not_found(&mut sender, server_ip, round).await?;
+                Ok::<(), moonpool_sim::SimulationError>(())
+            } => result?,
+            // Connection died first (expected under chaos): give up the round.
+            () = driver => {}
+        }
 
         Ok(())
     }

--- a/moonpool-sim-examples/src/topology.rs
+++ b/moonpool-sim-examples/src/topology.rs
@@ -72,7 +72,8 @@ impl Process for TopologyProcess {
 
         let listener = ctx.network().bind(ctx.my_ip()).await?;
         loop {
-            let accepted = tokio::select! {
+            let accepted = moonpool_sim::select! {
+                biased;
                 r = listener.accept() => r,
                 () = ctx.shutdown().cancelled() => return Ok(()),
             };

--- a/moonpool-sim/Cargo.toml
+++ b/moonpool-sim/Cargo.toml
@@ -28,7 +28,9 @@ exploration = ["dep:moonpool-explorer"]
 [dependencies]
 # SimProviders always bundles the real TokioTaskProvider (single-thread executor),
 # so tokio-task is mandatory; net/fs/time come in only via the tokio-providers feature.
-moonpool-core = { path = "../moonpool-core", version = "0.7.0", default-features = false, features = ["tokio-task"] }
+# deterministic-select flips moonpool_core::select! to the seeded rotation combinator
+# for every crate in a sim-linking build graph (cargo feature unification).
+moonpool-core = { path = "../moonpool-core", version = "0.7.0", default-features = false, features = ["tokio-task", "deterministic-select"] }
 # Assertion accounting (pure std, wasm-able) — always present. The fork-based
 # exploration backend below is optional and layers on top of it.
 moonpool-assertions = { path = "../moonpool-assertions", version = "0.7.0" }

--- a/moonpool-sim/Cargo.toml
+++ b/moonpool-sim/Cargo.toml
@@ -25,7 +25,7 @@ exploration = ["dep:moonpool-explorer"]
 # SimProviders bundles SimTaskProvider on the moonpool deterministic executor,
 # so no core tokio feature is mandatory; net/fs/time (and TokioTaskProvider for
 # conformance testing) come in only via the tokio-providers feature.
-# deterministic-select flips moonpool_core::select! to the seeded rotation combinator
+# deterministic-select flips moonpool_core::select! to the seeded-offset expansion
 # for every crate in a sim-linking build graph (cargo feature unification).
 moonpool-core = { path = "../moonpool-core", version = "0.7.0", default-features = false, features = ["deterministic-select"] }
 # Assertion accounting (pure std, wasm-able) — always present. The fork-based

--- a/moonpool-sim/Cargo.toml
+++ b/moonpool-sim/Cargo.toml
@@ -26,16 +26,20 @@ tokio-providers = ["moonpool-core/tokio-providers"]
 exploration = ["dep:moonpool-explorer"]
 
 [dependencies]
-# SimProviders always bundles the real TokioTaskProvider (single-thread executor),
-# so tokio-task is mandatory; net/fs/time come in only via the tokio-providers feature.
+# SimProviders bundles SimTaskProvider on the moonpool deterministic executor,
+# so no core tokio feature is mandatory; net/fs/time (and TokioTaskProvider for
+# conformance testing) come in only via the tokio-providers feature.
 # deterministic-select flips moonpool_core::select! to the seeded rotation combinator
 # for every crate in a sim-linking build graph (cargo feature unification).
-moonpool-core = { path = "../moonpool-core", version = "0.7.0", default-features = false, features = ["tokio-task", "deterministic-select"] }
+moonpool-core = { path = "../moonpool-core", version = "0.7.0", default-features = false, features = ["deterministic-select"] }
 # Assertion accounting (pure std, wasm-able) — always present. The fork-based
 # exploration backend below is optional and layers on top of it.
 moonpool-assertions = { path = "../moonpool-assertions", version = "0.7.0" }
 moonpool-explorer = { path = "../moonpool-explorer", version = "0.7.0", optional = true }
 
+# Runnable/Task split, waker wiring, join + cancellation for the deterministic
+# executor (same backbone as madsim); no_std-able, no runtime of its own.
+async-task = "4.7"
 async-trait = "0.1"
 crc32c = "0.6"
 futures = "0.3"
@@ -46,12 +50,10 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2.0"
 parking_lot = "0.12"
-# Library code uses tokio::spawn / task::JoinHandle / yield_now (rt),
-# Notify / mpsc (sync), select! (macros), and the named-task instrumentation
-# that TokioTaskProvider relies on (tracing + tokio_unstable). The per-seed
-# runtime uses runtime::Builder + RngSeed (rt). No net/fs/time in lib code.
-# Tests pull "full" via dev-dependencies.
-tokio = { version = "1", features = ["rt", "sync", "macros", "tracing"] }
+# No tokio in library code: tasks run on the moonpool deterministic executor
+# (async-task) and select! comes from moonpool-core. Tests pull tokio "full"
+# via dev-dependencies for #[tokio::test]-style SimWorld unit tests.
+# tokio-util: CancellationToken (shutdown signalling) + compat (io bridging).
 tokio-util = { version = "0.7", features = ["compat"] }
 tracing = "0.1"
 

--- a/moonpool-sim/Cargo.toml
+++ b/moonpool-sim/Cargo.toml
@@ -9,15 +9,11 @@ description = "Simulation engine for the moonpool framework"
 documentation = "https://docs.rs/moonpool-sim"
 readme = "README.md"
 
-[package.metadata.docs.rs]
-rustdoc-args = ["--cfg", "tokio_unstable"]
-rustc-args = ["--cfg", "tokio_unstable"]
-
 [features]
 # tokio-providers re-exports core's production provider bundle (TokioProviders,
-# TokioNetworkProvider, TokioTimeProvider) for examples/tests that drive the same
-# code under prod + sim. Default-on; disable for a wasm-able sim
-# (`--no-default-features`), which still keeps TokioTaskProvider via core/tokio-task.
+# TokioNetworkProvider, TokioTaskProvider, TokioTimeProvider) for examples/tests
+# that drive the same code under prod + sim. Default-on; disable for a wasm-able
+# sim (`--no-default-features`), which runs tasks on the moonpool executor.
 default = ["tokio-providers", "exploration"]
 tokio-providers = ["moonpool-core/tokio-providers"]
 # Fork-based multiverse exploration (libc/mmap — never wasm). When off, assertion

--- a/moonpool-sim/src/executor/join.rs
+++ b/moonpool-sim/src/executor/join.rs
@@ -55,9 +55,17 @@ impl<T> JoinHandle<T> {
     /// Abort the task: it will never be polled again and its future is
     /// dropped. Awaiting the handle afterwards yields
     /// `Err(JoinError::Cancelled)`.
+    ///
+    /// Aborting a task that already finished is a no-op and awaiting the
+    /// handle still yields the task's output (tokio parity: abort racing
+    /// completion loses).
     pub fn abort(&self) {
-        // Dropping the FallibleTask cancels the task (async-task semantics).
-        drop(self.inner.lock().take());
+        let mut inner = self.inner.lock();
+        // A finished task keeps its output harvestable; only a live task is
+        // cancelled (dropping the FallibleTask cancels, async-task semantics).
+        if inner.as_ref().is_some_and(|task| !task.is_finished()) {
+            drop(inner.take());
+        }
     }
 }
 
@@ -132,12 +140,14 @@ pub fn yield_now() -> YieldNow {
 ///
 /// # Panics
 ///
-/// Debug builds panic when called from inside a task: a task awaiting
-/// "drain until nothing is runnable" would deadlock against itself. Tasks
-/// yield with [`yield_now`].
+/// Panics when called from inside a task (all builds): a task awaiting
+/// "drain until nothing is runnable" would silently degrade to plain
+/// [`yield_now`] semantics, resuming mid-drain while believing every
+/// runnable task quiesced. That contract violation must not survive only
+/// in release. Tasks yield with [`yield_now`].
 #[must_use = "futures do nothing unless awaited"]
 pub fn until_stalled() -> YieldNow {
-    debug_assert!(
+    assert!(
         !super::in_task(),
         "until_stalled() is driver-only; tasks must use executor::yield_now()"
     );

--- a/moonpool-sim/src/executor/join.rs
+++ b/moonpool-sim/src/executor/join.rs
@@ -1,0 +1,145 @@
+//! Join handles and yield primitives for the deterministic executor.
+
+use std::any::Any;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use async_task::FallibleTask;
+use moonpool_core::JoinError;
+use parking_lot::Mutex;
+
+use super::TaskMeta;
+
+/// A task's raw output: the value, or the payload of the panic that killed it
+/// (captured by the `catch_unwind` wrapper installed at spawn).
+pub(crate) type TaskResult<T> = Result<T, Box<dyn Any + Send>>;
+
+/// Owned handle to a spawned task, mirroring `tokio::task::JoinHandle`
+/// semantics.
+///
+/// - `.await` resolves to `Ok(output)`, or `Err(JoinError::Cancelled)` after
+///   [`abort`](Self::abort), or `Err(JoinError::Panicked)` if the task
+///   panicked (siblings and the executor are unaffected).
+/// - Dropping the handle **detaches** the task: it keeps running to
+///   completion. Only [`abort`](Self::abort) or dropping the whole
+///   [`Executor`](super::Executor) cancels it.
+/// - [`is_finished`](Self::is_finished) is a non-blocking completion probe.
+#[derive(Debug)]
+pub struct JoinHandle<T> {
+    /// `None` after `abort()` consumed the inner task (async-task cancels a
+    /// task when its `Task`/`FallibleTask` handle is dropped). The `Mutex`
+    /// (uncontended, single-threaded) exists so `abort(&self)` can take the
+    /// inner value while the handle satisfies the `Sync` bound that
+    /// `TaskProvider::JoinHandle` requires.
+    inner: Mutex<Option<FallibleTask<TaskResult<T>, TaskMeta>>>,
+}
+
+impl<T> JoinHandle<T> {
+    pub(crate) fn new(task: FallibleTask<TaskResult<T>, TaskMeta>) -> Self {
+        Self {
+            inner: Mutex::new(Some(task)),
+        }
+    }
+
+    /// Report whether the task has finished running (completed, panicked, or
+    /// was aborted). Non-blocking; mirrors `tokio::task::JoinHandle::is_finished`.
+    #[must_use]
+    pub fn is_finished(&self) -> bool {
+        match self.inner.lock().as_ref() {
+            Some(task) => task.is_finished(),
+            None => true,
+        }
+    }
+
+    /// Abort the task: it will never be polled again and its future is
+    /// dropped. Awaiting the handle afterwards yields
+    /// `Err(JoinError::Cancelled)`.
+    pub fn abort(&self) {
+        // Dropping the FallibleTask cancels the task (async-task semantics).
+        drop(self.inner.lock().take());
+    }
+}
+
+impl<T> Future for JoinHandle<T> {
+    type Output = Result<T, JoinError>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut inner = self.inner.lock();
+        match inner.as_mut() {
+            // Aborted through this handle.
+            None => Poll::Ready(Err(JoinError::Cancelled)),
+            Some(task) => match Pin::new(task).poll(cx) {
+                Poll::Pending => Poll::Pending,
+                // Cancelled elsewhere (executor drop) before completing.
+                Poll::Ready(None) => Poll::Ready(Err(JoinError::Cancelled)),
+                Poll::Ready(Some(Ok(output))) => Poll::Ready(Ok(output)),
+                Poll::Ready(Some(Err(_panic_payload))) => Poll::Ready(Err(JoinError::Panicked)),
+            },
+        }
+    }
+}
+
+impl<T> Drop for JoinHandle<T> {
+    fn drop(&mut self) {
+        // Detach-on-drop (tokio parity): the task keeps running.
+        if let Some(task) = self.inner.lock().take() {
+            task.detach();
+        }
+    }
+}
+
+/// Future returned by [`yield_now`] and [`until_stalled`]: pends once,
+/// waking its own waker, then completes on the next poll.
+#[derive(Debug)]
+pub struct YieldNow {
+    yielded: bool,
+}
+
+impl Future for YieldNow {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+        if self.yielded {
+            Poll::Ready(())
+        } else {
+            self.yielded = true;
+            cx.waker().wake_by_ref();
+            Poll::Pending
+        }
+    }
+}
+
+/// Yield control from inside a task.
+///
+/// The task is rescheduled into the ready queue and resumes at a
+/// seeded-random position among the runnable tasks (there is no "back of
+/// the queue" under randomized scheduling).
+#[must_use = "futures do nothing unless awaited"]
+pub fn yield_now() -> YieldNow {
+    YieldNow { yielded: false }
+}
+
+/// Driver-only: resume after every currently-runnable task has been polled
+/// to `Pending` or completion.
+///
+/// Awaited by the orchestrator's step loops between `sim.step()` calls.
+/// Mechanically identical to [`yield_now`], but because
+/// [`Executor::block_on`](super::Executor::block_on) only re-polls the
+/// driver after a full `run_until_stalled` drain, awaiting this from the
+/// driver guarantees the "all runnable tasks ran" contract that the old
+/// tokio-FIFO `yield_now` dance only approximated.
+///
+/// # Panics
+///
+/// Debug builds panic when called from inside a task: a task awaiting
+/// "drain until nothing is runnable" would deadlock against itself. Tasks
+/// yield with [`yield_now`].
+#[must_use = "futures do nothing unless awaited"]
+pub fn until_stalled() -> YieldNow {
+    debug_assert!(
+        !super::in_task(),
+        "until_stalled() is driver-only; tasks must use executor::yield_now()"
+    );
+    YieldNow { yielded: false }
+}

--- a/moonpool-sim/src/executor/mod.rs
+++ b/moonpool-sim/src/executor/mod.rs
@@ -127,13 +127,16 @@ use rand_chacha::ChaCha8Rng;
 /// uncounted: scheduling never perturbs fork-explorer breakpoint replay.
 const EXEC_RNG_SALT: u64 = 0x6578_6563_7363_6864; // "execschd"
 
-/// Debug-build ceiling on polls within one `run_until_stalled` drain.
+/// Ceiling on polls within one `run_until_stalled` drain (all builds).
 ///
-/// A task that unconditionally re-wakes itself forever (e.g. a busy
-/// `yield_now` loop with no exit) would make drain-until-empty spin
-/// endlessly; in debug builds we panic with the offending task's name
-/// instead of hanging.
-#[cfg(debug_assertions)]
+/// A task that unconditionally re-wakes itself forever (a busy `yield_now`
+/// loop with no exit, or a select over a source it synchronously re-readies,
+/// which tokio's cooperative budget used to interrupt) would make
+/// drain-until-empty spin endlessly and starve the driver, so `sim.step()`
+/// and every deadlock detector become unreachable. Panicking with the task's
+/// name and the seed beats hanging, and one counter increment per poll is
+/// noise next to the poll itself, so the bound is unconditional rather than
+/// debug-only: release CI is exactly where a silent hang hurts most.
 const DRAIN_POLL_BOUND: u64 = 1_000_000;
 
 /// Per-task metadata attached through `async_task::Builder::metadata`.
@@ -198,11 +201,15 @@ struct DriverWaker {
 
 impl Wake for DriverWaker {
     fn wake(self: Arc<Self>) {
-        self.woken.store(true, Ordering::Relaxed);
+        self.wake_by_ref();
     }
 
     fn wake_by_ref(self: &Arc<Self>) {
-        self.woken.store(true, Ordering::Relaxed);
+        // Release pairs with the Acquire load in block_on's stall check, so a
+        // wake fired just before the check is never missed on ordering
+        // grounds. Wakes are expected from this thread only (the executor is
+        // single-threaded); see the stall panic message for the contract.
+        self.woken.store(true, Ordering::Release);
     }
 }
 
@@ -229,12 +236,16 @@ impl Handle {
         let caught = AssertUnwindSafe(future).catch_unwind();
         // The guard unregisters the task's waker whenever the future is
         // dropped, keeping the kill-on-drop registry bounded by live tasks.
-        let guard_shared = Arc::clone(&self.shared);
+        // Constructed HERE (not inside the async block) so it lives in the
+        // future's captures: a task aborted before its first poll drops the
+        // capture and still unregisters; a guard built inside the block would
+        // never exist for a never-polled future and leak the entry.
+        let unregister = Unregister {
+            id,
+            shared: Arc::clone(&self.shared),
+        };
         let wrapped = async move {
-            let _unregister = Unregister {
-                id,
-                shared: guard_shared,
-            };
+            let _unregister = unregister;
             caught.await
         };
 
@@ -375,10 +386,12 @@ impl Executor {
             self.run_until_stalled();
 
             assert!(
-                driver_waker.woken.load(Ordering::Relaxed) || !self.shared.queue.lock().is_empty(),
+                driver_waker.woken.load(Ordering::Acquire) || !self.shared.queue.lock().is_empty(),
                 "deterministic executor stalled (seed {}): the driver future is not \
                  woken and no task is runnable, so every remaining future awaits a \
-                 wake that can never arrive",
+                 wake that can never arrive (note: the executor is single-threaded; \
+                 a wake signaled from another OS thread is unsupported and can race \
+                 this check)",
                 self.seed
             );
         }
@@ -389,7 +402,6 @@ impl Executor {
     /// The queue lock is released around every `runnable.run()` (fork
     /// safety; wakes fired during a poll re-acquire it to enqueue).
     fn run_until_stalled(&mut self) {
-        #[cfg(debug_assertions)]
         let mut polls: u64 = 0;
 
         loop {
@@ -398,22 +410,26 @@ impl Executor {
                 if queue.is_empty() {
                     break;
                 }
-                let index = self.rng.random_range(0..queue.len());
+                // A single runnable is a forced choice: skip the RNG draw on
+                // the dominant one-event-wakes-one-task path (the stream is
+                // uncounted, so draw counts are not a stability contract).
+                let index = if queue.len() == 1 {
+                    0
+                } else {
+                    self.rng.random_range(0..queue.len())
+                };
                 queue.swap_remove(index)
             };
 
-            #[cfg(debug_assertions)]
-            {
-                polls += 1;
-                assert!(
-                    polls < DRAIN_POLL_BOUND,
-                    "executor drain exceeded {} polls (seed {}): task '{}' appears to \
-                     busy-yield forever without an external wake",
-                    DRAIN_POLL_BOUND,
-                    self.seed,
-                    runnable.metadata().name,
-                );
-            }
+            polls += 1;
+            assert!(
+                polls < DRAIN_POLL_BOUND,
+                "executor drain exceeded {} polls (seed {}): task '{}' appears to \
+                 busy-yield forever without an external wake",
+                DRAIN_POLL_BOUND,
+                self.seed,
+                runnable.metadata().name,
+            );
 
             tracing::trace!(
                 task_id = runnable.metadata().id,
@@ -430,6 +446,24 @@ impl Executor {
 
 impl Drop for Executor {
     fn drop(&mut self) {
+        // Re-install this executor as CURRENT for the drain (block_on's guard
+        // is long gone): a task future whose Drop spawns through the provider
+        // then gets a valid, immediately-cancelled task (tokio's shutdown
+        // behavior) instead of a panic inside async-task's abort-on-panic
+        // destructor guard, which would abort the whole process. Skip if some
+        // executor is already installed (dropping mid-block_on of another).
+        let installed = CURRENT.with(|current| {
+            let mut current = current.borrow_mut();
+            if current.is_none() {
+                *current = Some(Handle {
+                    shared: Arc::clone(&self.shared),
+                });
+                true
+            } else {
+                false
+            }
+        });
+
         // Wake every live task: completed tasks ignore it, parked tasks get
         // their Runnable scheduled into the queue.
         let wakers: Vec<Waker> = self
@@ -444,14 +478,19 @@ impl Drop for Executor {
         }
 
         // Drop Runnables until the queue is empty: dropping one cancels its
-        // task and drops the future; if that wakes further tasks they are
-        // scheduled into the queue and consumed by this same loop.
+        // task and drops the future; if that wakes further tasks (or spawns
+        // new, instantly-doomed ones) they are scheduled into the queue and
+        // consumed by this same loop.
         loop {
             let runnable = self.shared.queue.lock().pop();
             match runnable {
                 Some(runnable) => drop(runnable),
                 None => break,
             }
+        }
+
+        if installed {
+            CURRENT.with(|current| current.borrow_mut().take());
         }
     }
 }

--- a/moonpool-sim/src/executor/mod.rs
+++ b/moonpool-sim/src/executor/mod.rs
@@ -1,0 +1,467 @@
+//! The moonpool deterministic executor: a single-threaded, seeded-random
+//! async task scheduler purpose-built for simulation.
+//!
+//! # Why moonpool owns an executor
+//!
+//! The simulation used to run on a tokio current-thread runtime whose only
+//! deterministic-scheduling lever was the unstable `RngSeed` API, forcing
+//! `--cfg tokio_unstable` onto every downstream consumer (issue #151). The
+//! deeper finding behind this module: tokio's current-thread scheduler is a
+//! plain FIFO queue, so its seed never randomized task *scheduling* at all.
+//! Owning the executor removes the unstable flag AND unlocks something tokio
+//! cannot offer: task polling order that is a deterministic function of the
+//! simulation seed, so the seed space explores task interleavings.
+//!
+//! # Why there is no reactor
+//!
+//! A production runtime pairs its executor with a reactor: an epoll/kqueue
+//! loop that turns OS events into waker calls, plus a timer wheel. In the
+//! simulation none of that exists; [`SimWorld`](crate::SimWorld)'s event
+//! queue *is* the reactor. Virtual time, network delivery, storage
+//! completion: every external event is a queue entry whose processing wakes
+//! the parked task through its ordinary [`Waker`]. The executor therefore
+//! only needs to answer one question: "of the tasks that are runnable right
+//! now, which do I poll next?"
+//!
+//! # Scheduling: randomized AND deterministic
+//!
+//! Those two words are not in tension. Deterministic means "same seed, same
+//! execution, bit for bit", not "one fixed schedule". The ready queue is a
+//! `Vec` and the next task is chosen by `swap_remove` at a seeded-random
+//! index (madsim uses the same distribution). The RNG is a private ChaCha8
+//! stream derived from the iteration seed with [`EXEC_RNG_SALT`]; it is
+//! deliberately NOT the counted `SIM_RNG` stream, so scheduling decisions
+//! never perturb fork-explorer breakpoint replay (`count@seed` timelines).
+//!
+//! The payoff: when one simulation event wakes two tasks, FIFO would run
+//! them in registration order on every seed forever, structurally hiding
+//! any race between them. Here, which task runs first is a per-seed choice:
+//! each seed replays exactly, and the *population* of seeds covers both
+//! orders. Ordering bugs live exactly there.
+//!
+//! # The driver contract: `block_on` + `until_stalled`
+//!
+//! [`Executor::block_on`] pins the main future (the simulation orchestrator)
+//! on the stack. It is not in the ready queue and is never scheduled
+//! randomly; it is the *driver*, alternating with the task pool:
+//!
+//! ```text
+//! loop {
+//!     poll driver ─ Ready? ──────────────► return
+//!     run_until_stalled()   // poll ready tasks in seeded-random order
+//!                           // until no task is runnable
+//!     (driver not woken AND queue empty) ─► panic: genuine deadlock
+//! }
+//! ```
+//!
+//! The orchestrator's step loops await [`until_stalled()`] between
+//! `sim.step()` calls. Because the driver is only re-polled after a full
+//! drain, resuming from `until_stalled().await` guarantees every task that
+//! was runnable has been polled to `Pending` or completion. This is strictly
+//! stronger than the contract the old tokio version relied on (`yield_now`
+//! re-queuing the driver at the back of a FIFO), and it stays correct under
+//! randomized scheduling, where "back of the queue" does not exist.
+//!
+//! Inside a task, use [`yield_now()`]: it reschedules the task at a seeded
+//! random position. `until_stalled()` is driver-only (debug-asserted): if a
+//! task awaited it, the drain-until-empty semantics would deadlock against
+//! itself.
+//!
+//! # Task lifecycle, panics, and kill-on-drop
+//!
+//! Spawning goes through [`async_task`]: each task splits into a `Runnable`
+//! (scheduled into the ready queue by its waker) and a
+//! [`JoinHandle`] wrapping the `FallibleTask` (awaitable output). Three
+//! contracts mirror tokio because the orchestrator depends on them:
+//!
+//! - **Detach on drop**: dropping a `JoinHandle` lets the task keep running.
+//! - **Abort**: [`JoinHandle::abort`] cancels the task; awaiting the handle
+//!   then yields `Err(JoinError::Cancelled)`.
+//! - **Panic isolation**: every spawned future is wrapped in
+//!   `catch_unwind`, so a panicking task never unwinds into the executor's
+//!   run loop; its handle yields `Err(JoinError::Panicked)` and sibling
+//!   tasks are unaffected.
+//!
+//! Dropping the executor kills every remaining task, replicating the
+//! "dropping the per-iteration tokio runtime kills leaked tasks" contract
+//! that isolates simulation iterations. The mechanism (borrowed from
+//! async-executor): a registry keeps one waker per live task; `Drop` wakes
+//! them all, which schedules every parked task into the ready queue, then
+//! pops and drops `Runnable`s until the queue is empty. Dropping a
+//! `Runnable` cancels its task and drops the future, and if that drop wakes
+//! further tasks they land in the queue and are consumed by the same loop.
+//!
+//! # Fork safety
+//!
+//! The fork-based explorer ([`moonpool-explorer`]) forks the process while
+//! tasks are being polled (assertion macros are fork points). Two rules keep
+//! that sound: everything is single-threaded, and **the queue lock is never
+//! held across `runnable.run()`**; wakes fired during a poll re-acquire the
+//! lock, and a child process inherits no held locks.
+//!
+//! [`moonpool-explorer`]: https://docs.rs/moonpool-explorer
+
+mod join;
+
+pub use join::{JoinHandle, YieldNow, until_stalled, yield_now};
+
+use std::cell::{Cell, RefCell};
+use std::collections::HashMap;
+use std::future::Future;
+use std::panic::AssertUnwindSafe;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::task::{Context, Poll, Wake, Waker};
+
+use futures::FutureExt;
+use parking_lot::Mutex;
+use rand::{RngExt, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+
+/// Salt mixed into the iteration seed before seeding the executor's
+/// scheduling RNG.
+///
+/// Decorrelates task-scheduling decisions from the in-run `SIM_RNG` stream
+/// (and the other salted streams) while keeping them fully reproducible from
+/// the same iteration seed. Like `CONFIG_RNG`/`SELECT_RNG`, this stream is
+/// uncounted: scheduling never perturbs fork-explorer breakpoint replay.
+const EXEC_RNG_SALT: u64 = 0x6578_6563_7363_6864; // "execschd"
+
+/// Debug-build ceiling on polls within one `run_until_stalled` drain.
+///
+/// A task that unconditionally re-wakes itself forever (e.g. a busy
+/// `yield_now` loop with no exit) would make drain-until-empty spin
+/// endlessly; in debug builds we panic with the offending task's name
+/// instead of hanging.
+#[cfg(debug_assertions)]
+const DRAIN_POLL_BOUND: u64 = 1_000_000;
+
+/// Per-task metadata attached through `async_task::Builder::metadata`.
+///
+/// The `id` keys the kill-on-drop waker registry; the `name` makes the
+/// per-poll trace events readable when debugging a seed.
+#[derive(Debug)]
+pub(crate) struct TaskMeta {
+    /// Registry key, unique per spawn within one executor.
+    pub(crate) id: u64,
+    /// Human-readable task name (from `spawn`'s `name` argument).
+    pub(crate) name: Arc<str>,
+}
+
+/// A schedulable task holding our metadata.
+pub(crate) type ExecRunnable = async_task::Runnable<TaskMeta>;
+
+thread_local! {
+    /// The executor currently driving this thread (installed by `block_on`).
+    static CURRENT: RefCell<Option<Handle>> = const { RefCell::new(None) };
+
+    /// True while a task is being polled by `run_until_stalled` (as opposed
+    /// to the driver). Guards the driver-only `until_stalled()` primitive.
+    static IN_TASK: Cell<bool> = const { Cell::new(false) };
+}
+
+/// Report whether the current code is running inside a task poll (true) or
+/// in the driver (false).
+pub(crate) fn in_task() -> bool {
+    IN_TASK.with(Cell::get)
+}
+
+/// State shared between the executor, its spawn handles, and task wakers.
+struct Shared {
+    /// The ready queue. `Vec` (not `VecDeque`) because the next task is
+    /// chosen by seeded `swap_remove`, not FIFO order.
+    queue: Mutex<Vec<ExecRunnable>>,
+    /// One waker per live (spawned, not yet completed/cancelled) task,
+    /// keyed by `TaskMeta::id`; consumed by kill-on-drop.
+    wakers: Mutex<HashMap<u64, Waker>>,
+    /// Next task id.
+    next_id: AtomicU64,
+}
+
+/// Removes a task's waker from the registry when its future is dropped
+/// (completion, cancellation, or executor drop).
+struct Unregister {
+    id: u64,
+    shared: Arc<Shared>,
+}
+
+impl Drop for Unregister {
+    fn drop(&mut self) {
+        self.shared.wakers.lock().remove(&self.id);
+    }
+}
+
+/// Wakes the driver by setting a flag `block_on` checks between drains.
+struct DriverWaker {
+    woken: AtomicBool,
+}
+
+impl Wake for DriverWaker {
+    fn wake(self: Arc<Self>) {
+        self.woken.store(true, Ordering::Relaxed);
+    }
+
+    fn wake_by_ref(self: &Arc<Self>) {
+        self.woken.store(true, Ordering::Relaxed);
+    }
+}
+
+/// Spawning access to a live executor (cloneable, thread-local installed).
+#[derive(Clone)]
+struct Handle {
+    shared: Arc<Shared>,
+}
+
+impl Handle {
+    fn spawn<T, F>(&self, name: &str, future: F) -> JoinHandle<T>
+    where
+        F: Future<Output = T> + Send + 'static,
+        T: Send + 'static,
+    {
+        let id = self.shared.next_id.fetch_add(1, Ordering::Relaxed);
+        let meta = TaskMeta {
+            id,
+            name: Arc::from(name),
+        };
+
+        // catch_unwind: a panicking task must resolve its JoinHandle with
+        // JoinError::Panicked instead of unwinding into the run loop.
+        let caught = AssertUnwindSafe(future).catch_unwind();
+        // The guard unregisters the task's waker whenever the future is
+        // dropped, keeping the kill-on-drop registry bounded by live tasks.
+        let guard_shared = Arc::clone(&self.shared);
+        let wrapped = async move {
+            let _unregister = Unregister {
+                id,
+                shared: guard_shared,
+            };
+            caught.await
+        };
+
+        let schedule_shared = Arc::clone(&self.shared);
+        let schedule = move |runnable: ExecRunnable| {
+            schedule_shared.queue.lock().push(runnable);
+        };
+
+        let (runnable, task) = async_task::Builder::new()
+            .metadata(meta)
+            .spawn(move |_| wrapped, schedule);
+
+        self.shared.wakers.lock().insert(id, runnable.waker());
+        runnable.schedule();
+
+        JoinHandle::new(task.fallible())
+    }
+}
+
+/// Installs a [`Handle`] as the thread's current executor for the duration
+/// of a `block_on` call.
+struct CurrentGuard;
+
+impl CurrentGuard {
+    fn install(handle: Handle) -> Self {
+        CURRENT.with(|current| {
+            let mut current = current.borrow_mut();
+            assert!(
+                current.is_none(),
+                "Executor::block_on is not reentrant: an executor is already running on this thread"
+            );
+            *current = Some(handle);
+        });
+        Self
+    }
+}
+
+impl Drop for CurrentGuard {
+    fn drop(&mut self) {
+        CURRENT.with(|current| current.borrow_mut().take());
+    }
+}
+
+/// Spawn a named task onto the executor currently running on this thread.
+///
+/// The returned [`JoinHandle`] mirrors tokio semantics: awaiting it yields
+/// the task's output (or a [`JoinError`](moonpool_core::JoinError) if the
+/// task was aborted or panicked), dropping it detaches the task, and
+/// [`JoinHandle::abort`] cancels it.
+///
+/// # Panics
+///
+/// Panics when called outside [`Executor::block_on`], mirroring
+/// `tokio::spawn` outside a runtime.
+pub fn spawn<T, F>(name: &str, future: F) -> JoinHandle<T>
+where
+    F: Future<Output = T> + Send + 'static,
+    T: Send + 'static,
+{
+    CURRENT.with(|current| {
+        current
+            .borrow()
+            .as_ref()
+            .expect("executor::spawn called outside Executor::block_on")
+            .spawn(name, future)
+    })
+}
+
+/// The deterministic single-threaded executor.
+///
+/// One instance is created per simulation iteration, seeded from the
+/// iteration seed; dropping it cancels every task that is still alive (see
+/// the [module docs](self) for the kill-on-drop mechanics).
+///
+/// # Examples
+///
+/// ```
+/// let mut executor = moonpool_sim::executor::Executor::new(42);
+/// let sum = executor.block_on(async {
+///     let task = moonpool_sim::executor::spawn("adder", async { 1 + 2 });
+///     task.await.expect("task completed")
+/// });
+/// assert_eq!(sum, 3);
+/// ```
+pub struct Executor {
+    shared: Arc<Shared>,
+    /// Seeded scheduling RNG (uncounted stream, see [`EXEC_RNG_SALT`]).
+    rng: ChaCha8Rng,
+    /// The iteration seed, kept for stall diagnostics.
+    seed: u64,
+}
+
+impl Executor {
+    /// Create an executor whose scheduling decisions derive from `seed`.
+    #[must_use]
+    pub fn new(seed: u64) -> Self {
+        Self {
+            shared: Arc::new(Shared {
+                queue: Mutex::new(Vec::new()),
+                wakers: Mutex::new(HashMap::new()),
+                next_id: AtomicU64::new(0),
+            }),
+            rng: ChaCha8Rng::seed_from_u64(seed ^ EXEC_RNG_SALT),
+            seed,
+        }
+    }
+
+    /// Run `main` as the driver future to completion, interleaving it with
+    /// the task pool (see the [module docs](self) for the drive loop).
+    ///
+    /// `main` needs no `Send` bound: it is pinned on this stack and never
+    /// enters the ready queue.
+    ///
+    /// # Panics
+    ///
+    /// - if called while another `block_on` is running on this thread;
+    /// - on a genuine deadlock: the driver is not woken, returns `Pending`,
+    ///   and no task is runnable (with the seed in the message, replacing
+    ///   tokio's silent forever-park).
+    pub fn block_on<F: Future>(&mut self, main: F) -> F::Output {
+        let _guard = CurrentGuard::install(Handle {
+            shared: Arc::clone(&self.shared),
+        });
+
+        let mut main = std::pin::pin!(main);
+        let driver_waker = Arc::new(DriverWaker {
+            woken: AtomicBool::new(false),
+        });
+        let waker = Waker::from(Arc::clone(&driver_waker));
+        let mut cx = Context::from_waker(&waker);
+
+        loop {
+            driver_waker.woken.store(false, Ordering::Relaxed);
+            if let Poll::Ready(output) = main.as_mut().poll(&mut cx) {
+                return output;
+            }
+
+            self.run_until_stalled();
+
+            assert!(
+                driver_waker.woken.load(Ordering::Relaxed) || !self.shared.queue.lock().is_empty(),
+                "deterministic executor stalled (seed {}): the driver future is not \
+                 woken and no task is runnable, so every remaining future awaits a \
+                 wake that can never arrive",
+                self.seed
+            );
+        }
+    }
+
+    /// Poll ready tasks in seeded-random order until none is runnable.
+    ///
+    /// The queue lock is released around every `runnable.run()` (fork
+    /// safety; wakes fired during a poll re-acquire it to enqueue).
+    fn run_until_stalled(&mut self) {
+        #[cfg(debug_assertions)]
+        let mut polls: u64 = 0;
+
+        loop {
+            let runnable = {
+                let mut queue = self.shared.queue.lock();
+                if queue.is_empty() {
+                    break;
+                }
+                let index = self.rng.random_range(0..queue.len());
+                queue.swap_remove(index)
+            };
+
+            #[cfg(debug_assertions)]
+            {
+                polls += 1;
+                assert!(
+                    polls < DRAIN_POLL_BOUND,
+                    "executor drain exceeded {} polls (seed {}): task '{}' appears to \
+                     busy-yield forever without an external wake",
+                    DRAIN_POLL_BOUND,
+                    self.seed,
+                    runnable.metadata().name,
+                );
+            }
+
+            tracing::trace!(
+                task_id = runnable.metadata().id,
+                task = %runnable.metadata().name,
+                "executor poll"
+            );
+
+            IN_TASK.with(|flag| flag.set(true));
+            runnable.run();
+            IN_TASK.with(|flag| flag.set(false));
+        }
+    }
+}
+
+impl Drop for Executor {
+    fn drop(&mut self) {
+        // Wake every live task: completed tasks ignore it, parked tasks get
+        // their Runnable scheduled into the queue.
+        let wakers: Vec<Waker> = self
+            .shared
+            .wakers
+            .lock()
+            .drain()
+            .map(|(_, waker)| waker)
+            .collect();
+        for waker in wakers {
+            waker.wake();
+        }
+
+        // Drop Runnables until the queue is empty: dropping one cancels its
+        // task and drops the future; if that wakes further tasks they are
+        // scheduled into the queue and consumed by this same loop.
+        loop {
+            let runnable = self.shared.queue.lock().pop();
+            match runnable {
+                Some(runnable) => drop(runnable),
+                None => break,
+            }
+        }
+    }
+}
+
+impl std::fmt::Debug for Executor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Executor")
+            .field("seed", &self.seed)
+            .field("ready_tasks", &self.shared.queue.lock().len())
+            .field("live_tasks", &self.shared.wakers.lock().len())
+            .finish_non_exhaustive()
+    }
+}

--- a/moonpool-sim/src/lib.rs
+++ b/moonpool-sim/src/lib.rs
@@ -110,6 +110,11 @@ pub use moonpool_core::{
     TcpListenerTrait, TimeError, TimeProvider, TokioTaskProvider, UID, WELL_KNOWN_RESERVED_COUNT,
     WellKnownToken,
 };
+// The deterministic select! (moonpool-sim always enables core's
+// deterministic-select, so this is the seeded rotation combinator). Process and
+// workload code must use this instead of tokio::select!, whose branch offset is
+// entropy-drawn outside a seeded tokio runtime.
+pub use moonpool_core::select;
 // Production provider bundle — only when the tokio-providers feature pulls core's
 // net/fs/time. A wasm-able sim (`--no-default-features`) omits these.
 #[cfg(feature = "tokio-providers")]

--- a/moonpool-sim/src/lib.rs
+++ b/moonpool-sim/src/lib.rs
@@ -110,7 +110,8 @@ pub use moonpool_core::{
     TcpListenerTrait, TimeError, TimeProvider, UID, WELL_KNOWN_RESERVED_COUNT, WellKnownToken,
 };
 // The deterministic select! (moonpool-sim always enables core's
-// deterministic-select, so this is the seeded rotation combinator). Process and
+// deterministic-select, so this is tokio's expansion with a seeded start
+// offset). Process and
 // workload code must use this instead of tokio::select!, whose branch offset is
 // entropy-drawn outside a seeded tokio runtime.
 pub use moonpool_core::select;

--- a/moonpool-sim/src/lib.rs
+++ b/moonpool-sim/src/lib.rs
@@ -107,8 +107,7 @@
 pub use moonpool_core::{
     CodecError, Endpoint, JsonCodec, MessageCodec, NetworkAddress, NetworkAddressParseError,
     NetworkProvider, Providers, RandomProvider, SimulationError, SimulationResult, TaskProvider,
-    TcpListenerTrait, TimeError, TimeProvider, TokioTaskProvider, UID, WELL_KNOWN_RESERVED_COUNT,
-    WellKnownToken,
+    TcpListenerTrait, TimeError, TimeProvider, UID, WELL_KNOWN_RESERVED_COUNT, WellKnownToken,
 };
 // The deterministic select! (moonpool-sim always enables core's
 // deterministic-select, so this is the seeded rotation combinator). Process and
@@ -118,7 +117,9 @@ pub use moonpool_core::select;
 // Production provider bundle — only when the tokio-providers feature pulls core's
 // net/fs/time. A wasm-able sim (`--no-default-features`) omits these.
 #[cfg(feature = "tokio-providers")]
-pub use moonpool_core::{TokioNetworkProvider, TokioProviders, TokioTimeProvider};
+pub use moonpool_core::{
+    TokioNetworkProvider, TokioProviders, TokioTaskProvider, TokioTimeProvider,
+};
 
 // =============================================================================
 // Core Modules
@@ -126,6 +127,9 @@ pub use moonpool_core::{TokioNetworkProvider, TokioProviders, TokioTimeProvider}
 
 /// Core simulation engine for deterministic testing.
 pub mod sim;
+
+/// The deterministic single-threaded executor (seeded-random scheduling).
+pub mod executor;
 
 /// Simulation runner and orchestration framework.
 pub mod runner;
@@ -194,7 +198,7 @@ pub use storage::{
 };
 
 // Provider exports
-pub use providers::{SimProviders, SimRandomProvider, SimTimeProvider};
+pub use providers::{SimProviders, SimRandomProvider, SimTaskProvider, SimTimeProvider};
 
 // Assertion vocabulary — always available (dependency-free accounting layer).
 pub use moonpool_assertions::{AssertCmp, AssertKind};

--- a/moonpool-sim/src/providers/mod.rs
+++ b/moonpool-sim/src/providers/mod.rs
@@ -5,8 +5,10 @@
 
 mod random;
 mod sim_providers;
+mod task;
 mod time;
 
 pub use random::SimRandomProvider;
 pub use sim_providers::SimProviders;
+pub use task::SimTaskProvider;
 pub use time::SimTimeProvider;

--- a/moonpool-sim/src/providers/sim_providers.rs
+++ b/moonpool-sim/src/providers/sim_providers.rs
@@ -2,13 +2,13 @@
 
 use std::net::IpAddr;
 
-use moonpool_core::{TokioTaskProvider, impl_providers_bundle};
+use moonpool_core::impl_providers_bundle;
 
 use crate::network::SimNetworkProvider;
 use crate::sim::WeakSimWorld;
 use crate::storage::SimStorageProvider;
 
-use super::{SimRandomProvider, SimTimeProvider};
+use super::{SimRandomProvider, SimTaskProvider, SimTimeProvider};
 
 /// Simulation providers bundle for deterministic testing.
 ///
@@ -34,14 +34,14 @@ use super::{SimRandomProvider, SimTimeProvider};
 ///
 /// - Uses `SimNetworkProvider` for simulated TCP connections
 /// - Uses `SimTimeProvider` for logical/simulated time
-/// - Uses `TokioTaskProvider` for task spawning (same as production)
+/// - Uses `SimTaskProvider` for task spawning on the deterministic executor
 /// - Uses `SimRandomProvider` for seeded deterministic randomness
 /// - Uses `SimStorageProvider` for simulated file I/O with per-process fault injection
 #[derive(Clone)]
 pub struct SimProviders {
     network: SimNetworkProvider,
     time: SimTimeProvider,
-    task: TokioTaskProvider,
+    task: SimTaskProvider,
     random: SimRandomProvider,
     storage: SimStorageProvider,
 }
@@ -59,7 +59,7 @@ impl SimProviders {
         Self {
             network: SimNetworkProvider::new(sim.clone()),
             time: SimTimeProvider::new(sim.clone()),
-            task: TokioTaskProvider,
+            task: SimTaskProvider,
             random: SimRandomProvider::new(seed),
             storage: SimStorageProvider::new(sim, ip),
         }
@@ -69,7 +69,7 @@ impl SimProviders {
 impl_providers_bundle!(SimProviders {
     network: SimNetworkProvider,
     time: SimTimeProvider,
-    task: TokioTaskProvider,
+    task: SimTaskProvider,
     random: SimRandomProvider,
     storage: SimStorageProvider,
 });

--- a/moonpool-sim/src/providers/task.rs
+++ b/moonpool-sim/src/providers/task.rs
@@ -27,12 +27,10 @@ impl TaskProvider for SimTaskProvider {
     where
         F: Future<Output = ()> + Send + 'static,
     {
-        let task_name = name.to_string();
-        crate::executor::spawn(name, async move {
-            tracing::trace!("Task {} starting", task_name);
-            future.await;
-            tracing::trace!("Task {} completed", task_name);
-        })
+        // No lifecycle-trace wrapper (unlike TokioTaskProvider, where the
+        // name would otherwise be lost): the executor stores the name in
+        // TaskMeta and traces every poll of the task with it.
+        crate::executor::spawn(name, future)
     }
 
     async fn yield_now(&self) {

--- a/moonpool-sim/src/providers/task.rs
+++ b/moonpool-sim/src/providers/task.rs
@@ -1,0 +1,41 @@
+//! Task provider backed by the moonpool deterministic executor.
+
+use std::future::Future;
+
+use moonpool_core::TaskProvider;
+
+/// Task provider that spawns onto the [deterministic
+/// executor](crate::executor) driving the current simulation iteration.
+///
+/// Where `TokioTaskProvider` binds tasks to the ambient tokio runtime, this
+/// provider binds them to the executor installed by
+/// [`Executor::block_on`](crate::executor::Executor::block_on): scheduling
+/// order is a seeded-random, fully reproducible function of the iteration
+/// seed.
+///
+/// # Panics
+///
+/// `spawn_task` panics when used outside `Executor::block_on` (mirroring
+/// `tokio::spawn` outside a runtime).
+#[derive(Clone, Debug, Default)]
+pub struct SimTaskProvider;
+
+impl TaskProvider for SimTaskProvider {
+    type JoinHandle = crate::executor::JoinHandle<()>;
+
+    fn spawn_task<F>(&self, name: &str, future: F) -> Self::JoinHandle
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        let task_name = name.to_string();
+        crate::executor::spawn(name, async move {
+            tracing::trace!("Task {} starting", task_name);
+            future.await;
+            tracing::trace!("Task {} completed", task_name);
+        })
+    }
+
+    async fn yield_now(&self) {
+        crate::executor::yield_now().await;
+    }
+}

--- a/moonpool-sim/src/providers/time.rs
+++ b/moonpool-sim/src/providers/time.rs
@@ -45,9 +45,12 @@ impl TimeProvider for SimTimeProvider {
     {
         let sleep_future = self.sim.sleep(duration).map_err(|_| TimeError::Shutdown)?;
 
-        // Race the future against the timeout using tokio::select!
-        // Both futures respect simulation time through the event system
-        tokio::select! {
+        // Race the future against the timeout. Both become ready via distinct
+        // simulation events, so the event queue's deterministic ordering (not
+        // branch order) decides the winner; `biased;` makes that explicit and
+        // keeps the select free of any offset draw.
+        moonpool_core::select! {
+            biased;
             result = future => Ok(result),
             _ = sleep_future => Err(TimeError::Elapsed),
         }

--- a/moonpool-sim/src/runner/builder.rs
+++ b/moonpool-sim/src/runner/builder.rs
@@ -859,8 +859,8 @@ impl SimulationBuilder {
         }
     }
 
-    /// Spin up a fresh tokio runtime, run the orchestrator on it, and
-    /// return its outcome.
+    /// Spin up a fresh deterministic executor, run the orchestrator on it,
+    /// and return its outcome.
     fn run_orchestrator_blocking(inputs: RunOrchestratorInputs<'_>) -> OrchestrationOutcome {
         let RunOrchestratorInputs {
             seed,
@@ -875,8 +875,11 @@ impl SimulationBuilder {
             obs_handle,
             run_time_budget,
         } = inputs;
-        let local_runtime = Self::build_local_runtime_for_seed(seed);
-        local_runtime.block_on(async move {
+        // Fresh executor per iteration: dropping it cancels every task that
+        // leaked past the settle phase, so no state crosses into the next seed
+        // (the same contract dropping the per-iteration tokio runtime gave).
+        let mut executor = crate::executor::Executor::new(seed);
+        executor.block_on(async move {
             WorkloadOrchestrator::orchestrate_workloads(OrchestrateInputs {
                 workloads,
                 fault_injectors,
@@ -1093,22 +1096,6 @@ impl SimulationBuilder {
                 pct,
             );
         }
-    }
-
-    /// Build a fresh single-threaded tokio runtime seeded for this iteration.
-    /// When dropped, ALL tasks are killed — no orphan tasks leak between
-    /// iterations.
-    fn build_local_runtime_for_seed(seed: u64) -> tokio::runtime::Runtime {
-        let mut seed_bytes = [0u8; 32];
-        seed_bytes[..8].copy_from_slice(&seed.to_le_bytes());
-        let rng_seed = tokio::runtime::RngSeed::from_bytes(&seed_bytes);
-        // No .enable_time(): the sim drives logical time via the event queue, not
-        // tokio's timer wheel. enable_time() also constructs a std::time::Instant
-        // at startup, which panics on wasm32-unknown-unknown.
-        tokio::runtime::Builder::new_current_thread()
-            .rng_seed(rng_seed)
-            .build()
-            .expect("per-iteration runtime")
     }
 
     /// Reset per-iteration state: capture buffers, RNG, buggify, and chaos.

--- a/moonpool-sim/src/runner/builder.rs
+++ b/moonpool-sim/src/runner/builder.rs
@@ -1305,8 +1305,9 @@ impl SimulationBuilder {
     #[instrument(skip_all)]
     /// Run the simulation and generate a report.
     ///
-    /// Creates a fresh tokio `LocalRuntime` per iteration for full isolation —
-    /// all tasks are killed when the runtime is dropped at iteration end.
+    /// Creates a fresh deterministic [`Executor`](crate::executor::Executor)
+    /// per iteration for full isolation — all tasks are killed when the
+    /// executor is dropped at iteration end.
     ///
     /// # Panics
     ///
@@ -1315,6 +1316,19 @@ impl SimulationBuilder {
         if self.entries.is_empty() {
             return Self::empty_report();
         }
+
+        // Uninstall the select! offset override on every exit path (normal,
+        // early return, panic): without this, the seeded source installed by
+        // set_select_seed would leak past run() and later selects on this
+        // thread would silently keep drawing from the stale sim stream
+        // instead of the documented entropy fallback.
+        struct SelectOverrideReset;
+        impl Drop for SelectOverrideReset {
+            fn drop(&mut self) {
+                crate::sim::reset_select_rng();
+            }
+        }
+        let _select_reset = SelectOverrideReset;
 
         // Install the observability layer once for the entire run. The guard
         // is dropped when run() returns, restoring the previous subscriber.

--- a/moonpool-sim/src/runner/builder.rs
+++ b/moonpool-sim/src/runner/builder.rs
@@ -1123,6 +1123,9 @@ impl SimulationBuilder {
         // Seed the independent config RNG that drives swarm-subset decisions.
         // Runs before `build_sim_for_iteration`, so `swarm_for_seed()` sees it.
         crate::sim::set_config_seed(seed);
+        // Seed the independent select! branch-offset stream and install it as
+        // moonpool_core::select!'s offset source for this iteration.
+        crate::sim::set_select_seed(seed);
         // Per-seed base for the workload operation-alphabet swarm mask; `None`
         // disables masking so workloads see the full alphabet.
         crate::sim::set_swarm_op_seed(swarm_operations.then_some(seed));

--- a/moonpool-sim/src/runner/builder.rs
+++ b/moonpool-sim/src/runner/builder.rs
@@ -1812,8 +1812,13 @@ mod tests {
 
     #[test]
     fn test_simulation_builder_with_failures() {
+        // Pinned seeds: without them, iteration seeds derive from the wall
+        // clock and this test demands both outcomes across 10 fair coin
+        // flips, a ~0.2% spontaneous failure rate. Each seed's outcome is a
+        // pure function of the seed, so pinning makes it deterministic.
         let report = SimulationBuilder::new()
             .workload(FailingWorkload)
+            .set_debug_seeds((1..=10).collect())
             .set_iterations(10)
             .run();
 

--- a/moonpool-sim/src/runner/context.rs
+++ b/moonpool-sim/src/runner/context.rs
@@ -22,7 +22,7 @@ use crate::observability::SimulationLayerHandle;
 use crate::providers::{SimProviders, SimRandomProvider, SimTimeProvider};
 use crate::storage::SimStorageProvider;
 
-use moonpool_core::{Providers, TokioTaskProvider};
+use moonpool_core::Providers;
 
 use super::topology::WorkloadTopology;
 
@@ -74,7 +74,7 @@ impl SimContext {
 
     /// Get the task provider.
     #[must_use]
-    pub fn task(&self) -> &TokioTaskProvider {
+    pub fn task(&self) -> &crate::providers::SimTaskProvider {
         self.providers.task()
     }
 

--- a/moonpool-sim/src/runner/orchestrator.rs
+++ b/moonpool-sim/src/runner/orchestrator.rs
@@ -107,7 +107,7 @@ pub(crate) struct ProcessConfig<'a> {
 /// events fire in the simulation event queue.
 struct ProcessManager<'a> {
     factory: Option<&'a dyn Fn() -> Box<dyn Process>>,
-    handles: Vec<Option<tokio::task::JoinHandle<()>>>,
+    handles: Vec<Option<crate::executor::JoinHandle<()>>>,
     /// Per-process shutdown tokens (child of the global `shutdown_signal`).
     /// Cancelling a child signals only that process; cancelling the parent
     /// signals all processes.
@@ -138,7 +138,7 @@ impl<'a> ProcessManager<'a> {
     /// Create a process manager from config and booted process handles.
     fn new(
         factory: &'a dyn Fn() -> Box<dyn Process>,
-        handles: Vec<Option<tokio::task::JoinHandle<()>>>,
+        handles: Vec<Option<crate::executor::JoinHandle<()>>>,
         process_tokens: Vec<Option<tokio_util::sync::CancellationToken>>,
         ips: Vec<String>,
         tag_registry: TagRegistry,
@@ -256,7 +256,8 @@ impl<'a> ProcessManager<'a> {
         let providers = crate::SimProviders::new(sim.clone(), seed, ip);
         let ctx = SimContext::new(providers, topology, state.clone(), obs.clone());
         let ip_for_log = ip_str.clone();
-        let handle = tokio::spawn(
+        let handle = crate::executor::spawn(
+            &format!("process@{ip_str}"),
             async move {
                 if let Err(e) = process.run(&ctx).await {
                     tracing::debug!("Restarted process at {} exited: {}", ip_for_log, e);
@@ -295,19 +296,19 @@ type WorkloadResult = (Box<dyn Workload>, SimulationResult<()>);
 type SetupTaskOutput = (Box<dyn Workload>, SimContext, SimulationResult<()>);
 
 /// Handle to a spawned `setup()` task.
-type SetupHandle = tokio::task::JoinHandle<SetupTaskOutput>;
+type SetupHandle = crate::executor::JoinHandle<SetupTaskOutput>;
 
 /// Per-process join handles (in option slots so they can be drained).
-type ProcessHandleSlots = Vec<Option<tokio::task::JoinHandle<()>>>;
+type ProcessHandleSlots = Vec<Option<crate::executor::JoinHandle<()>>>;
 
 /// Per-process cancellation tokens (in option slots so they can be drained).
 type ProcessTokenSlots = Vec<Option<tokio_util::sync::CancellationToken>>;
 
 /// Per-injector join handles (in option slots so they can be drained).
-type InjectorHandleSlots = Vec<Option<tokio::task::JoinHandle<InjectorResult>>>;
+type InjectorHandleSlots = Vec<Option<crate::executor::JoinHandle<InjectorResult>>>;
 
 /// Per-workload join handles (in option slots so they can be drained).
-type WorkloadHandleSlots = Vec<Option<tokio::task::JoinHandle<WorkloadResult>>>;
+type WorkloadHandleSlots = Vec<Option<crate::executor::JoinHandle<WorkloadResult>>>;
 
 /// Inputs needed to run the check phase.
 struct CheckPhaseInputs<'a> {
@@ -909,7 +910,7 @@ impl WorkloadOrchestrator {
         // suffices to flush them into the timeline.
         Self::pump_observability(sim, obs);
 
-        // === 7. CHECK PHASE (tokio::spawn + cooperative stepping) ===
+        // === 7. CHECK PHASE (executor spawn + cooperative stepping) ===
         let final_workloads = Self::do_check_phase(CheckPhaseInputs {
             sim,
             workloads: returned_workloads,
@@ -1024,7 +1025,8 @@ impl WorkloadOrchestrator {
         let mut setup_handles = Vec::with_capacity(workloads.len());
         for (workload, ctx) in workloads.into_iter().zip(contexts) {
             let ip = ctx.my_ip().to_string();
-            let handle = tokio::spawn(
+            let handle = crate::executor::spawn(
+                &format!("workload-setup@{ip}"),
                 async move {
                     let mut w = workload;
                     let result = w.setup(&ctx).await;
@@ -1046,7 +1048,8 @@ impl WorkloadOrchestrator {
         let mut workload_handles = Vec::with_capacity(workloads.len());
         for (workload, ctx) in workloads.into_iter().zip(contexts) {
             let ip = ctx.my_ip().to_string();
-            let handle = tokio::spawn(
+            let handle = crate::executor::spawn(
+                &format!("workload-run@{ip}"),
                 async move {
                     let mut w = workload;
                     let result = w.run(&ctx).await;
@@ -1172,7 +1175,7 @@ impl WorkloadOrchestrator {
             }
 
             if current_active > 0 {
-                tokio::task::yield_now().await;
+                crate::executor::until_stalled().await;
             }
         }
         // Final pump: capture events emitted after the last step.
@@ -1369,7 +1372,7 @@ impl WorkloadOrchestrator {
                     sim.time_provider(),
                     chaos_shutdown.clone(),
                 );
-                let handle = tokio::spawn(async move {
+                let handle = crate::executor::spawn("fault-injector", async move {
                     let mut injector = fi;
                     let result = injector.inject(&fault_ctx).await;
                     (injector, result)
@@ -1468,7 +1471,8 @@ impl WorkloadOrchestrator {
             let ctx = SimContext::new(providers, topology, state.clone(), obs.clone());
             let ip_for_log = ip.clone();
             let span_ip = ip.clone();
-            let handle = tokio::spawn(
+            let handle = crate::executor::spawn(
+                &format!("process@{span_ip}"),
                 async move {
                     if let Err(e) = process.run(&ctx).await {
                         tracing::debug!("Process at {} exited: {}", ip_for_log, e);
@@ -1494,7 +1498,8 @@ impl WorkloadOrchestrator {
         let mut check_handles = Vec::with_capacity(workloads.len());
         for (workload, ctx) in workloads.into_iter().zip(contexts) {
             let ip = ctx.my_ip().to_string();
-            let handle = tokio::spawn(
+            let handle = crate::executor::spawn(
+                &format!("workload-check@{ip}"),
                 async move {
                     let mut w = workload;
                     let result = w.check(&ctx).await;
@@ -1512,7 +1517,7 @@ impl WorkloadOrchestrator {
         loop {
             if check_handles
                 .iter()
-                .all(tokio::task::JoinHandle::is_finished)
+                .all(crate::executor::JoinHandle::is_finished)
             {
                 break;
             }
@@ -1520,7 +1525,7 @@ impl WorkloadOrchestrator {
                 sim.step();
                 Self::pump_observability(sim, obs);
             }
-            tokio::task::yield_now().await;
+            crate::executor::until_stalled().await;
         }
         Self::pump_observability(sim, obs);
 
@@ -1584,14 +1589,14 @@ impl WorkloadOrchestrator {
     /// `workload_collected`. Returns `true` if at least one handle finished
     /// during this call.
     async fn collect_finished_workloads(
-        workload_handles: &mut [Option<tokio::task::JoinHandle<WorkloadResult>>],
+        workload_handles: &mut [Option<crate::executor::JoinHandle<WorkloadResult>>],
         workload_collected: &mut [Option<WorkloadResult>],
     ) -> bool {
         let mut any_finished = false;
         for i in 0..workload_handles.len() {
             let finished = workload_handles[i]
                 .as_ref()
-                .is_some_and(tokio::task::JoinHandle::is_finished);
+                .is_some_and(crate::executor::JoinHandle::is_finished);
             if finished {
                 let handle = workload_handles[i]
                     .take()
@@ -1614,12 +1619,12 @@ impl WorkloadOrchestrator {
     /// Reap any fault-injector handles that have finished, discarding the
     /// injectors. The remaining live handles are returned in-place.
     async fn reap_finished_injectors(
-        injector_handles: &mut [Option<tokio::task::JoinHandle<InjectorResult>>],
+        injector_handles: &mut [Option<crate::executor::JoinHandle<InjectorResult>>],
     ) {
         for handle_opt in injector_handles {
             let finished = handle_opt
                 .as_ref()
-                .is_some_and(tokio::task::JoinHandle::is_finished);
+                .is_some_and(crate::executor::JoinHandle::is_finished);
             if finished {
                 let handle = handle_opt.take().expect("injector handle is finished");
                 match handle.await {
@@ -1638,7 +1643,7 @@ impl WorkloadOrchestrator {
     /// are still running.
     async fn collect_injector_results(
         mut returned: Vec<Box<dyn FaultInjector>>,
-        mut injector_handles: Vec<Option<tokio::task::JoinHandle<InjectorResult>>>,
+        mut injector_handles: Vec<Option<crate::executor::JoinHandle<InjectorResult>>>,
     ) -> Vec<Box<dyn FaultInjector>> {
         for handle_opt in &mut injector_handles {
             if let Some(handle) = handle_opt.take() {
@@ -1688,10 +1693,10 @@ impl WorkloadOrchestrator {
         state: &StateHandle,
         obs: &SimulationLayerHandle,
         shutdown_signal: &tokio_util::sync::CancellationToken,
-        handles: &[tokio::task::JoinHandle<T>],
+        handles: &[crate::executor::JoinHandle<T>],
     ) {
         loop {
-            if handles.iter().all(tokio::task::JoinHandle::is_finished) {
+            if handles.iter().all(crate::executor::JoinHandle::is_finished) {
                 break;
             }
             if sim.pending_event_count() > 0 {
@@ -1706,7 +1711,7 @@ impl WorkloadOrchestrator {
                 );
                 Self::pump_observability(sim, obs);
             }
-            tokio::task::yield_now().await;
+            crate::executor::until_stalled().await;
         }
         Self::pump_observability(sim, obs);
     }

--- a/moonpool-sim/src/sim/mod.rs
+++ b/moonpool-sim/src/sim/mod.rs
@@ -26,9 +26,9 @@ pub use events::{
 };
 pub use rng::{
     clear_rng_breakpoints, config_random_bool, config_random_f64, current_sim_seed,
-    reset_config_rng, reset_rng_call_count, reset_sim_rng, rng_call_count, set_config_seed,
-    set_rng_breakpoints, set_sim_seed, set_swarm_op_seed, sim_random, sim_random_range,
-    sim_random_range_or_default, swarm_op_enabled,
+    reset_config_rng, reset_rng_call_count, reset_select_rng, reset_sim_rng, rng_call_count,
+    set_config_seed, set_rng_breakpoints, set_select_seed, set_sim_seed, set_swarm_op_seed,
+    sim_random, sim_random_range, sim_random_range_or_default, swarm_op_enabled,
 };
 pub use sleep::SleepFuture;
 pub use world::{SimFaultRecord, SimWorld, WeakSimWorld};

--- a/moonpool-sim/src/sim/rng.rs
+++ b/moonpool-sim/src/sim/rng.rs
@@ -56,7 +56,7 @@ thread_local! {
 
     /// Thread-local `select!` branch-offset RNG, independent of [`SIM_RNG`].
     ///
-    /// Drives the branch rotation offsets of `moonpool_core::select!` (installed
+    /// Drives the branch start offsets of `moonpool_core::select!` (installed
     /// via [`set_select_seed`]). Like [`CONFIG_RNG`] it deliberately does NOT go
     /// through [`pre_sample`], so select polling order can never perturb the
     /// [`SIM_RNG`] call count or fork-explorer breakpoint replay.
@@ -78,7 +78,7 @@ const SWARM_OP_SALT: u64 = 0x6F70_6D61_736B_7372; // "opmasksr"
 
 /// Salt mixed into the iteration seed before seeding [`SELECT_RNG`].
 ///
-/// Decorrelates `select!` branch-rotation offsets from the in-run [`SIM_RNG`]
+/// Decorrelates `select!` branch start offsets from the in-run [`SIM_RNG`]
 /// stream (and from the other salted streams) while keeping them fully
 /// reproducible from the same iteration seed.
 const SELECT_RNG_SALT: u64 = 0x7365_6C62_726E_6368; // "selbrnch"
@@ -311,7 +311,7 @@ pub fn reset_config_rng() {
 /// install it as the branch-offset source for `moonpool_core::select!` on
 /// this thread.
 ///
-/// The seed is mixed with [`SELECT_RNG_SALT`] so branch-rotation offsets are
+/// The seed is mixed with [`SELECT_RNG_SALT`] so branch start offsets are
 /// decorrelated from [`SIM_RNG`] yet remain reproducible per iteration seed.
 /// Like [`set_config_seed`], this stream is uncounted: select polling order
 /// never perturbs the call counter or fork-explorer breakpoint replay.

--- a/moonpool-sim/src/sim/rng.rs
+++ b/moonpool-sim/src/sim/rng.rs
@@ -53,6 +53,14 @@ thread_local! {
     /// iteration, `None` otherwise. See [`swarm_op_enabled`] for how it is consumed; like
     /// [`CONFIG_RNG`] it never touches the [`SIM_RNG`] call count.
     static SWARM_OP_SEED: Cell<Option<u64>> = const { Cell::new(None) };
+
+    /// Thread-local `select!` branch-offset RNG, independent of [`SIM_RNG`].
+    ///
+    /// Drives the branch rotation offsets of `moonpool_core::select!` (installed
+    /// via [`set_select_seed`]). Like [`CONFIG_RNG`] it deliberately does NOT go
+    /// through [`pre_sample`], so select polling order can never perturb the
+    /// [`SIM_RNG`] call count or fork-explorer breakpoint replay.
+    static SELECT_RNG: RefCell<ChaCha8Rng> = RefCell::new(ChaCha8Rng::seed_from_u64(0));
 }
 
 /// Salt mixed into the iteration seed before seeding [`CONFIG_RNG`].
@@ -67,6 +75,13 @@ const CONFIG_RNG_SALT: u64 = 0x6D6F_6F6E_7377_726D; // "moonswrm"
 /// Distinct from [`CONFIG_RNG_SALT`] so per-seed *operation* subset decisions
 /// are decorrelated from the *fault-family* subset decisions of the same seed.
 const SWARM_OP_SALT: u64 = 0x6F70_6D61_736B_7372; // "opmasksr"
+
+/// Salt mixed into the iteration seed before seeding [`SELECT_RNG`].
+///
+/// Decorrelates `select!` branch-rotation offsets from the in-run [`SIM_RNG`]
+/// stream (and from the other salted streams) while keeping them fully
+/// reproducible from the same iteration seed.
+const SELECT_RNG_SALT: u64 = 0x7365_6C62_726E_6368; // "selbrnch"
 
 /// Increment the RNG call counter and check for breakpoints.
 ///
@@ -290,6 +305,36 @@ pub fn reset_config_rng() {
     CONFIG_RNG.with(|rng| {
         *rng.borrow_mut() = ChaCha8Rng::seed_from_u64(0);
     });
+}
+
+/// Seed the thread-local `select!` offset RNG from an iteration seed and
+/// install it as the branch-offset source for `moonpool_core::select!` on
+/// this thread.
+///
+/// The seed is mixed with [`SELECT_RNG_SALT`] so branch-rotation offsets are
+/// decorrelated from [`SIM_RNG`] yet remain reproducible per iteration seed.
+/// Like [`set_config_seed`], this stream is uncounted: select polling order
+/// never perturbs the call counter or fork-explorer breakpoint replay.
+pub fn set_select_seed(seed: u64) {
+    SELECT_RNG.with(|rng| {
+        *rng.borrow_mut() = ChaCha8Rng::seed_from_u64(seed ^ SELECT_RNG_SALT);
+    });
+    moonpool_core::select_support::set_select_offset_override(Some(select_offset_from_stream));
+}
+
+/// Reset the `select!` offset RNG and uninstall the override, restoring
+/// moonpool-core's entropy fallback (production behavior).
+pub fn reset_select_rng() {
+    SELECT_RNG.with(|rng| {
+        *rng.borrow_mut() = ChaCha8Rng::seed_from_u64(0);
+    });
+    moonpool_core::select_support::set_select_offset_override(None);
+}
+
+/// The offset source registered with moonpool-core: one uncounted
+/// [`SELECT_RNG`] draw per `select!` execution.
+fn select_offset_from_stream(branches: u32) -> u32 {
+    SELECT_RNG.with(|rng| rng.borrow_mut().random_range(0..branches))
 }
 
 /// Generate a random f64 in `[0.0, 1.0)` using the configuration RNG.
@@ -677,6 +722,44 @@ mod tests {
         let _: f64 = sim_random();
         assert_eq!(rng_call_count(), 1);
         assert_eq!(current_sim_seed(), 42); // no breakpoint triggered
+    }
+
+    #[test]
+    fn select_rng_does_not_perturb_sim_rng_and_replays() {
+        // Control: SIM_RNG sequence with no SELECT_RNG draws interleaved.
+        reset_sim_rng();
+        set_sim_seed(42);
+        let control: Vec<f64> = (0..5).map(|_| sim_random::<f64>()).collect();
+        let control_count = rng_call_count();
+
+        // Experiment: interleave select-offset draws between SIM_RNG draws.
+        reset_sim_rng();
+        set_sim_seed(42);
+        set_select_seed(42);
+        let mut offsets_a = Vec::new();
+        let mut experiment = Vec::new();
+        for _ in 0..5 {
+            offsets_a.push(select_offset_from_stream(8));
+            experiment.push(sim_random::<f64>());
+        }
+        for (c, e) in control.iter().zip(experiment.iter()) {
+            assert_f64_eq(*c, *e);
+        }
+        assert_eq!(
+            rng_call_count(),
+            control_count,
+            "select offsets must not touch the SIM_RNG call count"
+        );
+
+        // Same select seed replays the same offset stream.
+        set_select_seed(42);
+        let offsets_b: Vec<u32> = (0..5).map(|_| select_offset_from_stream(8)).collect();
+        assert_eq!(offsets_a, offsets_b);
+        assert!(
+            offsets_a.iter().any(|&o| o != offsets_a[0]),
+            "offset stream should vary"
+        );
+        reset_select_rng();
     }
 
     #[test]

--- a/moonpool-sim/src/sim/world.rs
+++ b/moonpool-sim/src/sim/world.rs
@@ -489,8 +489,8 @@ impl SimWorld {
 
     /// Create a task provider for this simulation
     #[must_use]
-    pub fn task_provider(&self) -> crate::TokioTaskProvider {
-        crate::TokioTaskProvider
+    pub fn task_provider(&self) -> crate::providers::SimTaskProvider {
+        crate::providers::SimTaskProvider
     }
 
     /// Create a storage provider for this simulation scoped to a process IP.

--- a/moonpool-sim/tests/chaos/connect_failure.rs
+++ b/moonpool-sim/tests/chaos/connect_failure.rs
@@ -199,7 +199,8 @@ fn test_connect_failure_mode_probabilistic_with_timeout() {
         // This simulates how production code should handle potential hangs
         let timeout_duration = Duration::from_millis(100);
 
-        let connect_result = tokio::select! {
+        let connect_result = moonpool_sim::select! {
+            biased;
             result = provider.connect(addr) => {
                 Some(result)
             }

--- a/moonpool-sim/tests/determinism.rs
+++ b/moonpool-sim/tests/determinism.rs
@@ -1,0 +1,102 @@
+//! End-to-end determinism guard: the same seed must replay the exact same
+//! execution, event for event, across full `SimulationBuilder` runs.
+//!
+//! This is the permanent tripwire for entropy leaks anywhere in the stack
+//! (executor scheduling, select! offsets, providers): if any component
+//! consults a non-seeded randomness source, the recorded traces diverge and
+//! this test fails.
+
+use std::sync::Mutex;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use moonpool_sim::{
+    SimContext, SimulationBuilder, SimulationResult, TaskProvider, TimeProvider, Workload,
+};
+
+/// Process-wide execution trace, rebuilt per run.
+static TRACE: Mutex<Vec<String>> = Mutex::new(Vec::new());
+
+fn record(entry: String) {
+    TRACE
+        .lock()
+        .expect("Mutex poisoned: prior task panicked")
+        .push(entry);
+}
+
+/// Spawns racing tasks that interleave sleeps and yields, recording every
+/// step with its virtual timestamp.
+struct RacingWorkload {
+    label: &'static str,
+}
+
+#[async_trait]
+impl Workload for RacingWorkload {
+    fn name(&self) -> &'static str {
+        self.label
+    }
+
+    async fn run(&mut self, ctx: &SimContext) -> SimulationResult<()> {
+        let mut handles = Vec::new();
+        for i in 0..4u32 {
+            let time = ctx.time().clone();
+            let task = ctx.task().yield_now();
+            drop(task); // exercise the provider surface without awaiting
+            let label = self.label;
+            handles.push(
+                ctx.task()
+                    .spawn_task(&format!("{label}-racer-{i}"), async move {
+                        for round in 0..3u32 {
+                            // Identical deadlines wake the racers in the same steps;
+                            // recording order captures the executor's decisions.
+                            let _ = time.sleep(Duration::from_millis(10)).await;
+                            record(format!("{label} task{i} round{round} t={:?}", time.now()));
+                        }
+                    }),
+            );
+        }
+        for handle in handles {
+            let _ = handle.await;
+        }
+        record(format!("{} done t={:?}", self.label, ctx.time().now()));
+        Ok(())
+    }
+}
+
+fn run_once(seed: u64) -> Vec<String> {
+    TRACE
+        .lock()
+        .expect("Mutex poisoned: prior task panicked")
+        .clear();
+    let report = SimulationBuilder::new()
+        .workload(RacingWorkload { label: "alpha" })
+        .workload(RacingWorkload { label: "beta" })
+        .set_debug_seeds(vec![seed])
+        // Exactly one iteration: the default UntilCoverageStable keeps
+        // iterating past the debug seed, which is not what a trace-equality
+        // check wants.
+        .set_iterations(1)
+        .run();
+    assert_eq!(report.failed_runs, 0, "seed {seed} must succeed");
+    TRACE
+        .lock()
+        .expect("Mutex poisoned: prior task panicked")
+        .clone()
+}
+
+#[test]
+fn same_seed_produces_identical_execution_traces() {
+    let first = run_once(42);
+    let second = run_once(42);
+    assert!(!first.is_empty(), "the workloads must have recorded steps");
+    assert_eq!(
+        first, second,
+        "same seed must replay the exact same execution"
+    );
+}
+
+#[test]
+fn other_seeds_also_complete() {
+    let trace = run_once(7);
+    assert!(!trace.is_empty());
+}

--- a/moonpool-sim/tests/executor.rs
+++ b/moonpool-sim/tests/executor.rs
@@ -1,0 +1,207 @@
+//! Behavior suite for the moonpool deterministic executor.
+//!
+//! Covers the tokio-parity contracts the orchestrator relies on (join,
+//! abort, detach-on-drop, panic isolation, kill-on-drop) and the
+//! determinism properties that are the executor's reason to exist
+//! (same seed same schedule, different seeds different schedules).
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use moonpool_core::JoinError;
+use moonpool_sim::executor::{Executor, JoinHandle, spawn, until_stalled, yield_now};
+use parking_lot::Mutex;
+
+#[test]
+fn spawn_and_join_returns_the_output() {
+    let mut executor = Executor::new(1);
+    let value = executor.block_on(async {
+        let handle = spawn("answer", async { 21 * 2 });
+        handle.await.expect("task completed")
+    });
+    assert_eq!(value, 42);
+}
+
+#[test]
+fn abort_cancels_and_reports_cancelled() {
+    let mut executor = Executor::new(1);
+    executor.block_on(async {
+        let handle: JoinHandle<()> = spawn("parked", std::future::pending());
+        assert!(!handle.is_finished());
+        handle.abort();
+        assert!(handle.is_finished());
+        match handle.await {
+            Err(JoinError::Cancelled) => {}
+            other => panic!("expected Cancelled, got {other:?}"),
+        }
+    });
+}
+
+#[test]
+fn panicking_task_is_isolated() {
+    let mut executor = Executor::new(1);
+    let sibling_output = executor.block_on(async {
+        let panicky: JoinHandle<()> = spawn("panicky", async { panic!("task boom") });
+        let sibling = spawn("sibling", async { 7 });
+
+        match panicky.await {
+            Err(JoinError::Panicked) => {}
+            other => panic!("expected Panicked, got {other:?}"),
+        }
+        // The sibling and the driver are unaffected by the panic.
+        sibling.await.expect("sibling completed")
+    });
+    assert_eq!(sibling_output, 7);
+}
+
+#[test]
+fn dropping_the_handle_detaches_the_task() {
+    let mut executor = Executor::new(1);
+    let ran = Arc::new(AtomicBool::new(false));
+    let ran_clone = Arc::clone(&ran);
+    executor.block_on(async move {
+        let handle = spawn("detached", async move {
+            ran_clone.store(true, Ordering::Relaxed);
+        });
+        drop(handle);
+        // One full drain later, the detached task has still run.
+        until_stalled().await;
+    });
+    assert!(ran.load(Ordering::Relaxed), "detached task must still run");
+}
+
+#[test]
+fn until_stalled_drains_every_runnable_task() {
+    let mut executor = Executor::new(1);
+    let log: Arc<Mutex<Vec<u64>>> = Arc::new(Mutex::new(Vec::new()));
+    executor.block_on(async {
+        for i in 0..8u64 {
+            let log = Arc::clone(&log);
+            drop(spawn(&format!("task-{i}"), async move {
+                // Two poll rounds each: yield once, then record.
+                yield_now().await;
+                log.lock().push(i);
+            }));
+        }
+        assert!(log.lock().is_empty(), "driver runs before any task");
+        until_stalled().await;
+        assert_eq!(log.lock().len(), 8, "all tasks polled to completion");
+    });
+}
+
+/// Run 16 immediately-ready tasks and record their completion order.
+fn completion_order(seed: u64) -> Vec<u64> {
+    let mut executor = Executor::new(seed);
+    let log: Arc<Mutex<Vec<u64>>> = Arc::new(Mutex::new(Vec::new()));
+    executor.block_on(async {
+        for i in 0..16u64 {
+            let log = Arc::clone(&log);
+            drop(spawn(&format!("task-{i}"), async move {
+                log.lock().push(i);
+            }));
+        }
+        until_stalled().await;
+    });
+    let order = log.lock().clone();
+    drop(executor);
+    order
+}
+
+#[test]
+fn same_seed_replays_the_same_schedule() {
+    for seed in 0..4 {
+        assert_eq!(
+            completion_order(seed),
+            completion_order(seed),
+            "seed {seed} must replay identically"
+        );
+    }
+}
+
+#[test]
+fn different_seeds_explore_different_schedules() {
+    let orders: Vec<Vec<u64>> = (0..8).map(completion_order).collect();
+    let distinct = orders
+        .iter()
+        .collect::<std::collections::HashSet<_>>()
+        .len();
+    assert!(
+        distinct > 1,
+        "8 seeds should produce more than one task interleaving, got {orders:?}"
+    );
+    // And none of them is plain FIFO spawn order for ALL seeds (that would
+    // mean the scheduler ignores the seed entirely).
+    let fifo: Vec<u64> = (0..16).collect();
+    assert!(
+        orders.iter().any(|o| *o != fifo),
+        "at least one seed must deviate from FIFO order"
+    );
+}
+
+#[test]
+fn dropping_the_executor_cancels_parked_tasks() {
+    /// Sets a flag when the future holding it is dropped.
+    struct DropFlag(Arc<AtomicBool>);
+    impl Drop for DropFlag {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::Relaxed);
+        }
+    }
+
+    let dropped = Arc::new(AtomicBool::new(false));
+    let completed = Arc::new(AtomicBool::new(false));
+
+    let mut executor = Executor::new(1);
+    let flag = DropFlag(Arc::clone(&dropped));
+    let completed_clone = Arc::clone(&completed);
+    executor.block_on(async move {
+        drop(spawn("parked-forever", async move {
+            let _flag = flag;
+            std::future::pending::<()>().await;
+            completed_clone.store(true, Ordering::Relaxed);
+        }));
+        // Let the task run up to its await point, then leave it parked.
+        until_stalled().await;
+    });
+
+    assert!(!dropped.load(Ordering::Relaxed), "task is parked, not dead");
+    drop(executor);
+    assert!(
+        dropped.load(Ordering::Relaxed),
+        "executor drop must cancel the parked task and drop its future"
+    );
+    assert!(!completed.load(Ordering::Relaxed), "task must not complete");
+}
+
+#[test]
+fn yield_now_requeues_the_task() {
+    let mut executor = Executor::new(3);
+    let value = executor.block_on(async {
+        let counter = spawn("yielder", async {
+            let mut n = 0;
+            for _ in 0..5 {
+                yield_now().await;
+                n += 1;
+            }
+            n
+        });
+        counter.await.expect("yielder completed")
+    });
+    assert_eq!(value, 5);
+}
+
+#[test]
+#[should_panic(expected = "deterministic executor stalled (seed 9)")]
+fn genuine_deadlock_panics_with_the_seed() {
+    let mut executor = Executor::new(9);
+    executor.block_on(async {
+        // Awaits a wake that can never arrive: no task, no timer, nothing.
+        std::future::pending::<()>().await;
+    });
+}
+
+#[test]
+#[should_panic(expected = "executor::spawn called outside Executor::block_on")]
+fn spawn_outside_block_on_panics() {
+    drop(spawn("orphan", async {}));
+}

--- a/moonpool-sim/tests/executor.rs
+++ b/moonpool-sim/tests/executor.rs
@@ -38,6 +38,42 @@ fn abort_cancels_and_reports_cancelled() {
 }
 
 #[test]
+fn abort_after_completion_still_yields_the_output() {
+    // tokio parity: abort racing an already-finished task loses, and the
+    // output stays harvestable.
+    let mut executor = Executor::new(1);
+    let value = executor.block_on(async {
+        let handle = spawn("done-then-aborted", async { 11 });
+        until_stalled().await;
+        assert!(handle.is_finished());
+        handle.abort();
+        handle.await.expect("completed before abort: output kept")
+    });
+    assert_eq!(value, 11);
+}
+
+#[test]
+fn abort_before_first_poll_unregisters_the_task() {
+    // A task cancelled before it was ever polled must still leave the
+    // kill-on-drop registry (its future's captures hold the guard).
+    let mut executor = Executor::new(1);
+    executor.block_on(async {
+        let handle: JoinHandle<()> = spawn("never-polled", std::future::pending());
+        handle.abort();
+        until_stalled().await;
+        match handle.await {
+            Err(JoinError::Cancelled) => {}
+            other => panic!("expected Cancelled, got {other:?}"),
+        }
+    });
+    let debug = format!("{executor:?}");
+    assert!(
+        debug.contains("live_tasks: 0"),
+        "registry must be empty after the aborted task is reaped, got {debug}"
+    );
+}
+
+#[test]
 fn panicking_task_is_isolated() {
     let mut executor = Executor::new(1);
     let sibling_output = executor.block_on(async {

--- a/moonpool-sim/tests/hyper_http.rs
+++ b/moonpool-sim/tests/hyper_http.rs
@@ -85,14 +85,16 @@ impl Process for HyperServer {
     async fn run(&mut self, ctx: &SimContext) -> SimulationResult<()> {
         let listener = ctx.network().bind(ctx.my_ip()).await?;
 
-        let (stream, _addr) = tokio::select! {
+        let (stream, _addr) = moonpool_sim::select! {
+            biased;
             result = listener.accept() => result?,
             () = ctx.shutdown().cancelled() => return Ok(()),
         };
 
         let io = TokioIo::new(stream.compat());
 
-        tokio::select! {
+        moonpool_sim::select! {
+            biased;
             result = hyper::server::conn::http1::Builder::new()
                 .serve_connection(io, service_fn(handle_request)) => {
                 // Ignore hyper errors during shutdown (connection reset, incomplete message)
@@ -125,7 +127,8 @@ impl Workload for HyperClient {
         })?;
 
         // Connect with shutdown awareness (connect may hang forever under chaos)
-        let stream = tokio::select! {
+        let stream = moonpool_sim::select! {
+            biased;
             result = ctx.network().connect(&server_ip) => result?,
             () = ctx.shutdown().cancelled() => return Ok(()),
         };
@@ -146,7 +149,8 @@ impl Workload for HyperClient {
             }
         };
 
-        tokio::select! {
+        moonpool_sim::select! {
+            biased;
             result = send_requests(&mut sender, &server_ip) => result?,
             () = driver => {}
             () = ctx.shutdown().cancelled() => {}

--- a/moonpool-sim/tests/reboot.rs
+++ b/moonpool-sim/tests/reboot.rs
@@ -31,7 +31,8 @@ impl Process for EchoProcess {
         tracing::debug!("EchoProcess bound to {}", ctx.my_ip());
 
         loop {
-            let result = tokio::select! {
+            let result = moonpool_sim::select! {
+                biased;
                 r = listener.accept() => r,
                 () = ctx.shutdown().cancelled() => return Ok(()),
             };
@@ -339,7 +340,8 @@ impl Process for GracefulProcess {
         tracing::info!("GracefulProcess bound to {}", ctx.my_ip());
 
         loop {
-            tokio::select! {
+            moonpool_sim::select! {
+                biased;
                 result = listener.accept() => {
                     if let Ok((mut stream, _)) = result {
                         use futures::io::{AsyncReadExt, AsyncWriteExt};

--- a/moonpool-sim/tests/topology.rs
+++ b/moonpool-sim/tests/topology.rs
@@ -58,7 +58,8 @@ impl Process for LocalityProcess {
         // Bind so the workload can connect, then idle until shutdown.
         let listener = ctx.network().bind(ctx.my_ip()).await?;
         loop {
-            tokio::select! {
+            moonpool_sim::select! {
+                biased;
                 _ = listener.accept() => {}
                 () = ctx.shutdown().cancelled() => return Ok(()),
             }

--- a/moonpool-transport-sim/Cargo.toml
+++ b/moonpool-transport-sim/Cargo.toml
@@ -14,7 +14,6 @@ moonpool-transport = { path = "../moonpool-transport", version = "0.7.0" }
 
 async-trait = "0.1"
 serde = { version = "1", features = ["derive"] }
-tokio = { version = "1", features = ["macros"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 

--- a/moonpool-transport-sim/src/process.rs
+++ b/moonpool-transport-sim/src/process.rs
@@ -52,7 +52,8 @@ impl Process for TransportServerProcess {
         let shutdown = ctx.shutdown().clone();
 
         loop {
-            tokio::select! {
+            moonpool_sim::select! {
+                biased;
                 Some((req, reply)) = append_stream.recv() => {
                     handle_append(&mut h, &mut n, &req, reply, my_ip);
                 }

--- a/moonpool-transport-sim/src/workload.rs
+++ b/moonpool-transport-sim/src/workload.rs
@@ -261,7 +261,8 @@ impl Workload for TransportClientWorkload {
                 Op::NormalAppend | Op::EmptyBlock | Op::MaxSizeBlock => {
                     match get_reply(&*transport, &endpoint, req, &encode, decode.clone()) {
                         Ok(fut) => {
-                            let drained: Option<Result<AppendBlockResponse, ReplyError>> = tokio::select! {
+                            let drained: Option<Result<AppendBlockResponse, ReplyError>> = moonpool_sim::select! {
+                                biased;
                                 r = fut => Some(r),
                                 () = shutdown.cancelled() => None,
                                 _ = time.sleep(Duration::from_secs(10)) => None,

--- a/moonpool-transport/Cargo.toml
+++ b/moonpool-transport/Cargo.toml
@@ -9,10 +9,6 @@ description = "FDB-style transport layer for the moonpool framework"
 documentation = "https://docs.rs/moonpool-transport"
 readme = "README.md"
 
-[package.metadata.docs.rs]
-rustdoc-args = ["--cfg", "tokio_unstable"]
-rustc-args = ["--cfg", "tokio_unstable"]
-
 [features]
 # Production convenience: the TokioTransport alias + NetTransportBuilder::tokio()
 # shortcut, which need core's TokioProviders. Default-on so examples/tests build;

--- a/moonpool-transport/Cargo.toml
+++ b/moonpool-transport/Cargo.toml
@@ -23,7 +23,9 @@ tokio = ["moonpool-core/tokio-providers"]
 [dependencies]
 # Transport is generic over `P: Providers`; it doesn't need core's production
 # providers unless the `tokio` feature is on (TokioTransport / Builder::tokio()).
-moonpool-core = { path = "../moonpool-core", version = "0.7.0", default-features = false }
+# "select" provides moonpool_core::select! (tokio passthrough here; sim-linking
+# build graphs flip it to the deterministic combinator via feature unification).
+moonpool-core = { path = "../moonpool-core", version = "0.7.0", default-features = false, features = ["select"] }
 moonpool-transport-derive = { path = "../moonpool-transport-derive", version = "0.7.0" }
 
 async-trait = "0.1"
@@ -32,9 +34,12 @@ futures = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2.0"
-# Library code only uses tokio::sync (Notify/mpsc/watch) and the select!/pin! macros.
-# spawn/runtime/time live in #[cfg(test)] mods and pull "full" via dev-dependencies.
-tokio = { version = "1", features = ["sync", "macros"] }
+# Library code only uses tokio::sync (Notify/mpsc); select! comes from
+# moonpool-core and pin! from std. spawn/runtime/time live in #[cfg(test)] mods
+# and pull "full" via dev-dependencies.
+tokio = { version = "1", features = ["sync"] }
+# CancellationToken for shutdown signalling (deterministic FIFO wake order).
+tokio-util = { version = "0.7", default-features = false }
 tracing = "0.1"
 
 [dev-dependencies]

--- a/moonpool-transport/examples/dynamic_endpoint.rs
+++ b/moonpool-transport/examples/dynamic_endpoint.rs
@@ -143,9 +143,11 @@ async fn run_server() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("Waiting for requests...\n");
 
-    // Handle requests (only from the first server for this demo)
+    // Handle requests (only from the first server for this demo).
+    // Four peer method queues: moonpool's select! keeps fair (rotated) polling
+    // between them, so a burst on one queue cannot starve the others.
     loop {
-        tokio::select! {
+        moonpool_core::select! {
             Some((req, reply)) = calc.add.recv() => {
                 let result = req.a + req.b;
                 println!("ADD: {} + {} = {}", req.a, req.b, result);

--- a/moonpool-transport/examples/well_known_endpoint.rs
+++ b/moonpool-transport/examples/well_known_endpoint.rs
@@ -100,8 +100,9 @@ async fn run_server() -> Result<(), Box<dyn std::error::Error>> {
     );
     println!("Waiting for ping requests...\n");
 
+    // Two peer streams (ping, heartbeat): fair rotated polling, not `biased;`.
     loop {
-        tokio::select! {
+        moonpool_core::select! {
             maybe_ping = ping_server.ping.recv() => {
                 if let Some((request, reply)) = maybe_ping {
                     println!("Received ping seq={}: {:?}", request.seq, request.message);

--- a/moonpool-transport/src/peer/core.rs
+++ b/moonpool-transport/src/peer/core.rs
@@ -671,7 +671,11 @@ async fn connection_task<P: Providers>(
         );
         let ping_active = ping_sleep_duration.is_some();
 
-        tokio::select! {
+        // Deliberately NOT `biased;`: data_to_send (outbound) and read (inbound)
+        // are peer data sources that can be ready in the same poll; the seeded
+        // rotation lets different seeds explore both send-first and read-first
+        // interleavings instead of pinning one winner forever.
+        moonpool_core::select! {
             // Check for shutdown
             _ = shutdown_rx.recv() => {
                 break;

--- a/moonpool-transport/src/peer/core.rs
+++ b/moonpool-transport/src/peer/core.rs
@@ -673,8 +673,8 @@ async fn connection_task<P: Providers>(
 
         // Deliberately NOT `biased;`: data_to_send (outbound) and read (inbound)
         // are peer data sources that can be ready in the same poll; the seeded
-        // rotation lets different seeds explore both send-first and read-first
-        // interleavings instead of pinning one winner forever.
+        // start offset lets different seeds explore both send-first and
+        // read-first interleavings instead of pinning one winner forever.
         moonpool_core::select! {
             // Check for shutdown
             _ = shutdown_rx.recv() => {

--- a/moonpool-transport/src/rpc/delivery.rs
+++ b/moonpool-transport/src/rpc/delivery.rs
@@ -45,8 +45,12 @@ where
     Resp: DeserializeOwned + Send + Sync + 'static,
     S: Future<Output = ()>,
 {
-    tokio::pin!(signal);
-    tokio::select! {
+    let mut signal = std::pin::pin!(signal);
+    // Reply and signal become ready via distinct simulation events, so the
+    // event queue decides the winner; `biased;` (reply first, matching FDB's
+    // reply-wins-if-resolved semantics) keeps this select offset-free.
+    moonpool_core::select! {
+        biased;
         result = reply_future => match result {
             Ok(resp) => Ok(resp),
             Err(ReplyError::BrokenPromise) => {

--- a/moonpool-transport/src/rpc/net_transport.rs
+++ b/moonpool-transport/src/rpc/net_transport.rs
@@ -36,7 +36,7 @@ use crate::{
     Endpoint, NetworkAddress, NetworkProvider, Peer, PeerConfig, Providers, TaskProvider,
     TcpListenerTrait, UID, WellKnownToken,
 };
-use tokio::sync::watch;
+use tokio_util::sync::CancellationToken;
 
 use super::endpoint_map::{EndpointMap, MessageReceiver};
 use super::request_stream::RequestStream;
@@ -147,9 +147,11 @@ pub struct NetTransport<P: Providers, C: MessageCodec = crate::JsonCodec> {
     /// Set via `set_weak_self()` after wrapping in `Arc`.
     weak_self: RwLock<Option<Weak<Self>>>,
 
-    /// Shutdown signal sender. When set to `true`, background tasks (`listen_task`) should exit.
-    /// Uses watch channel so multiple receivers can observe the same signal.
-    shutdown_tx: watch::Sender<bool>,
+    /// Shutdown signal. Cancelled on drop so background tasks (`listen_task`)
+    /// exit. `CancellationToken` has deterministic FIFO wake order, unlike
+    /// `tokio::sync::watch` whose shard pick draws from tokio's runtime RNG
+    /// (entropy-seeded outside a tokio runtime).
+    shutdown: CancellationToken,
 
     /// Weak reference as `dyn TransportHandle` for codec-erased types.
     /// Set by the builder alongside `weak_self`.
@@ -186,7 +188,6 @@ impl<P: Providers + Send + Sync, C: MessageCodec> NetTransport<P, C> {
     /// transport.set_weak_self(Arc::downgrade(&transport));
     /// ```
     pub fn new(local_address: NetworkAddress, providers: P, codec: C) -> Self {
-        let (shutdown_tx, _) = watch::channel(false);
         let data = TransportData::new(&providers);
         Self {
             data: RwLock::new(data),
@@ -195,7 +196,7 @@ impl<P: Providers + Send + Sync, C: MessageCodec> NetTransport<P, C> {
             codec,
             peer_config: PeerConfig::default(),
             weak_self: RwLock::new(None),
-            shutdown_tx,
+            shutdown: CancellationToken::new(),
             weak_handle: RwLock::new(None),
         }
     }
@@ -468,7 +469,7 @@ impl<P: Providers + Send + Sync, C: MessageCodec> NetTransport<P, C> {
     /// );
     ///
     /// loop {
-    ///     tokio::select! {
+    ///     moonpool_core::select! {
     ///         Some((req, reply)) = add_stream.recv() => {
     ///             reply.send(AddResponse { result: req.a + req.b });
     ///         }
@@ -889,12 +890,12 @@ impl<P: Providers + Send + Sync, C: MessageCodec> NetTransport<P, C> {
         tracing::info!("NetTransport: listening on {}", addr_str);
 
         // Spawn listen task (FDB: listen() actor)
-        // Pass shutdown receiver so the task can exit when transport is dropped
+        // Pass a shutdown token clone so the task can exit when transport is dropped
         let transport_weak = self.weak_self();
-        let shutdown_rx = self.shutdown_tx.subscribe();
+        let shutdown = self.shutdown.clone();
         drop(self.providers.task().spawn_task(
             "listen",
-            listen_task(transport_weak, listener, addr_str, shutdown_rx),
+            listen_task(transport_weak, listener, addr_str, shutdown),
         ));
 
         Ok(())
@@ -908,8 +909,7 @@ impl<P: Providers + Send + Sync, C: MessageCodec> NetTransport<P, C> {
 impl<P: Providers, C: MessageCodec> Drop for NetTransport<P, C> {
     fn drop(&mut self) {
         tracing::debug!("NetTransport: signaling shutdown to background tasks");
-        // Signal shutdown - ignore error if no receivers
-        let _ = self.shutdown_tx.send(true);
+        self.shutdown.cancel();
     }
 }
 
@@ -1275,32 +1275,20 @@ async fn listen_task<P: Providers + Send + Sync, C: MessageCodec>(
     transport: Weak<NetTransport<P, C>>,
     listener: <P::Network as NetworkProvider>::TcpListener,
     listen_addr: String,
-    mut shutdown_rx: watch::Receiver<bool>,
+    shutdown: CancellationToken,
 ) {
     tracing::debug!("listen_task: started on {}", listen_addr);
 
     loop {
         // Use select! to race between accept and shutdown signal
-        tokio::select! {
+        moonpool_core::select! {
             // Bias toward shutdown to ensure timely exit
             biased;
 
             // Check shutdown signal first
-            result = shutdown_rx.changed() => {
-                match result {
-                    Ok(()) if *shutdown_rx.borrow() => {
-                        tracing::debug!("listen_task: shutdown signal received, exiting for {}", listen_addr);
-                        break;
-                    }
-                    Err(_) => {
-                        // Channel closed means transport was dropped
-                        tracing::debug!("listen_task: shutdown channel closed, exiting for {}", listen_addr);
-                        break;
-                    }
-                    _ => {
-                        // Value changed but not to true - continue
-                    }
-                }
+            () = shutdown.cancelled() => {
+                tracing::debug!("listen_task: shutdown signal received, exiting for {}", listen_addr);
+                break;
             }
 
             // Accept next connection

--- a/moonpool-wasm-demo/Cargo.toml
+++ b/moonpool-wasm-demo/Cargo.toml
@@ -23,9 +23,6 @@ serde_json = "1"
 # The workload emits standard `client_*` observability events; the generic
 # recorder reconstructs the timeline from them.
 tracing = "0.1"
-# `macros` for `tokio::select!` in the workload/server loops. The runtime itself
-# comes from moonpool-sim.
-tokio = { version = "1", features = ["macros"] }
 
 # wasm-only glue. The crate version MUST exactly match the flake's
 # wasm-bindgen-cli (0.2.121) — a mismatch is the #1 wasm-bindgen footgun and

--- a/moonpool-wasm-demo/src/lib.rs
+++ b/moonpool-wasm-demo/src/lib.rs
@@ -215,7 +215,8 @@ impl Process for PongServer {
 
         let shutdown = ctx.shutdown().clone();
         loop {
-            tokio::select! {
+            moonpool_sim::select! {
+                biased;
                 Some((req, reply)) = ping_stream.recv() => {
                     reply.send(Pong { seq: req.seq });
                 }
@@ -273,7 +274,8 @@ impl Workload for PingClient {
                 &encode,
                 decode.clone(),
             ) {
-                Ok(fut) => tokio::select! {
+                Ok(fut) => moonpool_sim::select! {
+                    biased;
                     r = fut => Some(r),
                     () = shutdown.cancelled() => None,
                     _ = time.sleep(Duration::from_millis(TIMEOUT_MS)) => None,

--- a/moonpool/Cargo.toml
+++ b/moonpool/Cargo.toml
@@ -16,8 +16,10 @@ readme = "README.md"
 default = ["sim", "tokio", "transport"]
 sim = ["dep:moonpool-sim"]
 transport = ["dep:moonpool-transport"]
-# Production providers (TokioProviders) on core, and the transport tokio shortcut.
-tokio = ["moonpool-core/tokio-providers", "moonpool-transport?/tokio"]
+# Production providers (TokioProviders) on core, the transport tokio shortcut,
+# and moonpool::select! (core's tokio passthrough) so the documented lean
+# config `default-features = false, features = ["tokio"]` has the macro too.
+tokio = ["moonpool-core/tokio-providers", "moonpool-core/select", "moonpool-transport?/tokio"]
 
 [dependencies]
 moonpool-core = { path = "../moonpool-core", version = "0.7.0", default-features = false }


### PR DESCRIPTION
Closes #151.

**Built on #150** (merged, thanks @FlorentinDUBOIS): this branch is rebased on top of it. The final commit then goes further than the cfg-gate: task naming is removed from `TokioTaskProvider` entirely. Spawning uses plain `tokio::spawn`, the task name only feeds the surrounding trace spans, and the workspace `unexpected_cfgs` declaration is gone, so no `cfg(tokio_unstable)` remains anywhere in the tree.

## What

moonpool no longer needs `--cfg tokio_unstable`, anywhere, for anything. Downstream consumers (the issue's motivating case: stable-pinned Sozu with no rustflags) build on plain stable Rust. Along the way the simulation gains a capability tokio could not provide: task scheduling order is now a seeded, per-iteration-reproducible random choice, so the seed space explores task interleavings instead of replaying one FIFO order forever.

## Why this shape

The exploration behind the design found that tokio's unstable `RngSeed` never randomized current-thread task scheduling at all (the run queue is plain FIFO): its only load-bearing effect was seeding `thread_rng_n`, which `tokio::select!` uses for its branch-poll offset. That reframed the work as two independent pieces:

1. **`select!` determinism** without tokio internals: `moonpool::select!` is a thin rotation combinator. Tokio's fair mode is exactly `biased;` plus a random start index, so the macro draws the start from a moonpool-owned seeded stream and dispatches over the N rotations of a real `tokio::select! { biased; ... }`. All polling mechanics (disabled mask, preconditions, refutable patterns, else, coop budget) are inherited from tokio, never copied. Production builds get a verbatim `pub use tokio::select` passthrough; the `deterministic-select` feature (enabled by moonpool-sim, propagated by cargo feature unification) flips sim-linking graphs to the combinator.
2. **A moonpool-owned executor** (async-task backbone, madsim's seeded swap_remove scheduling). No reactor needed: SimWorld's event queue already plays that role. Tokio-parity JoinHandle (await/is_finished/abort/detach-on-drop), catch_unwind panic isolation, kill-on-drop waker registry preserving the iteration-hermeticity contract, and an explicit `until_stalled()` driver primitive that replaces the yield_now/FIFO dance with a strictly stronger guarantee.

Guard-style selects (20 sites: work vs shutdown/timeout) are now `biased;`, which changes nothing observable (the event queue's deterministic tie-break already decided those) and removes the offset draw. The two true peer races (transport connection_task send-vs-receive, the axum example accept loop) keep the seeded rotation so seeds explore both winners. `tokio::sync::watch` (whose shard pick also draws tokio entropy) became a `CancellationToken`.

## Breaking

Recorded simulation seeds from earlier versions are invalidated: scheduling and select offsets now come from moonpool-owned seeded streams, so a given seed produces a different (still fully deterministic) execution. Re-baseline stored failing seeds.

## Verification

- 620 tests pass on a full rebuild with no rustflags; clippy pedantic clean in default and no-default-features modes
- `cargo xtask sim run-all`: 6/6 simulation binaries
- New permanent guards: executor contract suite (same-seed replay, cross-seed schedule diversity) and an end-to-end determinism tripwire (two SimulationBuilder runs on one seed must produce byte-identical traces)
- wasm32 gates: moonpool-sim (which no longer depends on tokio at all), moonpool-wasm-demo, and (new) moonpool-transport
- CI now enforces the acceptance criterion directly: a no-rustflags `cargo check` of core/sim/transport
- Book: new chapter (The Deterministic Executor) plus 13 chapters updated for the executor and the select idiom

🤖 Generated with [Claude Code](https://claude.com/claude-code)

