### PR TITLE
fix(moonpool-sim): use real client IP when creating connection pairs

### DIFF
--- a/moonpool-sim/src/network/sim/provider.rs
+++ b/moonpool-sim/src/network/sim/provider.rs
@@ -5,19 +5,28 @@ use crate::network::ConnectFailureMode;
 use crate::sim::rng::sim_random;
 use crate::{Event, WeakSimWorld};
 use std::io;
+use std::net::IpAddr;
 use tracing::instrument;
 
 /// Simulated networking implementation
+///
+/// Scoped to the IP of the process that owns it: [`connect`](Self::connect)
+/// uses this IP as the local address for the connections it initiates, so
+/// per-pair chaos (e.g. `max_pair_latency`) can key off the real client IP
+/// instead of a placeholder.
 #[derive(Debug, Clone)]
 pub struct SimNetworkProvider {
     sim: WeakSimWorld,
+    /// IP address of the process that owns connections initiated through
+    /// this provider.
+    local_ip: IpAddr,
 }
 
 impl SimNetworkProvider {
-    /// Create a new simulated network provider
+    /// Create a new simulated network provider scoped to a process IP.
     #[must_use]
-    pub fn new(sim: WeakSimWorld) -> Self {
-        Self { sim }
+    pub fn new(sim: WeakSimWorld, local_ip: IpAddr) -> Self {
+        Self { sim, local_ip }
     }
 
     /// Sleep in simulation time.
@@ -126,8 +135,11 @@ impl NetworkProvider for SimNetworkProvider {
         let delay = sim
             .with_network_config(|config| crate::network::sample_latency(&config.connect_latency));
 
-        // Create a connection pair for bidirectional communication
-        let (client_id, server_id) = sim.create_connection_pair("client-addr", addr);
+        // Create a connection pair for bidirectional communication, using this
+        // process's real IP as the client's local address (port is irrelevant,
+        // only the IP is parsed out) so per-pair chaos can key off it.
+        let client_addr = std::net::SocketAddr::new(self.local_ip, 0).to_string();
+        let (client_id, server_id) = sim.create_connection_pair(&client_addr, addr);
 
         // FDB SimClogging: fix a permanent per-pair latency at first contact, for
         // both directions. No-op (returns ZERO, no RNG) when max_pair_latency is off.

--- a/moonpool-sim/src/providers/sim_providers.rs
+++ b/moonpool-sim/src/providers/sim_providers.rs
@@ -57,7 +57,7 @@ impl SimProviders {
     #[must_use]
     pub fn new(sim: WeakSimWorld, seed: u64, ip: IpAddr) -> Self {
         Self {
-            network: SimNetworkProvider::new(sim.clone()),
+            network: SimNetworkProvider::new(sim.clone(), ip),
             time: SimTimeProvider::new(sim.clone()),
             task: SimTaskProvider,
             random: SimRandomProvider::new(seed),

--- a/moonpool-sim/src/sim/world.rs
+++ b/moonpool-sim/src/sim/world.rs
@@ -475,10 +475,14 @@ impl SimWorld {
             .len()
     }
 
-    /// Create a network provider for this simulation
+    /// Create a network provider for this simulation scoped to a process IP.
+    ///
+    /// The IP is used as the local address for connections this provider
+    /// initiates via [`NetworkProvider::connect`](crate::NetworkProvider::connect),
+    /// so per-pair chaos (e.g. `max_pair_latency`) can key off it.
     #[must_use]
-    pub fn network_provider(&self) -> SimNetworkProvider {
-        SimNetworkProvider::new(self.downgrade())
+    pub fn network_provider(&self, ip: std::net::IpAddr) -> SimNetworkProvider {
+        SimNetworkProvider::new(self.downgrade(), ip)
     }
 
     /// Create a time provider for this simulation
@@ -3013,7 +3017,7 @@ impl WeakSimWorld {
     weak_forward!(pass #[doc = "Read data from connection's receive buffer."] read_from_connection(&self, connection_id: ConnectionId, buf: &mut [u8]) -> usize);
     weak_forward!(pass #[doc = "Write data to connection's receive buffer."] write_to_connection(&self, connection_id: ConnectionId, data: &[u8]) -> ());
     weak_forward!(pass #[doc = "Buffer data for ordered sending on a connection."] buffer_send(&self, connection_id: ConnectionId, data: Vec<u8>) -> ());
-    weak_forward!(wrap #[doc = "Get a network provider for the simulation."] network_provider(&self) -> SimNetworkProvider);
+    weak_forward!(wrap #[doc = "Get a network provider for the simulation scoped to a process IP."] network_provider(&self, ip: std::net::IpAddr) -> SimNetworkProvider);
     weak_forward!(wrap #[doc = "Get a time provider for the simulation."] time_provider(&self) -> crate::providers::SimTimeProvider);
     weak_forward!(wrap #[doc = "Sleep for the specified duration in simulation time."] sleep(&self, duration: Duration) -> SleepFuture);
 

--- a/moonpool-sim/tests/chaos/bit_flip.rs
+++ b/moonpool-sim/tests/chaos/bit_flip.rs
@@ -27,7 +27,7 @@ fn test_bit_flip_disabled_with_zero_probability() {
         config.chaos.bit_flip_probability = 0.0; // Explicitly disable
 
         let mut sim = SimWorld::new_with_network_config(config);
-        let provider = sim.network_provider();
+        let provider = sim.network_provider("127.0.0.1".parse().expect("valid ip"));
 
         // Send multiple messages
         let addr = "test-server";
@@ -71,7 +71,7 @@ fn test_bit_flip_injection_with_high_probability() {
         config.chaos.bit_flip_cooldown = Duration::ZERO;
 
         let mut sim = SimWorld::new_with_network_config(config);
-        let provider = sim.network_provider();
+        let provider = sim.network_provider("127.0.0.1".parse().expect("valid ip"));
 
         let addr = "chaos-server";
         let listener = provider.bind(addr).await.unwrap();
@@ -115,7 +115,7 @@ fn test_bit_flip_cooldown() {
         config.chaos.bit_flip_cooldown = Duration::from_secs(10); // Long cooldown
 
         let mut sim = SimWorld::new_with_network_config(config);
-        let provider = sim.network_provider();
+        let provider = sim.network_provider("127.0.0.1".parse().expect("valid ip"));
 
         let addr = "cooldown-server";
         let listener = provider.bind(addr).await.unwrap();
@@ -153,7 +153,7 @@ fn test_peer_checksum_error_recovery() {
         config.chaos.bit_flip_cooldown = Duration::ZERO;
 
         let mut sim = SimWorld::new_with_network_config(config);
-        let provider = sim.network_provider();
+        let provider = sim.network_provider("127.0.0.1".parse().expect("valid ip"));
 
         let addr = "recovery-server";
         let listener = provider.bind(addr).await.unwrap();
@@ -191,7 +191,7 @@ fn test_bit_flip_with_message_exchange() {
         config.chaos.bit_flip_cooldown = Duration::ZERO;
 
         let mut sim = SimWorld::new_with_network_config(config);
-        let provider = sim.network_provider();
+        let provider = sim.network_provider("127.0.0.1".parse().expect("valid ip"));
 
         let addr = "message-exchange";
         let listener = provider.bind(addr).await.unwrap();

--- a/moonpool-sim/tests/chaos/connect_failure.rs
+++ b/moonpool-sim/tests/chaos/connect_failure.rs
@@ -30,7 +30,7 @@ fn test_connect_failure_mode_disabled() {
         config.chaos.connect_failure_mode = ConnectFailureMode::Disabled;
 
         let sim = SimWorld::new_with_network_config(config);
-        let provider = sim.network_provider();
+        let provider = sim.network_provider("127.0.0.1".parse().expect("valid ip"));
 
         let addr = "test-server";
         let _listener = provider.bind(addr).await.unwrap();
@@ -67,7 +67,7 @@ fn test_connect_failure_mode_always_fail() {
         config.chaos.connect_failure_mode = ConnectFailureMode::AlwaysFail;
 
         let sim = SimWorld::new_with_network_config(config);
-        let provider = sim.network_provider();
+        let provider = sim.network_provider("127.0.0.1".parse().expect("valid ip"));
 
         let addr = "fail-server";
         let _listener = provider.bind(addr).await.unwrap();
@@ -110,7 +110,7 @@ fn test_connect_failure_mode_probabilistic_error() {
         config.chaos.connect_failure_probability = 0.0;
 
         let sim = SimWorld::new_with_network_config(config);
-        let provider = sim.network_provider();
+        let provider = sim.network_provider("127.0.0.1".parse().expect("valid ip"));
 
         let addr = "prob-server";
         let _listener = provider.bind(addr).await.unwrap();
@@ -152,7 +152,7 @@ fn test_connect_failure_requires_buggify() {
         config.chaos.connect_failure_mode = ConnectFailureMode::AlwaysFail; // Would fail if buggify active
 
         let sim = SimWorld::new_with_network_config(config);
-        let provider = sim.network_provider();
+        let provider = sim.network_provider("127.0.0.1".parse().expect("valid ip"));
 
         let addr = "no-buggify-server";
         let _listener = provider.bind(addr).await.unwrap();
@@ -190,7 +190,7 @@ fn test_connect_failure_mode_probabilistic_with_timeout() {
         config.chaos.connect_failure_probability = 1.0; // 100% hang (not error)
 
         let sim = SimWorld::new_with_network_config(config);
-        let provider = sim.network_provider();
+        let provider = sim.network_provider("127.0.0.1".parse().expect("valid ip"));
 
         let addr = "hang-server";
         let _listener = provider.bind(addr).await.unwrap();
@@ -238,7 +238,7 @@ fn test_connect_failure_deterministic() {
             config.chaos.connect_failure_mode = ConnectFailureMode::AlwaysFail;
 
             let sim = SimWorld::new_with_network_config(config);
-            let provider = sim.network_provider();
+            let provider = sim.network_provider("127.0.0.1".parse().expect("valid ip"));
 
             let addr = "det-server";
             let _listener = provider.bind(addr).await.unwrap();
@@ -281,7 +281,7 @@ fn test_connect_failure_existing_connections() {
         config.chaos.connect_failure_mode = ConnectFailureMode::Disabled; // Start with disabled
 
         let mut sim = SimWorld::new_with_network_config(config);
-        let provider = sim.network_provider();
+        let provider = sim.network_provider("127.0.0.1".parse().expect("valid ip"));
 
         let addr = "existing-conn-server";
         let _listener = provider.bind(addr).await.unwrap();
@@ -321,7 +321,7 @@ fn test_connect_failure_error_message_always_fail() {
         config.chaos.connect_failure_mode = ConnectFailureMode::AlwaysFail;
 
         let sim = SimWorld::new_with_network_config(config);
-        let provider = sim.network_provider();
+        let provider = sim.network_provider("127.0.0.1".parse().expect("valid ip"));
 
         let addr = "error-msg-server";
         let _listener = provider.bind(addr).await.unwrap();
@@ -362,7 +362,7 @@ fn test_connect_failure_error_message_probabilistic() {
         config.chaos.connect_failure_probability = 0.0; // Force error path, not hang
 
         let sim = SimWorld::new_with_network_config(config);
-        let provider = sim.network_provider();
+        let provider = sim.network_provider("127.0.0.1".parse().expect("valid ip"));
 
         let addr = "error-msg-server-2";
         let _listener = provider.bind(addr).await.unwrap();
@@ -412,7 +412,7 @@ fn test_connect_failure_random_config() {
         );
 
         let sim = SimWorld::new_with_network_config(config);
-        let provider = sim.network_provider();
+        let provider = sim.network_provider("127.0.0.1".parse().expect("valid ip"));
 
         let addr = "random-config-server";
         let _listener = provider.bind(addr).await.unwrap();

--- a/moonpool-sim/tests/chaos/partial_read.rs
+++ b/moonpool-sim/tests/chaos/partial_read.rs
@@ -27,7 +27,7 @@ async fn drain_with_partial_reads(seed: u64, max_bytes: usize, payload: &[u8]) -
     config.chaos.partial_read_max_bytes = max_bytes;
 
     let mut sim = SimWorld::new_with_network_config_and_seed(config, seed);
-    let provider = sim.network_provider();
+    let provider = sim.network_provider("127.0.0.1".parse().expect("valid ip"));
 
     let addr = "partial-read-server";
     let listener = provider.bind(addr).await.unwrap();
@@ -125,7 +125,7 @@ fn test_partial_read_disabled_without_buggify() {
 
         let config = NetworkConfiguration::fast_local();
         let mut sim = SimWorld::new_with_network_config(config);
-        let provider = sim.network_provider();
+        let provider = sim.network_provider("127.0.0.1".parse().expect("valid ip"));
 
         let addr = "no-partial-read-server";
         let listener = provider.bind(addr).await.unwrap();

--- a/moonpool-sim/tests/chaos/random_close.rs
+++ b/moonpool-sim/tests/chaos/random_close.rs
@@ -28,7 +28,7 @@ fn test_random_close_disabled_with_zero_probability() {
         config.chaos.random_close_probability = 0.0; // Explicitly disable
 
         let mut sim = SimWorld::new_with_network_config(config);
-        let provider = sim.network_provider();
+        let provider = sim.network_provider("127.0.0.1".parse().expect("valid ip"));
 
         // Send multiple messages
         let addr = "test-server";
@@ -71,7 +71,7 @@ fn test_random_close_injection_with_high_probability() {
         config.chaos.random_close_cooldown = Duration::ZERO;
 
         let mut sim = SimWorld::new_with_network_config(config);
-        let provider = sim.network_provider();
+        let provider = sim.network_provider("127.0.0.1".parse().expect("valid ip"));
 
         let addr = "chaos-server";
         let listener = provider.bind(addr).await.unwrap();
@@ -112,7 +112,7 @@ fn test_random_close_asymmetric_behavior() {
         config.chaos.random_close_probability = 0.0; // We'll trigger manually
 
         let mut sim = SimWorld::new_with_network_config(config);
-        let provider = sim.network_provider();
+        let provider = sim.network_provider("127.0.0.1".parse().expect("valid ip"));
 
         let addr = "asymmetric-test";
         let listener = provider.bind(addr).await.unwrap();
@@ -168,7 +168,7 @@ fn test_random_close_cooldown() {
         config.chaos.random_close_cooldown = Duration::from_secs(100); // Very long cooldown
 
         let mut sim = SimWorld::new_with_network_config(config);
-        let provider = sim.network_provider();
+        let provider = sim.network_provider("127.0.0.1".parse().expect("valid ip"));
 
         let addr = "cooldown-server";
         let listener = provider.bind(addr).await.unwrap();
@@ -214,7 +214,7 @@ fn test_random_close_explicit_vs_silent() {
         config.chaos.random_close_explicit_ratio = 0.3; // 30% explicit
 
         let mut sim = SimWorld::new_with_network_config(config);
-        let provider = sim.network_provider();
+        let provider = sim.network_provider("127.0.0.1".parse().expect("valid ip"));
 
         let addr = "explicit-test";
         let listener = provider.bind(addr).await.unwrap();
@@ -255,7 +255,7 @@ fn test_random_close_paired_connection_coordination() {
         config.chaos.random_close_probability = 0.0; // Manual control
 
         let mut sim = SimWorld::new_with_network_config(config);
-        let provider = sim.network_provider();
+        let provider = sim.network_provider("127.0.0.1".parse().expect("valid ip"));
 
         let addr = "paired-test";
         let listener = provider.bind(addr).await.unwrap();
@@ -292,7 +292,7 @@ fn test_random_close_buffer_clearing() {
         config.chaos.random_close_probability = 0.0;
 
         let mut sim = SimWorld::new_with_network_config(config);
-        let provider = sim.network_provider();
+        let provider = sim.network_provider("127.0.0.1".parse().expect("valid ip"));
 
         let addr = "buffer-test";
         let listener = provider.bind(addr).await.unwrap();
@@ -330,7 +330,7 @@ fn test_random_close_bidirectional_communication() {
         config.chaos.random_close_cooldown = Duration::from_millis(10);
 
         let mut sim = SimWorld::new_with_network_config(config);
-        let provider = sim.network_provider();
+        let provider = sim.network_provider("127.0.0.1".parse().expect("valid ip"));
 
         let addr = "bidirectional-test";
         let listener = provider.bind(addr).await.unwrap();
@@ -389,7 +389,7 @@ fn test_random_close_with_partitions() {
         config.chaos.partition_probability = 0.05;
 
         let mut sim = SimWorld::new_with_network_config(config);
-        let provider = sim.network_provider();
+        let provider = sim.network_provider("127.0.0.1".parse().expect("valid ip"));
 
         let addr = "partition-test";
         let listener = provider.bind(addr).await.unwrap();

--- a/moonpool-sim/tests/network/latency.rs
+++ b/moonpool-sim/tests/network/latency.rs
@@ -37,7 +37,7 @@ fn test_fast_local_configuration() {
     local_runtime.block_on(async move {
         let fast_config = NetworkConfiguration::fast_local();
         let mut sim = SimWorld::new_with_network_config(fast_config);
-        let provider = sim.network_provider();
+        let provider = sim.network_provider("127.0.0.1".parse().expect("valid ip"));
 
         let start_time = std::time::Instant::now();
         simple_network_test(provider, "fast-test").await.unwrap();
@@ -68,7 +68,7 @@ fn test_default_simulation_configuration() {
     local_runtime.block_on(async move {
         let wan_config = NetworkConfiguration::default(); // Use default config with reasonable delays
         let mut sim = SimWorld::new_with_network_config(wan_config);
-        let provider = sim.network_provider();
+        let provider = sim.network_provider("127.0.0.1".parse().expect("valid ip"));
 
         let start_time = std::time::Instant::now();
         simple_network_test(provider, "wan-test").await.unwrap();
@@ -108,7 +108,7 @@ fn test_custom_latency_configuration() {
         };
 
         let mut sim = SimWorld::new_with_network_config(config);
-        let provider = sim.network_provider();
+        let provider = sim.network_provider("127.0.0.1".parse().expect("valid ip"));
 
         simple_network_test(provider, "custom-test").await.unwrap();
 
@@ -154,7 +154,7 @@ fn test_latency_range_sampling() {
 
         for _run in 0..5 {
             let mut sim = SimWorld::new_with_network_config(config.clone());
-            let provider = sim.network_provider();
+            let provider = sim.network_provider("127.0.0.1".parse().expect("valid ip"));
 
             simple_network_test(provider, "jitter-test").await.unwrap();
 
@@ -205,7 +205,7 @@ fn test_network_randomization_ranges() {
         };
 
         let mut sim = SimWorld::new_with_network_config(config);
-        let provider = sim.network_provider();
+        let provider = sim.network_provider("127.0.0.1".parse().expect("valid ip"));
 
         simple_network_test(provider, "custom-ranges-test")
             .await
@@ -229,5 +229,58 @@ fn test_network_randomization_ranges() {
         );
 
         println!("Custom ranges test completed in sim time: {sim_time:?}");
+    });
+}
+
+/// Regression test for the client-initiated connection's local IP.
+///
+/// `SimNetworkProvider::connect()` used to call `create_connection_pair` with a
+/// literal placeholder address for the client side, so the client connection's
+/// `local_ip` stayed `None` forever. `connection_base_latency()` requires both
+/// endpoint IPs to activate `max_pair_latency`, so per-pair latency was a
+/// silent no-op on every connection made through `NetworkProvider::connect()`.
+///
+/// This test fails without the fix: `sim.pair_latency(client_ip, server_ip)`
+/// stays `None` because the client's `local_ip` never resolves, so
+/// `connection_base_latency` bails out before touching the pair map.
+#[test]
+fn test_client_initiated_connection_records_pair_latency() {
+    let local_runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .enable_time()
+        .build()
+        .expect("Failed to build local runtime");
+
+    local_runtime.block_on(async move {
+        let mut config = NetworkConfiguration::fast_local();
+        // Enable the "stably slow link" chaos feature: a nonzero range means
+        // connection_base_latency() should memoize a latency for the pair.
+        config.chaos.max_pair_latency = Duration::from_millis(5)..Duration::from_millis(10);
+
+        let mut sim = SimWorld::new_with_network_config(config);
+
+        let client_ip: std::net::IpAddr = "10.0.1.1".parse().expect("valid ip");
+        let server_ip: std::net::IpAddr = "10.0.1.2".parse().expect("valid ip");
+        let server_addr = "10.0.1.2:8080";
+
+        let provider = sim.network_provider(client_ip);
+        let listener = provider.bind(server_addr).await.unwrap();
+        let _client = provider.connect(server_addr).await.unwrap();
+        let (_server, _peer_addr) = listener.accept().await.unwrap();
+
+        sim.run_until_empty();
+
+        let latency = sim.pair_latency(client_ip, server_ip);
+        assert!(
+            latency.is_some(),
+            "expected a per-pair base latency to be recorded for the \
+             client-initiated connection ({client_ip} -> {server_ip}); this is \
+             None when the client's local_ip never resolves"
+        );
+        let latency = latency.expect("checked above");
+        assert!(
+            latency >= Duration::from_millis(5) && latency < Duration::from_millis(10),
+            "latency {latency:?} outside configured max_pair_latency range"
+        );
     });
 }

--- a/moonpool-sim/tests/network/vectored.rs
+++ b/moonpool-sim/tests/network/vectored.rs
@@ -23,7 +23,7 @@ fn vectored_write_preserves_slice_boundaries_as_delivery_events() {
 
     local_runtime.block_on(async move {
         let mut sim = SimWorld::new_with_network_config(NetworkConfiguration::fast_local());
-        let provider = sim.network_provider();
+        let provider = sim.network_provider("127.0.0.1".parse().expect("valid ip"));
         let addr = "vectored-write-test";
 
         let listener = provider.bind(addr).await.expect("bind should succeed");

--- a/moonpool-sim/tests/sim/integration.rs
+++ b/moonpool-sim/tests/sim/integration.rs
@@ -12,7 +12,7 @@ fn test_basic_simulation_bind() {
 
     local_runtime.block_on(async move {
         let sim = SimWorld::new();
-        let provider = sim.network_provider();
+        let provider = sim.network_provider("127.0.0.1".parse().expect("valid ip"));
 
         // Test basic binding functionality
         let listener = provider.bind("test-addr").await.unwrap();
@@ -52,7 +52,7 @@ fn test_simple_echo_simulation() {
         // Use fast local config for integration tests to avoid timeouts
         let config = NetworkConfiguration::fast_local(); // Deterministic, fast
         let mut sim = SimWorld::new_with_network_config(config);
-        let provider = sim.network_provider();
+        let provider = sim.network_provider("127.0.0.1".parse().expect("valid ip"));
 
         // Test simple echo server with simulation
         simple_echo_server(provider, "echo-server").await.unwrap();
@@ -83,7 +83,7 @@ fn test_deterministic_simulation_behavior() {
             // Use fast local config for deterministic integration tests
             let config = NetworkConfiguration::fast_local();
             let mut sim = SimWorld::new_with_network_config(config);
-            let provider = sim.network_provider();
+            let provider = sim.network_provider("127.0.0.1".parse().expect("valid ip"));
 
             simple_echo_server(provider, "deterministic-test")
                 .await
@@ -130,7 +130,7 @@ fn test_network_provider_trait_usage() {
 
     local_runtime.block_on(async move {
         let sim = SimWorld::new();
-        let provider = sim.network_provider();
+        let provider = sim.network_provider("127.0.0.1".parse().expect("valid ip"));
 
         let addr = use_provider_generically(provider, "dynamic-test")
             .await


### PR DESCRIPTION
## What

Scope `SimNetworkProvider` to the owning process's IP and use it as the client-side local address when creating connection pairs, replacing the `"client-addr"` placeholder that could never parse to an IP.

## Why

The client connection's `local_ip` was always `None`, so `connection_base_latency()` bailed out and the `max_pair_latency` / `pair_latencies` "stably slow link" machinery was a silent no-op on every connection made through `NetworkProvider::connect()`. This is also a prerequisite for the topology work in #156.

Closes #155

## Notes

The constructor change follows the exact precedent of `SimStorageProvider`, which already required a per-process IP; every real construction path (`SimProviders::new`) had the IP in scope, so no new plumbing was invented. Default behavior is unchanged: `max_pair_latency` defaults to an empty range, and nothing in the existing suite exercised it (which is why the bug was silent). The regression test `test_client_initiated_connection_records_pair_latency` was verified to fail against the old placeholder behavior before the fix. Test-file churn is mechanical IP-argument threading at 34 call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CR3ZGUAsfNdLgY3uJS7hby
