### PR TITLE
feat(moonpool-sim): topology-aware network chaos

### DIFF
--- a/book/src/appendix/03-configuration.md
+++ b/book/src/appendix/03-configuration.md
@@ -16,6 +16,7 @@ The builder pattern for configuring and running simulation experiments. Created 
 | `workloads_with_client_id(count, cid, factory)` | `WorkloadCount`, `ClientId`, factory | Factory workloads with custom client IDs |
 | `processes(count, factory)` | `impl Into<ProcessCount>`, `Fn() -> Box<dyn Process>` | Add server processes (system under test) |
 | `cluster(config, factory)` | `LocalityConfig`, `Fn() -> Box<dyn Process>` | Add processes laid out across a datacenter/zone/machine topology (replaces `processes`) |
+| `link_latency(config)` | `LinkLatencyConfig` | Give links a distance-dependent latency, resolved through the `cluster` topology |
 | `tags(dimensions)` | `&[(&str, &[&str])]` | Attach round-robin tag distribution to processes |
 | `attrition(config)` | `Attrition` | Enable automatic process reboots during chaos phase |
 | `invariant(i)` | `impl Invariant` | Add an invariant checked after every simulation event |
@@ -104,13 +105,14 @@ The `prob_*` fields are **weights**, not probabilities. They are normalized inte
 
 ### AttritionScope
 
-Which failure domain a reboot kills. `PerMachine` and `PerZone` require a [`.cluster()`](../part3-building/09-attrition.md#failure-domains-correlated-reboots) topology; without locality they are a no-op.
+Which failure domain a reboot kills. `PerMachine`, `PerZone`, and `PerDatacenter` require a [`.cluster()`](../part3-building/09-attrition.md#failure-domains-correlated-reboots) topology; without locality they are a no-op.
 
 | Variant | Behavior |
 |---------|----------|
 | `PerProcess` | Reboot one random process at a time (the default) |
 | `PerMachine` | Reboot every process on a random machine together, atomically against `max_dead` |
 | `PerZone` | Reboot every process in a random zone together, atomically against `max_dead` |
+| `PerDatacenter` | Reboot every process in a random datacenter together, atomically against `max_dead` |
 
 ### RebootKind
 
@@ -133,6 +135,7 @@ Top-level network simulation parameters.
 | `connect_latency` | `LatencyDistribution` | `Uniform` 1ms..11ms |
 | `read_latency` | `LatencyDistribution` | `Uniform` 10us..60us |
 | `write_latency` | `LatencyDistribution` | `Uniform` 100us..600us |
+| `link_latency` | `Option<LinkLatencyConfig>` | `None` (distance-blind) |
 | `chaos` | `ChaosConfiguration` | See below |
 
 ### Constructor variants
@@ -154,6 +157,17 @@ Each per-operation latency field above is a `LatencyDistribution`, not a plain r
 | `Bimodal { fast_range, slow_range, slow_probability }` | Fast cluster with a rare slow tail | Cross-datacenter hops, GC spikes (FoundationDB) |
 
 `default()` and `fast_local()` keep every field `Uniform`, so behavior is unchanged unless you opt in. `random_for_seed()` mixes all three shapes per field for chaos seeds. The same `LatencyDistribution` type configures storage `read_latency`, `write_latency`, and `sync_latency`.
+
+### Link latency (distance-based)
+
+`link_latency` is realism, not chaos: it lives on `NetworkConfiguration` and is applied whatever the chaos mode. Each ordered IP pair is classified through the installed locality topology, samples its class distribution once at first contact, and keeps that value for the run. The result lands in the same per-pair budget as `max_pair_latency` and is summed with it. A pair where either endpoint has no locality gets nothing.
+
+| Field | Type | Default |
+|-------|------|---------|
+| `same_machine` | `LatencyDistribution` | `Uniform` 10us..50us |
+| `same_zone` | `LatencyDistribution` | `Uniform` 100us..500us |
+| `same_datacenter` | `LatencyDistribution` | `Uniform` 500us..2ms |
+| `cross_datacenter` | `LatencyDistribution` | `Uniform` 20ms..80ms |
 
 ## ChaosConfiguration
 
@@ -182,7 +196,7 @@ Each ordered IP pair samples one fixed latency from this range at first contact 
 | `partition_duration` | `Range<Duration>` | 200ms..2s |
 | `partition_strategy` | `PartitionStrategy` | `Random` |
 
-**PartitionStrategy** variants: `Random`, `UniformSize`, `IsolateSingle`.
+**PartitionStrategy** variants: `Random`, `UniformSize`, `IsolateSingle`, `IsolateZone`, `IsolateDatacenter`, `AsymmetricSend`, `AsymmetricRecv`. The two `Isolate{Zone,Datacenter}` arms need a [`.cluster()`](../part3-building/09-attrition.md#failure-domains-correlated-reboots) topology and degrade to `Random` selection without one. The two `Asymmetric*` arms cut a single node one way, using the same primitives as `partition_send_from()` / `partition_recv_to()`.
 
 ### Bit Flips
 

--- a/book/src/appendix/04-fault-reference.md
+++ b/book/src/appendix/04-fault-reference.md
@@ -31,6 +31,7 @@ Configured via `ChaosConfiguration` (nested under `NetworkConfiguration::chaos`)
 | Bimodal tail | `LatencyDistribution::Bimodal { fast_range, slow_range, slow_probability }` | opt-in | Rare cross-datacenter hops, GC spikes (FoundationDB model) |
 | Write clogging | `clog_probability` / `clog_duration` | 0%, 100-300ms | Backpressure handling, flow control |
 | Per-pair permanent latency | `max_pair_latency` | `ZERO..ZERO` (off) | One stably-slow peer blocking quorum, asymmetric link delay |
+| Distance-based link latency | `link_latency` (`LinkLatencyConfig`) | `None` (off) | Loopback vs rack vs region hops, cross-datacenter replication cost |
 | Clock drift | `clock_drift_enabled` / `clock_drift_max` | enabled, 100ms | Lease expiration, distributed consensus, TTL handling |
 | Buggified delay | `buggified_delay_probability` / `buggified_delay_max` | 25%, 100ms | Race conditions, timing-dependent bugs |
 | Handshake delay | `handshake_delay_enabled` / `handshake_delay_max` | enabled, 10ms | TLS negotiation, connection startup overhead |
@@ -42,6 +43,8 @@ Configured via `ChaosConfiguration` (nested under `NetworkConfiguration::chaos`)
 | Random partition | `partition_probability` | 0% | Split-brain, quorum loss, leader election |
 | Partition duration | `partition_duration` | 200ms-2s | Recovery time after network heal |
 | Partition strategy | `partition_strategy` | `Random` | `Random` / `UniformSize` / `IsolateSingle` patterns |
+| Failure-domain partition | `partition_strategy = IsolateZone` / `IsolateDatacenter` | `Random` | Rack or region cut (needs a `cluster` topology, else falls back to `Random`) |
+| One-way partition | `partition_strategy = AsymmetricSend` / `AsymmetricRecv` | `Random` | Half-reachable node, failure detectors that infer liveness from the wrong direction |
 
 Manual partition methods are also available on `SimWorld`: `partition_pair()`, `partition_send_from()`, `partition_recv_to()`.
 
@@ -118,6 +121,7 @@ Configured via [`Attrition`](../part3-building/attrition.md) (built-in) or custo
 | Crash reboot | `RebootKind::Crash` | Immediate task abort, all connections reset, restart after recovery delay |
 | Crash + wipe | `RebootKind::CrashAndWipe` | Crash behavior + immediate wipe of all persistent storage owned by the process (scoped by IP) |
 | Continuous attrition | `Attrition` config | Random reboots during chaos phase with weighted `prob_graceful`/`prob_crash`/`prob_wipe` and `max_dead` limit |
+| Correlated reboot | `AttritionScope::PerMachine` / `PerZone` / `PerDatacenter` | Reboot every process of one failure domain together; only fires when the whole group fits in `max_dead` |
 
 ## Configuration Presets
 

--- a/book/src/part3-building/09-attrition.md
+++ b/book/src/part3-building/09-attrition.md
@@ -54,7 +54,7 @@ Attrition {
 
 **`grace_period_ms`** controls how long a graceful shutdown has to complete. Again, drawn randomly from the range. The default is 2 to 5 seconds.
 
-**`scope`** decides which failure domain each reboot targets. The default, `AttritionScope::PerProcess`, kills one random process at a time. `PerMachine` and `PerZone` kill **all collocated processes together**, which is the subject of the next section.
+**`scope`** decides which failure domain each reboot targets. The default, `AttritionScope::PerProcess`, kills one random process at a time. `PerMachine`, `PerZone`, and `PerDatacenter` kill **all collocated processes together**, which is the subject of the next section.
 
 ## Using Attrition
 
@@ -123,7 +123,7 @@ let machine_mates = ctx.topology().peers_on_my_machine();
 let same_dc = ctx.topology().ips_in_domain(DomainLevel::Datacenter, me.datacenter());
 ```
 
-Now `scope` earns its keep. With `AttritionScope::PerMachine`, attrition picks a machine instead of a process and reboots **every process on it in the same instant**. The two processes that share `dc1-z1-m1` die together and recover together, exactly as they would when their host kernel panics. `PerZone` does the same one level up.
+Now `scope` earns its keep. With `AttritionScope::PerMachine`, attrition picks a machine instead of a process and reboots **every process on it in the same instant**. The two processes that share `dc1-z1-m1` die together and recover together, exactly as they would when their host kernel panics. `PerZone` does the same one level up, and `PerDatacenter` one level above that, for the region-wide blackout that only a replication scheme spanning datacenters is supposed to survive.
 
 ```rust
 .enable_chaos([Chaos::Attrition {
@@ -141,6 +141,8 @@ Now `scope` earns its keep. With `AttritionScope::PerMachine`, attrition picks a
 ```
 
 `max_dead` still counts dead **processes**, and a machine reboot is atomic against that budget: attrition only kills a machine when the whole group fits within the remaining budget. With two processes per machine, `max_dead: 2` lets exactly one machine be down at a time and never leaves a machine half-dead. Set it to a multiple of your machine size that matches how many machines your replication can lose.
+
+The same topology also shapes the network, not just the reboots. `PartitionStrategy::IsolateZone` and `IsolateDatacenter` cut a whole domain off the rest of the cluster, and `LinkLatencyConfig` gives cross-datacenter links their real cost. Both are covered in [Network Faults](10-network-faults.md).
 
 For targeted correlated faults, `FaultContext` exposes the group reboots directly. `ctx.reboot_machine("dc1-z1-m1", RebootKind::Crash)` kills a named machine and returns the IPs it took down, and `ctx.reboot_domain(DomainLevel::Datacenter, "dc1", kind)` blacks out a whole datacenter. Combined with `ctx.ips_in_domain(...)`, the same domain ids drive network partitions across a zone or datacenter boundary, so you can model a region cut as cleanly as a host reboot.
 

--- a/book/src/part3-building/10-network-faults.md
+++ b/book/src/part3-building/10-network-faults.md
@@ -20,6 +20,17 @@ For tail latency testing, moonpool supports **bimodal latency distribution**, fo
 
 Re-sampling latency per operation has a blind spot: no single connection ever stays slow. Real clusters break differently. One machine sits behind a degraded switch port and every message to it lags, run after run, while the rest of the fleet is healthy. That **stably-slow peer** is exactly what stalls a quorum or reorders a consensus round, and uniform per-operation jitter never produces it. So moonpool borrows FoundationDB's `SimClogging` trick: set `max_pair_latency` to a range and each ordered IP pair draws **one** fixed latency at first contact, then carries it for the whole run. Off by default (`ZERO..ZERO`), it adds nothing. Turn it on and some pairs are permanently sluggish while others are quick, which is how you find the bug where the slow replica is the one holding the lease.
 
+There is a second blind spot, and it is not a fault at all. A message between two processes on the same machine and a message between Paris and Montreal are both "one network operation" to the simulator, drawn from the same range. Real deployments do not work that way: loopback is tens of microseconds, a rack hop is hundreds, a cross-region hop is tens of milliseconds. If a replication protocol only ever sees uniform links, its cross-datacenter behavior is untested. `NetworkConfiguration::link_latency` fixes that. Give it a `LinkLatencyConfig` and each locality distance gets its own distribution:
+
+```rust
+SimulationBuilder::new()
+    .cluster(LocalityConfig::new(2, 2, 2, 1), || Box::new(MyNode::new()))
+    // Same machine, same zone, same datacenter, cross datacenter.
+    .link_latency(LinkLatencyConfig::default())
+```
+
+The engine classifies every IP pair through the [`.cluster()`](09-attrition.md#failure-domains-correlated-reboots) topology, samples the matching distribution once at first contact, and keeps that value for the whole run, in the same per-pair budget as `max_pair_latency` (when both are on, the two samples are summed). A pair where either side has no locality, a workload client for instance, gets nothing extra, so plain `.processes()` runs are unaffected. FoundationDB does not model this at all, it runs a single global latency distribution, but a library that wants to find cross-region replication bugs needs the distance to be visible in the timing.
+
 ### Connection Drops
 
 Random close injects spontaneous connection failures during I/O operations, at a configurable probability (default 0.001%). When triggered, 30% of closes are **explicit** (the caller gets an error) and 70% are **silent** (the connection just stops working). This ratio, taken from FoundationDB, tests both error-handling paths and timeout-based failure detection.
@@ -48,15 +59,23 @@ Simulated clocks can drift by up to 100ms (configurable) between nodes. This tes
 
 ### Network Partitions
 
-Moonpool supports three partition strategies:
+Moonpool supports seven partition strategies:
 
 | Strategy | Behavior | Tests |
 |----------|----------|-------|
 | Random | Random IP pairs partitioned | General chaos |
 | UniformSize | Partition of random size (1 to n-1 nodes) | Various quorum scenarios |
 | IsolateSingle | One node isolated from all others | Common production failure |
+| IsolateZone | Every process of one random zone cut from the rest | Rack or availability-zone loss |
+| IsolateDatacenter | Every process of one random datacenter cut from the rest | Region loss, cross-datacenter replication |
+| AsymmetricSend | One node's outgoing traffic blocked, incoming still flows | Half-reachable node, failure detectors |
+| AsymmetricRecv | One node's incoming traffic blocked, outgoing still flows | The mirror case |
 
 Partitions have configurable probability and duration. They can be programmatic (via `FaultContext::partition`) or automatic (via `partition_probability` in the chaos config).
+
+The first three strategies are IP-blind: they pick nodes out of a hat. `IsolateZone` and `IsolateDatacenter` read the [`.cluster()`](09-attrition.md#failure-domains-correlated-reboots) topology instead, so the cut lands exactly where a real one would, on the boundary that shares a switch or a region. Without a topology they fall back to `Random` selection, which keeps them safe to draw for any seed.
+
+The asymmetric pair is worth dwelling on. A node whose sends are blocked still hears every heartbeat from the cluster, so it happily believes it is healthy while everyone else marks it dead. Systems that infer liveness from "I can see you" rather than "you can see me" split brains here. Both arms record their own fault events (`SendPartitionCreated`, `RecvPartitionCreated`) on the timeline, so an invariant can correlate application behavior with the exact one-way cut that caused it.
 
 ### Connect Failures
 

--- a/moonpool-sim/src/lib.rs
+++ b/moonpool-sim/src/lib.rs
@@ -129,6 +129,9 @@ pub use moonpool_core::{
 /// Core simulation engine for deterministic testing.
 pub mod sim;
 
+/// Failure-domain locality vocabulary shared by the engine and the runner.
+pub mod locality;
+
 /// The deterministic single-threaded executor (seeded-random scheduling).
 pub mod executor;
 
@@ -165,12 +168,15 @@ pub use sim::{
     set_swarm_op_seed, sim_random, sim_random_range, sim_random_range_or_default, swarm_op_enabled,
 };
 
+// Locality vocabulary re-exports (shared by engine and runner)
+pub use locality::{DomainLevel, LocalityInfo};
+
 // Runner module re-exports
 pub use runner::{
-    Attrition, AttritionScope, Chaos, ChaosMode, ClientId, DomainLevel, FaultContext,
-    FaultInjector, IterationControl, LocalityConfig, LocalityInfo, MachineRegistry, Process,
-    ProcessTags, RebootKind, SimContext, SimulationBuilder, SimulationMetrics, SimulationReport,
-    TagRegistry, Workload, WorkloadCount, WorkloadTopology,
+    Attrition, AttritionScope, Chaos, ChaosMode, ClientId, FaultContext, FaultInjector,
+    IterationControl, LocalityConfig, MachineRegistry, Process, ProcessTags, RebootKind,
+    SimContext, SimulationBuilder, SimulationMetrics, SimulationReport, TagRegistry, Workload,
+    WorkloadCount, WorkloadTopology,
 };
 
 // Chaos module re-exports

--- a/moonpool-sim/src/lib.rs
+++ b/moonpool-sim/src/lib.rs
@@ -169,7 +169,7 @@ pub use sim::{
 };
 
 // Locality vocabulary re-exports (shared by engine and runner)
-pub use locality::{DomainLevel, LocalityInfo};
+pub use locality::{DomainLevel, LinkClass, LocalityInfo};
 
 // Runner module re-exports
 pub use runner::{
@@ -194,8 +194,8 @@ pub use observability::{
 
 // Network exports
 pub use network::{
-    ChaosConfiguration, ConnectFailureMode, LatencyDistribution, NetworkConfiguration,
-    SimNetworkProvider, sample_duration, sample_latency,
+    ChaosConfiguration, ConnectFailureMode, LatencyDistribution, LinkLatencyConfig,
+    NetworkConfiguration, PartitionStrategy, SimNetworkProvider, sample_duration, sample_latency,
 };
 
 // Storage exports

--- a/moonpool-sim/src/locality.rs
+++ b/moonpool-sim/src/locality.rs
@@ -25,6 +25,23 @@ pub enum DomainLevel {
     Machine,
 }
 
+/// How far apart two processes are in the locality hierarchy.
+///
+/// Derived by [`LocalityInfo::link_class`] and used by the engine to pick a
+/// distance-appropriate latency distribution
+/// ([`LinkLatencyConfig`](crate::network::LinkLatencyConfig)).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LinkClass {
+    /// Both processes run on the same machine (loopback).
+    SameMachine,
+    /// Same zone, different machines (rack-local).
+    SameZone,
+    /// Same datacenter, different zones.
+    SameDatacenter,
+    /// Different datacenters (wide area).
+    CrossDatacenter,
+}
+
 /// Resolved failure-domain locality for a single process instance.
 ///
 /// Identifiers are globally unique and hierarchical (`dc1`, `dc1-z1`,
@@ -79,11 +96,29 @@ impl LocalityInfo {
             DomainLevel::Machine => &self.machine,
         }
     }
+
+    /// Classify the network distance between this process and `other`.
+    ///
+    /// Walks the hierarchy from the innermost level outwards, so a shared
+    /// machine wins over a shared zone, and a shared zone over a shared
+    /// datacenter. Symmetric by construction.
+    #[must_use]
+    pub fn link_class(&self, other: &Self) -> LinkClass {
+        if self.machine == other.machine {
+            LinkClass::SameMachine
+        } else if self.zone == other.zone {
+            LinkClass::SameZone
+        } else if self.datacenter == other.datacenter {
+            LinkClass::SameDatacenter
+        } else {
+            LinkClass::CrossDatacenter
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{DomainLevel, LocalityInfo};
+    use super::{DomainLevel, LinkClass, LocalityInfo};
 
     #[test]
     fn id_for_matches_accessors() {
@@ -91,5 +126,34 @@ mod tests {
         assert_eq!(loc.id_for(DomainLevel::Datacenter), loc.datacenter());
         assert_eq!(loc.id_for(DomainLevel::Zone), loc.zone());
         assert_eq!(loc.id_for(DomainLevel::Machine), loc.machine());
+    }
+
+    #[test]
+    fn link_class_walks_the_hierarchy_inside_out() {
+        let reference = LocalityInfo::new("dc1", "dc1-z1", "dc1-z1-m1");
+        let same_machine = LocalityInfo::new("dc1", "dc1-z1", "dc1-z1-m1");
+        let same_zone = LocalityInfo::new("dc1", "dc1-z1", "dc1-z1-m2");
+        let same_datacenter = LocalityInfo::new("dc1", "dc1-z2", "dc1-z2-m1");
+        let cross_datacenter = LocalityInfo::new("dc2", "dc2-z1", "dc2-z1-m1");
+
+        assert_eq!(
+            reference.link_class(&same_machine),
+            LinkClass::SameMachine,
+            "same machine id must win over every outer level"
+        );
+        assert_eq!(reference.link_class(&same_zone), LinkClass::SameZone);
+        assert_eq!(
+            reference.link_class(&same_datacenter),
+            LinkClass::SameDatacenter
+        );
+        assert_eq!(
+            reference.link_class(&cross_datacenter),
+            LinkClass::CrossDatacenter
+        );
+        assert_eq!(
+            cross_datacenter.link_class(&reference),
+            LinkClass::CrossDatacenter,
+            "classification must be symmetric"
+        );
     }
 }

--- a/moonpool-sim/src/locality.rs
+++ b/moonpool-sim/src/locality.rs
@@ -1,0 +1,95 @@
+//! Failure-domain locality vocabulary shared by the engine and the runner.
+//!
+//! Locality models a `FoundationDB`-style Cluster → Datacenter → Zone → Machine →
+//! Process hierarchy so that collocated processes share fate. The two core types
+//! live here, at the crate root, because both layers need them:
+//!
+//! - the [`runner`](crate::runner) builds the topology
+//!   ([`LocalityConfig`](crate::runner::LocalityConfig),
+//!   [`MachineRegistry`](crate::runner::MachineRegistry)) and drives correlated
+//!   reboots from it;
+//! - the [`sim`](crate::sim) engine consumes a plain `ip -> LocalityInfo` map
+//!   ([`SimWorld::set_localities`](crate::SimWorld::set_localities)) to shape
+//!   network partitions and distance-based latency.
+//!
+//! The engine never imports from the runner, so the vocabulary sits below both.
+
+/// The level of a failure domain in the locality hierarchy.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DomainLevel {
+    /// A whole datacenter.
+    Datacenter,
+    /// A zone within a datacenter.
+    Zone,
+    /// A single machine — the unit of shared fate.
+    Machine,
+}
+
+/// Resolved failure-domain locality for a single process instance.
+///
+/// Identifiers are globally unique and hierarchical (`dc1`, `dc1-z1`,
+/// `dc1-z1-m1`) so that domain queries never confuse a machine in one
+/// datacenter with a machine in another.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct LocalityInfo {
+    datacenter: String,
+    zone: String,
+    machine: String,
+}
+
+impl LocalityInfo {
+    /// Create locality from explicit datacenter, zone, and machine ids.
+    #[must_use]
+    pub fn new(
+        datacenter: impl Into<String>,
+        zone: impl Into<String>,
+        machine: impl Into<String>,
+    ) -> Self {
+        Self {
+            datacenter: datacenter.into(),
+            zone: zone.into(),
+            machine: machine.into(),
+        }
+    }
+
+    /// The datacenter id (e.g. `dc1`).
+    #[must_use]
+    pub fn datacenter(&self) -> &str {
+        &self.datacenter
+    }
+
+    /// The zone id (e.g. `dc1-z1`).
+    #[must_use]
+    pub fn zone(&self) -> &str {
+        &self.zone
+    }
+
+    /// The machine id (e.g. `dc1-z1-m1`).
+    #[must_use]
+    pub fn machine(&self) -> &str {
+        &self.machine
+    }
+
+    /// The id at the given domain level.
+    #[must_use]
+    pub fn id_for(&self, level: DomainLevel) -> &str {
+        match level {
+            DomainLevel::Datacenter => &self.datacenter,
+            DomainLevel::Zone => &self.zone,
+            DomainLevel::Machine => &self.machine,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DomainLevel, LocalityInfo};
+
+    #[test]
+    fn id_for_matches_accessors() {
+        let loc = LocalityInfo::new("dc1", "dc1-z2", "dc1-z2-m3");
+        assert_eq!(loc.id_for(DomainLevel::Datacenter), loc.datacenter());
+        assert_eq!(loc.id_for(DomainLevel::Zone), loc.zone());
+        assert_eq!(loc.id_for(DomainLevel::Machine), loc.machine());
+    }
+}

--- a/moonpool-sim/src/network/config.rs
+++ b/moonpool-sim/src/network/config.rs
@@ -82,6 +82,7 @@
 //! - Clock drift: FDB sim2.actor.cpp:1058-1064
 //! - Connect failures: FDB sim2.actor.cpp:1243-1250
 
+use crate::locality::LinkClass;
 use crate::sim::rng::{
     config_random_bool, sim_random_f64, sim_random_range, sim_random_range_or_default,
 };
@@ -443,6 +444,60 @@ impl ChaosConfiguration {
     }
 }
 
+/// Distance-based latency, one [`LatencyDistribution`] per locality class.
+///
+/// This is *realism*, not chaos: a cross-datacenter hop is slow on a healthy
+/// day. Attach it to [`NetworkConfiguration::link_latency`] and the engine
+/// classifies every IP pair through the installed locality topology
+/// ([`SimWorld::set_localities`](crate::SimWorld::set_localities)), samples the
+/// matching distribution once at first contact, and applies that fixed extra to
+/// every delivery on the pair (it lands in the same per-pair budget as
+/// [`ChaosConfiguration::max_pair_latency`], summed with it).
+///
+/// A pair where either endpoint has no locality gets no distance latency, so
+/// plain `.processes()` runs are unaffected.
+///
+/// `FoundationDB` does not model this (a single global latency distribution),
+/// but it is what makes cross-datacenter replication testing meaningful.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LinkLatencyConfig {
+    /// Processes collocated on one machine (loopback).
+    pub same_machine: LatencyDistribution,
+    /// Different machines in the same zone (rack-local).
+    pub same_zone: LatencyDistribution,
+    /// Different zones in the same datacenter.
+    pub same_datacenter: LatencyDistribution,
+    /// Different datacenters (wide area).
+    pub cross_datacenter: LatencyDistribution,
+}
+
+impl Default for LinkLatencyConfig {
+    /// Rough real-world one-way link delays: microseconds on loopback, tens of
+    /// milliseconds between regions.
+    fn default() -> Self {
+        let uniform = |start, end| LatencyDistribution::Uniform { start, end };
+        Self {
+            same_machine: uniform(Duration::from_micros(10), Duration::from_micros(50)),
+            same_zone: uniform(Duration::from_micros(100), Duration::from_micros(500)),
+            same_datacenter: uniform(Duration::from_micros(500), Duration::from_millis(2)),
+            cross_datacenter: uniform(Duration::from_millis(20), Duration::from_millis(80)),
+        }
+    }
+}
+
+impl LinkLatencyConfig {
+    /// The distribution to sample for a given locality distance.
+    #[must_use]
+    pub fn distribution_for(&self, class: LinkClass) -> &LatencyDistribution {
+        match class {
+            LinkClass::SameMachine => &self.same_machine,
+            LinkClass::SameZone => &self.same_zone,
+            LinkClass::SameDatacenter => &self.same_datacenter,
+            LinkClass::CrossDatacenter => &self.cross_datacenter,
+        }
+    }
+}
+
 /// Configuration for network simulation parameters
 #[derive(Debug, Clone)]
 pub struct NetworkConfiguration {
@@ -456,6 +511,12 @@ pub struct NetworkConfiguration {
     pub read_latency: LatencyDistribution,
     /// Latency distribution for write operations
     pub write_latency: LatencyDistribution,
+
+    /// Distance-based per-pair latency, resolved through the locality topology.
+    ///
+    /// `None` (the default) keeps every link equally fast, whatever the
+    /// topology. See [`LinkLatencyConfig`].
+    pub link_latency: Option<LinkLatencyConfig>,
 
     /// Chaos injection configuration
     pub chaos: ChaosConfiguration,
@@ -484,6 +545,8 @@ impl Default for NetworkConfiguration {
                 start: Duration::from_micros(100),
                 end: Duration::from_micros(600),
             },
+            // Realism knob, opt-in: distance-blind by default.
+            link_latency: None,
             chaos: ChaosConfiguration::default(),
         }
     }
@@ -680,6 +743,9 @@ impl NetworkConfiguration {
                 Duration::from_micros(sim_random_range(50..1000))
                     ..Duration::from_micros(sim_random_range(200..2000)),
             ),
+            // Distance latency models the deployment, not the seed, so chaos
+            // runs leave it to the caller (and draw no RNG for it).
+            link_latency: None,
             chaos: ChaosConfiguration::random_for_seed(),
         }
     }
@@ -709,6 +775,7 @@ impl NetworkConfiguration {
             connect_latency: uniform(ten_us, ten_us),
             read_latency: uniform(one_us, one_us),
             write_latency: uniform(one_us, one_us),
+            link_latency: None,
             chaos: ChaosConfiguration::disabled(),
         }
     }

--- a/moonpool-sim/src/network/config.rs
+++ b/moonpool-sim/src/network/config.rs
@@ -31,6 +31,8 @@
 //! | Send-only block | `partition_send_from()` | Manual | Asymmetric network failures |
 //! | Recv-only block | `partition_recv_to()` | Manual | Asymmetric network failures |
 //! | Partition strategy | `partition_strategy` | Random | Different failure patterns (uniform, isolate) |
+//! | Zone / datacenter cut | `partition_strategy = IsolateZone` / `IsolateDatacenter` | Random | Rack or region loss (needs a locality topology) |
+//! | One-way cut | `partition_strategy = AsymmetricSend` / `AsymmetricRecv` | Random | Half-reachable node, failure detector confusion |
 //!
 //! ## Data Integrity Faults
 //!
@@ -97,6 +99,10 @@ use std::time::Duration;
 /// - Random: General chaos, unpredictable failures
 /// - `UniformSize`: Tests various quorum sizes and split scenarios
 /// - `IsolateSingle`: Tests single-node isolation (common in production)
+/// - `IsolateZone` / `IsolateDatacenter`: Tests correlated, topology-shaped cuts
+///   (rack or region loss)
+/// - `AsymmetricSend` / `AsymmetricRecv`: Tests one-way reachability, where a node
+///   still hears the cluster but cannot answer (or the reverse)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum PartitionStrategy {
     /// Random IP pairs selected for partitioning.
@@ -112,6 +118,35 @@ pub enum PartitionStrategy {
     /// Isolate single node - always partition exactly one node from the rest.
     /// Tests the common production scenario where a single node becomes unreachable.
     IsolateSingle,
+
+    /// Isolate a whole zone - cut every process of one random zone from the rest.
+    ///
+    /// Models a rack or availability-zone loss, where collocated processes fail
+    /// together. Requires a locality topology
+    /// ([`SimWorld::set_localities`](crate::SimWorld::set_localities), installed by
+    /// [`.cluster()`](crate::SimulationBuilder::cluster)); without one it degrades
+    /// to [`Random`](Self::Random) selection.
+    IsolateZone,
+
+    /// Isolate a whole datacenter - cut every process of one random datacenter
+    /// from the rest.
+    ///
+    /// Models a region-level network cut, the classic cross-datacenter replication
+    /// test. Degrades to [`Random`](Self::Random) without a locality topology.
+    IsolateDatacenter,
+
+    /// Block all *outgoing* traffic from one random node (one-way cut).
+    ///
+    /// The node still receives, so it keeps seeing cluster traffic while its own
+    /// replies vanish (the failure mode that breaks naive failure detectors).
+    /// FDB models the same asymmetry with its send-side clogging.
+    AsymmetricSend,
+
+    /// Block all *incoming* traffic to one random node (one-way cut).
+    ///
+    /// The mirror of [`AsymmetricSend`](Self::AsymmetricSend): the node keeps
+    /// sending, but hears nothing back.
+    AsymmetricRecv,
 }
 
 /// Connection establishment failure mode for fault injection.
@@ -323,11 +358,17 @@ impl ChaosConfiguration {
             buggified_delay_probability: f64::from(sim_random_range(20..30)) / 100.0, // 20-30%
             connect_failure_mode: ConnectFailureMode::random_for_seed(),
             connect_failure_probability: f64::from(sim_random_range(40..60)) / 100.0, // 40-60%
-            // Randomly choose partition strategy
-            partition_strategy: match sim_random_range(0..3) {
+            // Randomly choose partition strategy. The locality-shaped arms
+            // degrade to `Random` selection when the run has no topology, so
+            // they are safe to draw for every seed.
+            partition_strategy: match sim_random_range(0..7) {
                 0 => PartitionStrategy::Random,
                 1 => PartitionStrategy::UniformSize,
-                _ => PartitionStrategy::IsolateSingle,
+                2 => PartitionStrategy::IsolateSingle,
+                3 => PartitionStrategy::IsolateZone,
+                4 => PartitionStrategy::IsolateDatacenter,
+                5 => PartitionStrategy::AsymmetricSend,
+                _ => PartitionStrategy::AsymmetricRecv,
             },
             // Permanent per-pair latency, randomized upper bound up to 100ms (FDB
             // buggifies MAX_CLOGGING_LATENCY to 0.1s). Kept last so existing RNG
@@ -762,6 +803,48 @@ mod swarm_tests {
             0.0_f64.to_bits(),
             "expected 0.0, got {value}"
         );
+    }
+}
+
+#[cfg(test)]
+mod partition_strategy_tests {
+    use super::{ChaosConfiguration, PartitionStrategy};
+    use crate::sim::rng::{reset_sim_rng, set_sim_seed};
+    use std::collections::BTreeSet;
+
+    fn strategy_for(seed: u64) -> PartitionStrategy {
+        reset_sim_rng();
+        set_sim_seed(seed);
+        ChaosConfiguration::random_for_seed().partition_strategy
+    }
+
+    #[test]
+    fn random_for_seed_reaches_every_strategy() {
+        let mut seen: BTreeSet<String> = BTreeSet::new();
+        for seed in 0..500_u64 {
+            seen.insert(format!("{:?}", strategy_for(seed)));
+        }
+        for expected in [
+            PartitionStrategy::Random,
+            PartitionStrategy::UniformSize,
+            PartitionStrategy::IsolateSingle,
+            PartitionStrategy::IsolateZone,
+            PartitionStrategy::IsolateDatacenter,
+            PartitionStrategy::AsymmetricSend,
+            PartitionStrategy::AsymmetricRecv,
+        ] {
+            assert!(
+                seen.contains(&format!("{expected:?}")),
+                "no seed in 0..500 selected {expected:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn strategy_selection_is_reproducible_per_seed() {
+        for seed in [0_u64, 1, 42, 12_345] {
+            assert_eq!(strategy_for(seed), strategy_for(seed));
+        }
     }
 }
 

--- a/moonpool-sim/src/network/mod.rs
+++ b/moonpool-sim/src/network/mod.rs
@@ -11,8 +11,8 @@ pub mod sim;
 
 // Re-export configuration
 pub use config::{
-    ChaosConfiguration, ConnectFailureMode, LatencyDistribution, NetworkConfiguration,
-    PartitionStrategy, sample_duration, sample_latency,
+    ChaosConfiguration, ConnectFailureMode, LatencyDistribution, LinkLatencyConfig,
+    NetworkConfiguration, PartitionStrategy, sample_duration, sample_latency,
 };
 
 // Re-export simulation network provider

--- a/moonpool-sim/src/runner/builder.rs
+++ b/moonpool-sim/src/runner/builder.rs
@@ -396,6 +396,8 @@ pub struct SimulationBuilder {
     seeds: Vec<u64>,
     network_chaos: Option<ChaosMode>,
     storage_chaos: Option<ChaosMode>,
+    /// Distance-based link latency, applied to every iteration's network config.
+    link_latency: Option<crate::network::LinkLatencyConfig>,
     /// Buggify-driven knob value-perturbation, enabled via [`Chaos::BuggifyKnobs`].
     /// Internal flag (not a public builder method) so the opt-in stays inside the
     /// `enable_chaos`/`Chaos` model.
@@ -432,6 +434,7 @@ impl SimulationBuilder {
             seeds: Vec::new(),
             network_chaos: None,
             storage_chaos: None,
+            link_latency: None,
             buggify_knobs: false,
             swarm_operations: false,
             invariants: Vec::new(),
@@ -534,6 +537,27 @@ impl SimulationBuilder {
             name,
             locality: Some(config),
         });
+        self
+    }
+
+    /// Give links a distance-dependent latency, resolved through the
+    /// [`.cluster()`](Self::cluster) topology.
+    ///
+    /// Realism rather than chaos: a cross-datacenter hop stays slow even on a
+    /// healthy seed. Each ordered IP pair samples its class distribution once at
+    /// first contact and keeps it for the run. Pairs where either side has no
+    /// locality (workload clients, plain `.processes()` runs) are unaffected.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// SimulationBuilder::new()
+    ///     .cluster(LocalityConfig::new(2, 2, 2, 1), || Box::new(MyNode::new()))
+    ///     .link_latency(LinkLatencyConfig::default())
+    /// ```
+    #[must_use]
+    pub fn link_latency(mut self, config: crate::network::LinkLatencyConfig) -> Self {
+        self.link_latency = Some(config);
         self
     }
 
@@ -906,6 +930,7 @@ impl SimulationBuilder {
     fn build_sim_for_iteration(
         network_chaos: Option<ChaosMode>,
         storage_chaos: Option<ChaosMode>,
+        link_latency: Option<crate::network::LinkLatencyConfig>,
         buggify_knobs: bool,
         seed: u64,
     ) -> crate::sim::SimWorld {
@@ -931,6 +956,9 @@ impl SimulationBuilder {
                 storage_config.apply_buggify_knobs();
             }
         }
+        // Distance latency is deployment shape, not a per-seed fault: it is
+        // applied verbatim, whatever the chaos mode.
+        network_config.link_latency = link_latency;
         let mut sim = crate::sim::SimWorld::new_with_network_config_and_seed(network_config, seed);
         sim.set_storage_config(storage_config);
         sim
@@ -1462,6 +1490,7 @@ impl SimulationBuilder {
         let mut sim = Self::build_sim_for_iteration(
             self.network_chaos,
             self.storage_chaos,
+            self.link_latency.clone(),
             self.buggify_knobs,
             seed,
         );

--- a/moonpool-sim/src/runner/builder.rs
+++ b/moonpool-sim/src/runner/builder.rs
@@ -1459,12 +1459,18 @@ impl SimulationBuilder {
             .as_ref()
             .map(Self::resolve_process_config);
 
-        let sim = Self::build_sim_for_iteration(
+        let mut sim = Self::build_sim_for_iteration(
             self.network_chaos,
             self.storage_chaos,
             self.buggify_knobs,
             seed,
         );
+        // Hand the engine the resolved topology as plain data so locality-aware
+        // network faults and distance-based latency can see it. Empty (and thus
+        // inert) for plain `.processes()` runs.
+        if let Some(config) = &process_config {
+            sim.set_localities(config.machine_registry.locality_map());
+        }
         let start_time = Instant::now();
         // Derive the per-seed attrition regime: `Swarm` draws a fresh reboot regime
         // from `CONFIG_RNG` (after the network/storage masks, keeping the draw order

--- a/moonpool-sim/src/runner/fault_injector.rs
+++ b/moonpool-sim/src/runner/fault_injector.rs
@@ -493,6 +493,10 @@ impl FaultInjector for AttritionInjector {
                     let zones = ctx.machine_registry().all_zones();
                     self.inject_domain(ctx, DomainLevel::Zone, &zones)?;
                 }
+                AttritionScope::PerDatacenter => {
+                    let datacenters = ctx.machine_registry().all_datacenters();
+                    self.inject_domain(ctx, DomainLevel::Datacenter, &datacenters)?;
+                }
             }
         }
         Ok(())

--- a/moonpool-sim/src/runner/fault_injector.rs
+++ b/moonpool-sim/src/runner/fault_injector.rs
@@ -40,8 +40,9 @@ use async_trait::async_trait;
 use moonpool_core::TimeProvider;
 
 use crate::SimulationResult;
+use crate::locality::DomainLevel;
 use crate::providers::{SimRandomProvider, SimTimeProvider};
-use crate::runner::locality::{DomainLevel, MachineRegistry};
+use crate::runner::locality::MachineRegistry;
 use crate::runner::process::{AttritionScope, RebootKind};
 use crate::runner::tags::TagRegistry;
 use crate::sim::SimWorld;

--- a/moonpool-sim/src/runner/locality.rs
+++ b/moonpool-sim/src/runner/locality.rs
@@ -1,10 +1,15 @@
-//! Failure-domain locality for correlated fault injection.
+//! Failure-domain topology layout and the IP → locality registry.
 //!
 //! Locality models a `FoundationDB`-style Cluster → Datacenter → Zone → Machine →
 //! Process hierarchy so that collocated processes share fate. It is **orthogonal
 //! to tags** ([`super::tags`]): tags round-robin independent dimensions, while
 //! locality assigns *contiguous* hierarchical groups whose processes can be
 //! rebooted together (see [`AttritionScope`](super::process::AttritionScope)).
+//!
+//! The vocabulary types ([`DomainLevel`], [`LocalityInfo`]) live in
+//! [`crate::locality`] because the simulation engine consumes them too; this
+//! module owns the *layout* ([`LocalityConfig`]) and the *registry*
+//! ([`MachineRegistry`]), both runner-side concerns.
 //!
 //! # Example
 //!
@@ -16,74 +21,9 @@
 use std::collections::HashMap;
 use std::net::IpAddr;
 
+use crate::locality::{DomainLevel, LocalityInfo};
+
 use super::builder::ProcessCount;
-
-/// The level of a failure domain in the locality hierarchy.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum DomainLevel {
-    /// A whole datacenter.
-    Datacenter,
-    /// A zone within a datacenter.
-    Zone,
-    /// A single machine — the unit of shared fate.
-    Machine,
-}
-
-/// Resolved failure-domain locality for a single process instance.
-///
-/// Identifiers are globally unique and hierarchical (`dc1`, `dc1-z1`,
-/// `dc1-z1-m1`) so that domain queries never confuse a machine in one
-/// datacenter with a machine in another.
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub struct LocalityInfo {
-    datacenter: String,
-    zone: String,
-    machine: String,
-}
-
-impl LocalityInfo {
-    /// Create locality from explicit datacenter, zone, and machine ids.
-    #[must_use]
-    pub fn new(
-        datacenter: impl Into<String>,
-        zone: impl Into<String>,
-        machine: impl Into<String>,
-    ) -> Self {
-        Self {
-            datacenter: datacenter.into(),
-            zone: zone.into(),
-            machine: machine.into(),
-        }
-    }
-
-    /// The datacenter id (e.g. `dc1`).
-    #[must_use]
-    pub fn datacenter(&self) -> &str {
-        &self.datacenter
-    }
-
-    /// The zone id (e.g. `dc1-z1`).
-    #[must_use]
-    pub fn zone(&self) -> &str {
-        &self.zone
-    }
-
-    /// The machine id (e.g. `dc1-z1-m1`).
-    #[must_use]
-    pub fn machine(&self) -> &str {
-        &self.machine
-    }
-
-    /// The id at the given domain level.
-    #[must_use]
-    pub fn id_for(&self, level: DomainLevel) -> &str {
-        match level {
-            DomainLevel::Datacenter => &self.datacenter,
-            DomainLevel::Zone => &self.zone,
-            DomainLevel::Machine => &self.machine,
-        }
-    }
-}
 
 /// Configuration for laying processes out across a failure-domain topology.
 ///
@@ -287,13 +227,5 @@ mod tests {
             vec!["dc1".to_string(), "dc2".to_string()]
         );
         assert!(!reg.is_empty());
-    }
-
-    #[test]
-    fn id_for_matches_accessors() {
-        let loc = LocalityInfo::new("dc1", "dc1-z2", "dc1-z2-m3");
-        assert_eq!(loc.id_for(DomainLevel::Datacenter), loc.datacenter());
-        assert_eq!(loc.id_for(DomainLevel::Zone), loc.zone());
-        assert_eq!(loc.id_for(DomainLevel::Machine), loc.machine());
     }
 }

--- a/moonpool-sim/src/runner/locality.rs
+++ b/moonpool-sim/src/runner/locality.rs
@@ -18,7 +18,7 @@
 //! .cluster(LocalityConfig::new(3, 3, 3, 1), || Box::new(MyNode::new()))
 //! ```
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::net::IpAddr;
 
 use crate::locality::{DomainLevel, LocalityInfo};
@@ -125,6 +125,19 @@ impl MachineRegistry {
     #[must_use]
     pub fn locality_for(&self, ip: IpAddr) -> Option<&LocalityInfo> {
         self.ip_locality.get(&ip)
+    }
+
+    /// Export the registry as plain, deterministically ordered data for the
+    /// simulation engine ([`SimWorld::set_localities`](crate::SimWorld::set_localities)).
+    ///
+    /// The engine only needs `ip -> LocalityInfo`; keeping the registry itself
+    /// runner-side preserves the layering (the engine never imports the runner).
+    #[must_use]
+    pub fn locality_map(&self) -> BTreeMap<IpAddr, LocalityInfo> {
+        self.ip_locality
+            .iter()
+            .map(|(ip, locality)| (*ip, locality.clone()))
+            .collect()
     }
 
     /// Find all IPs whose domain at `level` matches `id`.

--- a/moonpool-sim/src/runner/mod.rs
+++ b/moonpool-sim/src/runner/mod.rs
@@ -28,7 +28,7 @@ pub use builder::{Chaos, ChaosMode, ClientId, WorkloadCount};
 pub use builder::{IterationControl, SimulationBuilder};
 pub use context::SimContext;
 pub use fault_injector::{FaultContext, FaultInjector};
-pub use locality::{DomainLevel, LocalityConfig, LocalityInfo, MachineRegistry};
+pub use locality::{LocalityConfig, MachineRegistry};
 pub use process::{Attrition, AttritionScope, Process, RebootKind};
 pub use report::{SimulationMetrics, SimulationReport};
 pub use tags::{ProcessTags, TagRegistry};

--- a/moonpool-sim/src/runner/process.rs
+++ b/moonpool-sim/src/runner/process.rs
@@ -82,9 +82,10 @@ pub enum RebootKind {
 /// The failure domain a reboot targets.
 ///
 /// Controls how [`AttritionInjector`](super::fault_injector) selects victims.
-/// `PerMachine` / `PerZone` reboot all collocated processes *together* — modeling
-/// correlated failure — and require a [`.cluster()`](super::builder::SimulationBuilder::cluster)
-/// topology. Without locality they are a no-op.
+/// `PerMachine` / `PerZone` / `PerDatacenter` reboot all collocated processes
+/// *together* (modeling correlated failure) and require a
+/// [`.cluster()`](super::builder::SimulationBuilder::cluster) topology. Without
+/// locality they are a no-op.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum AttritionScope {
     /// Reboot a single random process (the historical behavior).
@@ -94,6 +95,12 @@ pub enum AttritionScope {
     PerMachine,
     /// Reboot every process in a single random zone atomically.
     PerZone,
+    /// Reboot every process in a single random datacenter atomically.
+    ///
+    /// The widest correlated failure: a whole region going down. Only fires when
+    /// the entire datacenter fits in the remaining `max_dead` budget, so a
+    /// datacenter-sized budget is needed for it to ever trigger.
+    PerDatacenter,
 }
 
 /// Built-in attrition configuration for automatic process reboots.
@@ -157,10 +164,11 @@ pub struct Attrition {
     /// The failure domain each reboot targets.
     ///
     /// [`AttritionScope::PerProcess`] (the default) kills one random process at
-    /// a time. [`AttritionScope::PerMachine`] / [`AttritionScope::PerZone`] kill
-    /// all collocated processes together, modeling correlated failure; they
-    /// require a [`.cluster()`](super::builder::SimulationBuilder::cluster)
-    /// topology and respect `max_dead` as a whole-group budget.
+    /// a time. [`AttritionScope::PerMachine`], [`AttritionScope::PerZone`], and
+    /// [`AttritionScope::PerDatacenter`] kill all collocated processes together,
+    /// modeling correlated failure; they require a
+    /// [`.cluster()`](super::builder::SimulationBuilder::cluster) topology and
+    /// respect `max_dead` as a whole-group budget.
     pub scope: AttritionScope,
 }
 

--- a/moonpool-sim/src/runner/topology.rs
+++ b/moonpool-sim/src/runner/topology.rs
@@ -3,7 +3,9 @@
 //! This module provides types for configuring topology and
 //! creating topology information for workloads and processes.
 
-use super::locality::{DomainLevel, LocalityInfo, MachineRegistry};
+use crate::locality::{DomainLevel, LocalityInfo};
+
+use super::locality::MachineRegistry;
 use super::tags::{ProcessTags, TagRegistry};
 
 /// Topology information provided to workloads and processes.

--- a/moonpool-sim/src/sim/world.rs
+++ b/moonpool-sim/src/sim/world.rs
@@ -15,6 +15,7 @@ use tracing::instrument;
 use crate::{
     SimulationError, SimulationResult,
     chaos::fault_events::SimFaultEvent,
+    locality::{DomainLevel, LocalityInfo},
     network::{
         NetworkConfiguration, PartitionStrategy,
         sim::{ConnectionId, ListenerId, SimNetworkProvider},
@@ -44,6 +45,12 @@ pub(crate) struct SimInner {
 
     // Network management
     pub(crate) network: NetworkState,
+
+    /// Read-only failure-domain locality per process IP, installed once at setup
+    /// by [`SimWorld::set_localities`]. Empty for runs without a topology
+    /// (plain `.processes()`), which makes every locality-driven behavior
+    /// degrade to its flat equivalent.
+    pub(crate) localities: BTreeMap<IpAddr, LocalityInfo>,
 
     // Storage management
     pub(crate) storage: StorageState,
@@ -77,6 +84,7 @@ impl SimInner {
             event_queue: EventQueue::new(),
             next_sequence: 0,
             network: NetworkState::new(NetworkConfiguration::default()),
+            localities: BTreeMap::new(),
             storage: StorageState::default(),
             wakers: WakerRegistry::default(),
             next_task_id: 0,
@@ -95,6 +103,7 @@ impl SimInner {
             event_queue: EventQueue::new(),
             next_sequence: 0,
             network: NetworkState::new(network_config),
+            localities: BTreeMap::new(),
             storage: StorageState::default(),
             wakers: WakerRegistry::default(),
             next_task_id: 0,
@@ -516,6 +525,47 @@ impl SimWorld {
             .expect("RwLock poisoned: prior task panicked")
             .storage
             .config = config;
+    }
+
+    /// Install the failure-domain locality of every process IP.
+    ///
+    /// Called once at setup by the runner (from the `.cluster()` topology it
+    /// already resolves) and directly by tests. The engine treats the map as
+    /// read-only plain data: it never sees the runner's `MachineRegistry`.
+    ///
+    /// The map shapes two behaviors:
+    /// - locality-aware partition strategies
+    ///   ([`PartitionStrategy::IsolateZone`] / [`IsolateDatacenter`](PartitionStrategy::IsolateDatacenter));
+    /// - distance-based link latency
+    ///   ([`LinkLatencyConfig`](crate::network::config::NetworkConfiguration)).
+    ///
+    /// An empty map (the default, and what plain `.processes()` runs get) makes
+    /// both degrade to their flat, topology-blind behavior.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the simulation lock is poisoned by a prior task panic.
+    #[instrument(skip(self, localities), fields(count = localities.len()))]
+    pub fn set_localities(&mut self, localities: BTreeMap<IpAddr, LocalityInfo>) {
+        self.inner
+            .write()
+            .expect("RwLock poisoned: prior task panicked")
+            .localities = localities;
+    }
+
+    /// The failure-domain locality of a process IP, if a topology is installed.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the simulation lock is poisoned by a prior task panic.
+    #[must_use]
+    pub fn locality_for(&self, ip: IpAddr) -> Option<LocalityInfo> {
+        self.inner
+            .read()
+            .expect("RwLock poisoned: prior task panicked")
+            .localities
+            .get(&ip)
+            .cloned()
     }
 
     /// Set the storage configuration for a single process IP.
@@ -2709,22 +2759,60 @@ impl SimWorld {
             .inner
             .write()
             .expect("RwLock poisoned: prior task panicked");
-        let expires_at = inner.current_time + duration;
+        Self::insert_send_partition(&mut inner, ip, duration);
+        Ok(())
+    }
 
-        inner.network.send_partitions.insert(ip, expires_at);
-
-        let clear_event = Event::Connection {
-            id: 0,
-            state: ConnectionStateChange::SendPartitionClear,
-        };
+    /// Schedule a partition-expiry event at `expires_at`.
+    ///
+    /// Shared by every directional partition path so the clear event and the
+    /// sequence bookkeeping stay in one place.
+    fn schedule_partition_clear(
+        inner: &mut SimInner,
+        state: ConnectionStateChange,
+        expires_at: Duration,
+    ) {
+        let clear_event = Event::Connection { id: 0, state };
         let sequence = inner.next_sequence;
         inner.next_sequence += 1;
-        let scheduled_event = ScheduledEvent::new(expires_at, clear_event, sequence);
-        inner.event_queue.schedule(scheduled_event);
+        inner
+            .event_queue
+            .schedule(ScheduledEvent::new(expires_at, clear_event, sequence));
+    }
 
+    /// Block outgoing traffic from `ip` for `duration` on an already-locked
+    /// simulation, scheduling its expiry and recording the fault event.
+    ///
+    /// Shared by [`partition_send_from`](Self::partition_send_from) and the
+    /// automatic [`PartitionStrategy::AsymmetricSend`] rotation, so both surface
+    /// identically on the fault timeline.
+    fn insert_send_partition(inner: &mut SimInner, ip: IpAddr, duration: Duration) {
+        let expires_at = inner.current_time + duration;
+        inner.network.send_partitions.insert(ip, expires_at);
+        Self::schedule_partition_clear(
+            inner,
+            ConnectionStateChange::SendPartitionClear,
+            expires_at,
+        );
         inner.record_fault(SimFaultEvent::SendPartitionCreated { ip: ip.to_string() });
         tracing::debug!("Partitioned sends from {} until {:?}", ip, expires_at);
-        Ok(())
+    }
+
+    /// Block incoming traffic to `ip` for `duration` on an already-locked
+    /// simulation, scheduling its expiry and recording the fault event.
+    ///
+    /// Mirror of [`insert_send_partition`](Self::insert_send_partition), shared
+    /// with the [`PartitionStrategy::AsymmetricRecv`] rotation.
+    fn insert_recv_partition(inner: &mut SimInner, ip: IpAddr, duration: Duration) {
+        let expires_at = inner.current_time + duration;
+        inner.network.recv_partitions.insert(ip, expires_at);
+        Self::schedule_partition_clear(
+            inner,
+            ConnectionStateChange::RecvPartitionClear,
+            expires_at,
+        );
+        inner.record_fault(SimFaultEvent::RecvPartitionCreated { ip: ip.to_string() });
+        tracing::debug!("Partitioned receives to {} until {:?}", ip, expires_at);
     }
 
     /// Block all incoming communication to an IP address
@@ -2745,21 +2833,7 @@ impl SimWorld {
             .inner
             .write()
             .expect("RwLock poisoned: prior task panicked");
-        let expires_at = inner.current_time + duration;
-
-        inner.network.recv_partitions.insert(ip, expires_at);
-
-        let clear_event = Event::Connection {
-            id: 0,
-            state: ConnectionStateChange::RecvPartitionClear,
-        };
-        let sequence = inner.next_sequence;
-        inner.next_sequence += 1;
-        let scheduled_event = ScheduledEvent::new(expires_at, clear_event, sequence);
-        inner.event_queue.schedule(scheduled_event);
-
-        inner.record_fault(SimFaultEvent::RecvPartitionCreated { ip: ip.to_string() });
-        tracing::debug!("Partitioned receives to {} until {:?}", ip, expires_at);
+        Self::insert_recv_partition(&mut inner, ip, duration);
         Ok(())
     }
 
@@ -2819,19 +2893,27 @@ impl SimWorld {
     /// - Random: randomly partition individual IP pairs
     /// - `UniformSize`: create uniform-sized partition groups
     /// - `IsolateSingle`: isolate exactly one node from the rest
+    /// - `IsolateZone` / `IsolateDatacenter`: isolate a whole failure domain
+    ///   (degrades to `Random` selection without a locality topology)
+    /// - `AsymmetricSend` / `AsymmetricRecv`: one-way cut on a single node
     fn randomly_trigger_partitions_with_inner(inner: &mut SimInner) {
-        let partition_config = &inner.network.config;
+        let chaos = &inner.network.config.chaos;
 
-        if partition_config.chaos.partition_probability == 0.0 {
+        if chaos.partition_probability == 0.0 {
             return;
         }
 
         // Check if we should trigger a partition this step
-        if sim_random::<f64>() >= partition_config.chaos.partition_probability {
+        if sim_random::<f64>() >= chaos.partition_probability {
             return;
         }
 
-        // Collect unique IPs from connections
+        let strategy = chaos.partition_strategy;
+        let duration_range = chaos.partition_duration.clone();
+
+        // Collect unique IPs from connections. `HashSet` iteration order is not
+        // stable across processes, so sort before any RNG-driven selection:
+        // determinism depends on the candidate list being canonical.
         let unique_ips: HashSet<IpAddr> = inner
             .network
             .connections
@@ -2843,26 +2925,56 @@ impl SimWorld {
             return; // Need at least 2 IPs to partition
         }
 
-        let ip_list: Vec<IpAddr> = unique_ips.into_iter().collect();
-        let partition_duration =
-            crate::network::sample_duration(&partition_config.chaos.partition_duration);
-        let expires_at = inner.current_time + partition_duration;
+        let mut ip_list: Vec<IpAddr> = unique_ips.into_iter().collect();
+        ip_list.sort_unstable();
 
-        // Select IPs to partition based on strategy
-        let partitioned_ips: Vec<IpAddr> = match partition_config.chaos.partition_strategy {
-            PartitionStrategy::Random => {
-                // Original behavior: randomly decide for each IP
-                ip_list
-                    .iter()
-                    .filter(|_| sim_random::<f64>() < 0.5)
-                    .copied()
-                    .collect()
+        let partition_duration = crate::network::sample_duration(&duration_range);
+
+        // One-way strategies cut a single node's send or receive side; they use
+        // the directional primitives instead of a group cut.
+        if matches!(
+            strategy,
+            PartitionStrategy::AsymmetricSend | PartitionStrategy::AsymmetricRecv
+        ) {
+            let idx = sim_random_range(0..ip_list.len());
+            let ip = ip_list[idx];
+            if strategy == PartitionStrategy::AsymmetricSend {
+                Self::insert_send_partition(inner, ip, partition_duration);
+            } else {
+                Self::insert_recv_partition(inner, ip, partition_duration);
             }
+            return;
+        }
+
+        let partitioned_ips = Self::select_partition_group(inner, &ip_list, strategy);
+
+        // Don't partition if we selected all IPs or none
+        if partitioned_ips.is_empty() || partitioned_ips.len() == ip_list.len() {
+            return;
+        }
+
+        let expires_at = inner.current_time + partition_duration;
+        Self::cut_groups_bidirectionally(inner, &ip_list, &partitioned_ips, expires_at, strategy);
+
+        // Schedule restoration event
+        Self::schedule_partition_clear(inner, ConnectionStateChange::PartitionRestore, expires_at);
+    }
+
+    /// Select the IPs to cut off from the rest, per partition strategy.
+    ///
+    /// Every branch draws only from the seeded simulation RNG and only from the
+    /// canonically ordered `ip_list`, so the selection is reproducible.
+    fn select_partition_group(
+        inner: &SimInner,
+        ip_list: &[IpAddr],
+        strategy: PartitionStrategy,
+    ) -> Vec<IpAddr> {
+        match strategy {
             PartitionStrategy::UniformSize => {
                 // TigerBeetle-style: random partition size from 1 to n-1
                 let partition_size = sim_random_range(1..ip_list.len());
                 // Shuffle and take first N IPs
-                let mut shuffled = ip_list.clone();
+                let mut shuffled = ip_list.to_vec();
                 // Simple Fisher-Yates shuffle
                 for i in (1..shuffled.len()).rev() {
                     let j = sim_random_range(0..i + 1);
@@ -2875,21 +2987,83 @@ impl SimWorld {
                 let idx = sim_random_range(0..ip_list.len());
                 vec![ip_list[idx]]
             }
-        };
+            PartitionStrategy::IsolateZone => {
+                Self::select_domain_group(inner, ip_list, DomainLevel::Zone)
+                    .unwrap_or_else(|| Self::select_random_group(ip_list))
+            }
+            PartitionStrategy::IsolateDatacenter => {
+                Self::select_domain_group(inner, ip_list, DomainLevel::Datacenter)
+                    .unwrap_or_else(|| Self::select_random_group(ip_list))
+            }
+            // `Random`, plus the one-way arms which never reach here.
+            _ => Self::select_random_group(ip_list),
+        }
+    }
 
-        // Don't partition if we selected all IPs or none
-        if partitioned_ips.is_empty() || partitioned_ips.len() == ip_list.len() {
-            return;
+    /// Flip a coin per IP (the historical `Random` selection).
+    fn select_random_group(ip_list: &[IpAddr]) -> Vec<IpAddr> {
+        ip_list
+            .iter()
+            .filter(|_| sim_random::<f64>() < 0.5)
+            .copied()
+            .collect()
+    }
+
+    /// Select every connected IP that shares one randomly chosen failure domain
+    /// at `level`, modelling a rack or region loss.
+    ///
+    /// Returns `None` when no connected IP has a locality (no `.cluster()`
+    /// topology), which makes the caller degrade to flat random selection. The
+    /// candidate domain ids are deduplicated and sorted before the draw, so the
+    /// choice depends only on the seed.
+    fn select_domain_group(
+        inner: &SimInner,
+        ip_list: &[IpAddr],
+        level: DomainLevel,
+    ) -> Option<Vec<IpAddr>> {
+        let mut domain_ids: Vec<&str> = ip_list
+            .iter()
+            .filter_map(|ip| inner.localities.get(ip))
+            .map(|locality| locality.id_for(level))
+            .collect();
+        domain_ids.sort_unstable();
+        domain_ids.dedup();
+
+        if domain_ids.is_empty() {
+            return None;
         }
 
-        // Create bi-directional partitions between partitioned and non-partitioned groups
+        let chosen = domain_ids[sim_random_range(0..domain_ids.len())];
+        Some(
+            ip_list
+                .iter()
+                .filter(|ip| {
+                    inner
+                        .localities
+                        .get(ip)
+                        .is_some_and(|locality| locality.id_for(level) == chosen)
+                })
+                .copied()
+                .collect(),
+        )
+    }
+
+    /// Cut `partitioned_ips` off from the rest of `ip_list` in both directions,
+    /// recording one fault event per new directed pair.
+    fn cut_groups_bidirectionally(
+        inner: &mut SimInner,
+        ip_list: &[IpAddr],
+        partitioned_ips: &[IpAddr],
+        expires_at: Duration,
+        strategy: PartitionStrategy,
+    ) {
         let non_partitioned: Vec<IpAddr> = ip_list
             .iter()
             .filter(|ip| !partitioned_ips.contains(ip))
             .copied()
             .collect();
 
-        for &from_ip in &partitioned_ips {
+        for &from_ip in partitioned_ips {
             for &to_ip in &non_partitioned {
                 // Skip if already partitioned
                 if inner
@@ -2909,15 +3083,9 @@ impl SimWorld {
                     .ip_partitions
                     .insert((to_ip, from_ip), PartitionState { expires_at });
 
-                // Disjoint-field push: `partition_config` still borrows
-                // `inner.network`, so go through `pending_faults` directly.
-                let time_ms = u64::try_from(inner.current_time.as_millis()).unwrap_or(u64::MAX);
-                inner.pending_faults.push(SimFaultRecord {
-                    time_ms,
-                    event: SimFaultEvent::PartitionCreated {
-                        from: from_ip.to_string(),
-                        to: to_ip.to_string(),
-                    },
+                inner.record_fault(SimFaultEvent::PartitionCreated {
+                    from: from_ip.to_string(),
+                    to: to_ip.to_string(),
                 });
 
                 tracing::debug!(
@@ -2925,20 +3093,10 @@ impl SimWorld {
                     from_ip,
                     to_ip,
                     expires_at,
-                    partition_config.chaos.partition_strategy
+                    strategy
                 );
             }
         }
-
-        // Schedule restoration event
-        let restore_event = Event::Connection {
-            id: 0,
-            state: ConnectionStateChange::PartitionRestore,
-        };
-        let sequence = inner.next_sequence;
-        inner.next_sequence += 1;
-        let scheduled_event = ScheduledEvent::new(expires_at, restore_event, sequence);
-        inner.event_queue.schedule(scheduled_event);
     }
 }
 

--- a/moonpool-sim/src/sim/world.rs
+++ b/moonpool-sim/src/sim/world.rs
@@ -2126,18 +2126,28 @@ impl SimWorld {
     /// Get the permanent per-pair base latency for a connection, memoizing it on
     /// first contact (FDB `SimClogging`).
     ///
-    /// Returns [`Duration::ZERO`] — without drawing from the RNG or touching the
-    /// pair map — when the `max_pair_latency` range is disabled (its `end` is zero)
-    /// or the connection's endpoints are unknown. Otherwise samples a fixed latency
-    /// from `max_pair_latency` once per ordered IP pair and reuses it for the run.
+    /// Two independent extras share this one per-pair budget and are summed:
+    /// - the chaos `max_pair_latency` sample (a stably-slow link);
+    /// - the distance-based [`LinkLatencyConfig`](crate::network::LinkLatencyConfig)
+    ///   sample, classified through the installed locality topology.
+    ///
+    /// Returns [`Duration::ZERO`] without drawing from the RNG or touching the
+    /// pair map when both are off, or when the connection's endpoints are
+    /// unknown. Otherwise the sum is sampled once per ordered IP pair and reused
+    /// for the whole run.
     ///
     /// # Panics
     ///
     /// Panics if the simulation lock is poisoned by a prior task panic.
     #[must_use]
     pub fn connection_base_latency(&self, connection_id: ConnectionId) -> Duration {
-        let range = self.with_network_config(|config| config.chaos.max_pair_latency.clone());
-        if range.end.is_zero() {
+        let (range, link_latency) = self.with_network_config(|config| {
+            (
+                config.chaos.max_pair_latency.clone(),
+                config.link_latency.clone(),
+            )
+        });
+        if range.end.is_zero() && link_latency.is_none() {
             return Duration::ZERO;
         }
 
@@ -2162,8 +2172,52 @@ impl SimWorld {
         }
 
         // Sample a fixed latency for this pair and memoize it for the whole run.
-        let latency = crate::network::sample_duration(&range);
+        // The chaos draw comes first so runs without distance latency keep their
+        // historical RNG sequence.
+        let mut latency = if range.end.is_zero() {
+            Duration::ZERO
+        } else {
+            crate::network::sample_duration(&range)
+        };
+        if let Some(link_latency) = &link_latency {
+            latency =
+                latency.saturating_add(self.sample_link_latency(link_latency, local_ip, remote_ip));
+        }
         self.set_pair_latency_if_not_set(local_ip, remote_ip, latency)
+    }
+
+    /// Sample the distance-based extra for an IP pair.
+    ///
+    /// Returns [`Duration::ZERO`] (drawing nothing) when either endpoint has no
+    /// locality, which is the case for every run without a `.cluster()`
+    /// topology, and for workload/client IPs inside one.
+    fn sample_link_latency(
+        &self,
+        link_latency: &crate::network::LinkLatencyConfig,
+        local_ip: IpAddr,
+        remote_ip: IpAddr,
+    ) -> Duration {
+        let class = {
+            let inner = self
+                .inner
+                .read()
+                .expect("RwLock poisoned: prior task panicked");
+            let local = inner.localities.get(&local_ip);
+            let remote = inner.localities.get(&remote_ip);
+            local.zip(remote).map(|(l, r)| l.link_class(r))
+        };
+        let Some(class) = class else {
+            return Duration::ZERO;
+        };
+        let sampled = crate::network::sample_latency(link_latency.distribution_for(class));
+        tracing::debug!(
+            "Distance latency for {} -> {}: {:?} ({:?})",
+            local_ip,
+            remote_ip,
+            sampled,
+            class
+        );
+        sampled
     }
 
     // Per-connection asymmetric delay methods

--- a/moonpool-sim/tests/network.rs
+++ b/moonpool-sim/tests/network.rs
@@ -6,6 +6,8 @@
 mod latency;
 #[path = "network/partition.rs"]
 mod partition;
+#[path = "network/partition_strategy.rs"]
+mod partition_strategy;
 // Exercises TokioNetworkProvider — only available with the tokio-providers feature.
 #[cfg(feature = "tokio-providers")]
 #[path = "network/traits.rs"]

--- a/moonpool-sim/tests/network/latency.rs
+++ b/moonpool-sim/tests/network/latency.rs
@@ -1,8 +1,10 @@
 use futures::io::AsyncWriteExt;
 use moonpool_sim::{
-    ChaosConfiguration, LatencyDistribution, NetworkConfiguration, NetworkProvider, SimWorld,
-    TcpListenerTrait,
+    ChaosConfiguration, LatencyDistribution, LinkLatencyConfig, LocalityInfo, NetworkConfiguration,
+    NetworkProvider, SimWorld, TcpListenerTrait,
 };
+use std::collections::BTreeMap;
+use std::net::IpAddr;
 use std::time::Duration;
 
 /// Build a uniform latency distribution over `[start, end)` for test configs.
@@ -104,6 +106,7 @@ fn test_custom_latency_configuration() {
             connect_latency: uniform(Duration::from_millis(1), Duration::from_millis(1)),
             read_latency: uniform(Duration::from_micros(10), Duration::from_micros(10)),
             write_latency: uniform(Duration::from_millis(2), Duration::from_millis(2)),
+            link_latency: None,
             chaos: ChaosConfiguration::disabled(),
         };
 
@@ -147,6 +150,7 @@ fn test_latency_range_sampling() {
             connect_latency: uniform(Duration::from_millis(1), Duration::from_millis(6)),
             read_latency: uniform(Duration::from_micros(10), Duration::from_micros(10)),
             write_latency: uniform(Duration::from_millis(1), Duration::from_millis(6)),
+            link_latency: None,
             chaos: ChaosConfiguration::disabled(),
         };
 
@@ -201,6 +205,7 @@ fn test_network_randomization_ranges() {
             connect_latency: uniform(Duration::from_millis(3), Duration::from_millis(3)),
             read_latency: uniform(Duration::from_micros(100), Duration::from_micros(100)),
             write_latency: uniform(Duration::from_micros(500), Duration::from_micros(500)),
+            link_latency: None,
             chaos: ChaosConfiguration::disabled(),
         };
 
@@ -283,4 +288,163 @@ fn test_client_initiated_connection_records_pair_latency() {
             "latency {latency:?} outside configured max_pair_latency range"
         );
     });
+}
+
+// ---------------------------------------------------------------------------
+// Distance-based link latency (LinkLatencyConfig)
+// ---------------------------------------------------------------------------
+
+/// Per-class distributions with disjoint ranges, so a sampled value alone
+/// identifies which class the engine picked.
+fn distinct_link_latencies() -> LinkLatencyConfig {
+    LinkLatencyConfig {
+        same_machine: uniform(Duration::from_millis(1), Duration::from_millis(2)),
+        same_zone: uniform(Duration::from_millis(10), Duration::from_millis(11)),
+        same_datacenter: uniform(Duration::from_millis(100), Duration::from_millis(101)),
+        cross_datacenter: uniform(Duration::from_millis(1000), Duration::from_millis(1001)),
+    }
+}
+
+/// Locality map for the two IPs used by [`memoized_pair_latency`], each given as
+/// `(datacenter, zone, machine)`.
+fn two_process_localities(
+    client: (&str, &str, &str),
+    server: (&str, &str, &str),
+) -> BTreeMap<IpAddr, LocalityInfo> {
+    BTreeMap::from([
+        (
+            "10.0.1.1".parse().expect("valid ip"),
+            LocalityInfo::new(client.0, client.1, client.2),
+        ),
+        (
+            "10.0.1.2".parse().expect("valid ip"),
+            LocalityInfo::new(server.0, server.1, server.2),
+        ),
+    ])
+}
+
+/// Connect `10.0.1.1 -> 10.0.1.2` under `config` with `localities` installed,
+/// and return the per-pair latency the engine memoized for that direction.
+fn memoized_pair_latency(
+    config: NetworkConfiguration,
+    localities: BTreeMap<IpAddr, LocalityInfo>,
+) -> Option<Duration> {
+    let local_runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .enable_time()
+        .build()
+        .expect("Failed to build local runtime");
+
+    local_runtime.block_on(async move {
+        let mut sim = SimWorld::new_with_network_config_and_seed(config, 42);
+        sim.set_localities(localities);
+
+        let client_ip: IpAddr = "10.0.1.1".parse().expect("valid ip");
+        let server_ip: IpAddr = "10.0.1.2".parse().expect("valid ip");
+        let server_addr = "10.0.1.2:8080";
+
+        let provider = sim.network_provider(client_ip);
+        let listener = provider.bind(server_addr).await.expect("bind");
+        let _client = provider.connect(server_addr).await.expect("connect");
+        let (_server, _) = listener.accept().await.expect("accept");
+
+        sim.run_until_empty();
+        sim.pair_latency(client_ip, server_ip)
+    })
+}
+
+/// Each locality distance selects its own distribution.
+#[test]
+fn link_latency_classifies_the_pair_by_distance() {
+    let config = || {
+        let mut config = NetworkConfiguration::fast_local();
+        config.link_latency = Some(distinct_link_latencies());
+        config
+    };
+
+    let cases = [
+        (
+            ("dc1", "dc1-z1", "dc1-z1-m1"),
+            ("dc1", "dc1-z1", "dc1-z1-m1"),
+            Duration::from_millis(1)..Duration::from_millis(2),
+            "same machine",
+        ),
+        (
+            ("dc1", "dc1-z1", "dc1-z1-m1"),
+            ("dc1", "dc1-z1", "dc1-z1-m2"),
+            Duration::from_millis(10)..Duration::from_millis(11),
+            "same zone",
+        ),
+        (
+            ("dc1", "dc1-z1", "dc1-z1-m1"),
+            ("dc1", "dc1-z2", "dc1-z2-m1"),
+            Duration::from_millis(100)..Duration::from_millis(101),
+            "same datacenter",
+        ),
+        (
+            ("dc1", "dc1-z1", "dc1-z1-m1"),
+            ("dc2", "dc2-z1", "dc2-z1-m1"),
+            Duration::from_millis(1000)..Duration::from_millis(1001),
+            "cross datacenter",
+        ),
+    ];
+
+    for (client, server, expected, label) in cases {
+        let latency = memoized_pair_latency(config(), two_process_localities(client, server))
+            .unwrap_or_else(|| panic!("{label}: no per-pair latency recorded"));
+        assert!(
+            expected.contains(&latency),
+            "{label}: latency {latency:?} outside {expected:?}"
+        );
+    }
+}
+
+/// The distance sample and the chaos `max_pair_latency` sample share one
+/// per-pair budget: the memoized value is their sum.
+#[test]
+fn link_latency_sums_with_max_pair_latency() {
+    let mut config = NetworkConfiguration::fast_local();
+    config.chaos.max_pair_latency = Duration::from_millis(5)..Duration::from_millis(6);
+    config.link_latency = Some(distinct_link_latencies());
+
+    let localities = two_process_localities(
+        ("dc1", "dc1-z1", "dc1-z1-m1"),
+        ("dc2", "dc2-z1", "dc2-z1-m1"),
+    );
+    let latency =
+        memoized_pair_latency(config, localities).expect("per-pair latency should be recorded");
+
+    // 5..6ms of chaos plus 1000..1001ms of distance.
+    let expected = Duration::from_millis(1005)..Duration::from_millis(1007);
+    assert!(
+        expected.contains(&latency),
+        "latency {latency:?} is not the sum of both extras ({expected:?})"
+    );
+}
+
+/// Without locality for both endpoints there is no distance to speak of, so the
+/// pair gets no extra latency (and the engine must not panic).
+#[test]
+fn link_latency_is_inert_without_locality() {
+    let mut config = NetworkConfiguration::fast_local();
+    config.link_latency = Some(distinct_link_latencies());
+
+    // Empty topology: the plain `.processes()` case.
+    assert_eq!(
+        memoized_pair_latency(config.clone(), BTreeMap::new()),
+        Some(Duration::ZERO),
+        "an unlocalized pair must get no distance latency"
+    );
+
+    // Half-known topology: only the server has a locality, as when a workload
+    // client talks to a clustered process.
+    let partial = BTreeMap::from([(
+        "10.0.1.2".parse::<IpAddr>().expect("valid ip"),
+        LocalityInfo::new("dc1", "dc1-z1", "dc1-z1-m1"),
+    )]);
+    assert_eq!(
+        memoized_pair_latency(config, partial),
+        Some(Duration::ZERO),
+        "a pair with one unlocalized endpoint must get no distance latency"
+    );
 }

--- a/moonpool-sim/tests/network/latency.rs
+++ b/moonpool-sim/tests/network/latency.rs
@@ -301,7 +301,7 @@ fn distinct_link_latencies() -> LinkLatencyConfig {
         same_machine: uniform(Duration::from_millis(1), Duration::from_millis(2)),
         same_zone: uniform(Duration::from_millis(10), Duration::from_millis(11)),
         same_datacenter: uniform(Duration::from_millis(100), Duration::from_millis(101)),
-        cross_datacenter: uniform(Duration::from_millis(1000), Duration::from_millis(1001)),
+        cross_datacenter: uniform(Duration::from_millis(900), Duration::from_millis(950)),
     }
 }
 
@@ -384,7 +384,7 @@ fn link_latency_classifies_the_pair_by_distance() {
         (
             ("dc1", "dc1-z1", "dc1-z1-m1"),
             ("dc2", "dc2-z1", "dc2-z1-m1"),
-            Duration::from_millis(1000)..Duration::from_millis(1001),
+            Duration::from_millis(900)..Duration::from_millis(950),
             "cross datacenter",
         ),
     ];
@@ -414,8 +414,8 @@ fn link_latency_sums_with_max_pair_latency() {
     let latency =
         memoized_pair_latency(config, localities).expect("per-pair latency should be recorded");
 
-    // 5..6ms of chaos plus 1000..1001ms of distance.
-    let expected = Duration::from_millis(1005)..Duration::from_millis(1007);
+    // 5..6ms of chaos plus 900..950ms of distance.
+    let expected = Duration::from_millis(905)..Duration::from_millis(956);
     assert!(
         expected.contains(&latency),
         "latency {latency:?} is not the sum of both extras ({expected:?})"

--- a/moonpool-sim/tests/network/partition_strategy.rs
+++ b/moonpool-sim/tests/network/partition_strategy.rs
@@ -1,0 +1,276 @@
+//! Automatic partition rotation: strategy selection, including the
+//! locality-shaped and one-way arms.
+//!
+//! Each test forces the rotation on (`partition_probability = 1.0`) with a
+//! degenerate partition duration, so `sample_duration` consumes no RNG draw and
+//! the only randomness left is the strategy's own selection.
+
+use moonpool_sim::{
+    LocalityInfo, NetworkProvider, SimFaultEvent, SimWorld, TcpListenerTrait,
+    network::{NetworkConfiguration, PartitionStrategy},
+};
+use std::{collections::BTreeMap, net::IpAddr, time::Duration};
+
+/// Fixed seed for every rotation test in this file.
+const SEED: u64 = 42;
+
+/// How many `step()` calls to give the rotation before declaring it silent.
+const MAX_STEPS: usize = 20;
+
+fn ip(last_octet: u8) -> IpAddr {
+    format!("10.0.1.{last_octet}")
+        .parse()
+        .expect("valid test IP")
+}
+
+/// Network config with the automatic partition rotation forced on.
+fn rotation_config(strategy: PartitionStrategy) -> NetworkConfiguration {
+    let mut config = NetworkConfiguration::fast_local();
+    config.chaos.partition_probability = 1.0;
+    // Degenerate range: `sample_duration` returns `start` without an RNG draw,
+    // and 30s outlives the microsecond-scale `fast_local` timings.
+    config.chaos.partition_duration = Duration::from_secs(30)..Duration::from_secs(30);
+    config.chaos.partition_strategy = strategy;
+    config
+}
+
+/// Locality map for four processes laid out as `(datacenter, zone)` pairs,
+/// assigned to `10.0.1.1` ..= `10.0.1.4`.
+fn localities(layout: [(&str, &str); 4]) -> BTreeMap<IpAddr, LocalityInfo> {
+    layout
+        .iter()
+        .enumerate()
+        .map(|(index, (datacenter, zone))| {
+            let last_octet = u8::try_from(index + 1).expect("four processes");
+            let machine = format!("{zone}-m{last_octet}");
+            (
+                ip(last_octet),
+                LocalityInfo::new(*datacenter, *zone, machine),
+            )
+        })
+        .collect()
+}
+
+/// Build a simulation with two established connections, so the engine sees the
+/// four IPs `10.0.1.1` ..= `10.0.1.4`, then step until the rotation fires.
+///
+/// Returns the simulation (for partition-state assertions) and the fault events
+/// recorded by the triggering step.
+fn run_rotation(
+    strategy: PartitionStrategy,
+    locality_map: BTreeMap<IpAddr, LocalityInfo>,
+) -> (SimWorld, Vec<SimFaultEvent>) {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .enable_time()
+        .build()
+        .expect("failed to build test runtime");
+
+    let mut sim = SimWorld::new_with_network_config_and_seed(rotation_config(strategy), SEED);
+    sim.set_localities(locality_map);
+
+    let faults = runtime.block_on(async {
+        let first = sim.network_provider(ip(1));
+        let listener_two = first.bind("10.0.1.2:8080").await.expect("bind .2");
+        let _client_one = first
+            .connect("10.0.1.2:8080")
+            .await
+            .expect("connect .1->.2");
+        let (_server_two, _) = listener_two.accept().await.expect("accept on .2");
+
+        let third = sim.network_provider(ip(3));
+        let listener_four = third.bind("10.0.1.4:8080").await.expect("bind .4");
+        let _client_three = third
+            .connect("10.0.1.4:8080")
+            .await
+            .expect("connect .3->.4");
+        let (_server_four, _) = listener_four.accept().await.expect("accept on .4");
+
+        // Connections must stay alive while the rotation runs, otherwise the
+        // engine has no IPs left to choose from.
+        step_until_fault(&mut sim)
+    });
+
+    (sim, faults)
+}
+
+/// Step until the rotation records fault events, returning that step's faults
+/// (empty if the rotation stayed silent for `MAX_STEPS`).
+fn step_until_fault(sim: &mut SimWorld) -> Vec<SimFaultEvent> {
+    for _ in 0..MAX_STEPS {
+        sim.step();
+        let faults: Vec<SimFaultEvent> = sim
+            .take_faults()
+            .into_iter()
+            .map(|record| record.event)
+            .collect();
+        if !faults.is_empty() {
+            return faults;
+        }
+    }
+    Vec::new()
+}
+
+/// Assert that `a` and `b` cannot reach each other in either direction.
+fn assert_cut(sim: &SimWorld, a: IpAddr, b: IpAddr) {
+    assert!(
+        sim.is_partitioned(a, b).expect("live simulation"),
+        "expected {a} -> {b} to be partitioned"
+    );
+    assert!(
+        sim.is_partitioned(b, a).expect("live simulation"),
+        "expected {b} -> {a} to be partitioned"
+    );
+}
+
+/// Assert that `a` and `b` still reach each other in both directions.
+fn assert_intact(sim: &SimWorld, a: IpAddr, b: IpAddr) {
+    assert!(
+        !sim.is_partitioned(a, b).expect("live simulation"),
+        "expected {a} -> {b} to stay reachable"
+    );
+    assert!(
+        !sim.is_partitioned(b, a).expect("live simulation"),
+        "expected {b} -> {a} to stay reachable"
+    );
+}
+
+/// `IsolateZone` cuts the zone boundary and nothing else: both zones live in the
+/// same datacenter, so only a zone-aware strategy produces this cut.
+#[test]
+fn isolate_zone_cuts_exactly_the_zone_boundary() {
+    let layout = [
+        ("dc1", "dc1-z1"),
+        ("dc1", "dc1-z1"),
+        ("dc1", "dc1-z2"),
+        ("dc1", "dc1-z2"),
+    ];
+    let (sim, faults) = run_rotation(PartitionStrategy::IsolateZone, localities(layout));
+
+    assert!(!faults.is_empty(), "rotation should have cut the zone");
+    assert!(
+        faults
+            .iter()
+            .all(|event| matches!(event, SimFaultEvent::PartitionCreated { .. })),
+        "zone isolation should only record bidirectional partitions, got {faults:?}"
+    );
+
+    // Every cross-zone pair is cut in both directions.
+    for &near in &[ip(1), ip(2)] {
+        for &far in &[ip(3), ip(4)] {
+            assert_cut(&sim, near, far);
+        }
+    }
+    // Collocated processes keep talking.
+    assert_intact(&sim, ip(1), ip(2));
+    assert_intact(&sim, ip(3), ip(4));
+}
+
+/// `IsolateDatacenter` cuts one datacenter off while leaving its internal zone
+/// boundaries intact, the difference from `IsolateZone` on the same topology.
+#[test]
+fn isolate_datacenter_keeps_sibling_zones_connected() {
+    let layout = [
+        ("dc1", "dc1-z1"),
+        ("dc1", "dc1-z2"),
+        ("dc2", "dc2-z1"),
+        ("dc2", "dc2-z2"),
+    ];
+    let (sim, faults) = run_rotation(PartitionStrategy::IsolateDatacenter, localities(layout));
+
+    assert!(
+        !faults.is_empty(),
+        "rotation should have cut the datacenter"
+    );
+
+    for &near in &[ip(1), ip(2)] {
+        for &far in &[ip(3), ip(4)] {
+            assert_cut(&sim, near, far);
+        }
+    }
+    // Different zones, same datacenter: untouched by a datacenter-level cut.
+    assert_intact(&sim, ip(1), ip(2));
+    assert_intact(&sim, ip(3), ip(4));
+}
+
+/// `AsymmetricSend` silences one node's outgoing traffic while it keeps
+/// receiving: the one-way failure that fools naive failure detectors.
+#[test]
+fn asymmetric_send_blocks_only_the_outgoing_direction() {
+    let (sim, faults) = run_rotation(PartitionStrategy::AsymmetricSend, BTreeMap::new());
+
+    let blocked = match faults.as_slice() {
+        [SimFaultEvent::SendPartitionCreated { ip }] => {
+            ip.parse::<IpAddr>().expect("fault carries a valid IP")
+        }
+        other => panic!("expected exactly one send partition fault, got {other:?}"),
+    };
+
+    for other in [ip(1), ip(2), ip(3), ip(4)] {
+        if other == blocked {
+            continue;
+        }
+        assert!(
+            sim.is_partitioned(blocked, other).expect("live simulation"),
+            "sends from {blocked} to {other} should be blocked"
+        );
+        assert!(
+            !sim.is_partitioned(other, blocked).expect("live simulation"),
+            "{other} should still reach {blocked}"
+        );
+    }
+}
+
+/// `AsymmetricRecv` is the mirror image: the node keeps sending, but hears
+/// nothing back.
+#[test]
+fn asymmetric_recv_blocks_only_the_incoming_direction() {
+    let (sim, faults) = run_rotation(PartitionStrategy::AsymmetricRecv, BTreeMap::new());
+
+    let blocked = match faults.as_slice() {
+        [SimFaultEvent::RecvPartitionCreated { ip }] => {
+            ip.parse::<IpAddr>().expect("fault carries a valid IP")
+        }
+        other => panic!("expected exactly one recv partition fault, got {other:?}"),
+    };
+
+    for other in [ip(1), ip(2), ip(3), ip(4)] {
+        if other == blocked {
+            continue;
+        }
+        assert!(
+            sim.is_partitioned(other, blocked).expect("live simulation"),
+            "traffic from {other} to {blocked} should be blocked"
+        );
+        assert!(
+            !sim.is_partitioned(blocked, other).expect("live simulation"),
+            "{blocked} should still reach {other}"
+        );
+    }
+}
+
+/// Without a topology the locality-shaped arms must not panic: they degrade to
+/// the flat `Random` selection, producing the exact same cut for the same seed.
+#[test]
+fn locality_strategies_degrade_to_random_without_topology() {
+    let (_, random_faults) = run_rotation(PartitionStrategy::Random, BTreeMap::new());
+    let (_, zone_faults) = run_rotation(PartitionStrategy::IsolateZone, BTreeMap::new());
+    let (_, datacenter_faults) =
+        run_rotation(PartitionStrategy::IsolateDatacenter, BTreeMap::new());
+
+    assert!(
+        !random_faults.is_empty(),
+        "the reference `Random` rotation should have cut something"
+    );
+    let fingerprint = |faults: &[SimFaultEvent]| format!("{faults:?}");
+    assert_eq!(
+        fingerprint(&random_faults),
+        fingerprint(&zone_faults),
+        "IsolateZone without locality must behave like Random"
+    );
+    assert_eq!(
+        fingerprint(&random_faults),
+        fingerprint(&datacenter_faults),
+        "IsolateDatacenter without locality must behave like Random"
+    );
+}

--- a/moonpool-sim/tests/topology.rs
+++ b/moonpool-sim/tests/topology.rs
@@ -235,6 +235,44 @@ fn per_machine_attrition_respects_group_budget() {
 }
 
 // ============================================================================
+// Test: datacenter-scoped attrition blacks out a whole region and recovers.
+// ============================================================================
+
+#[test]
+fn per_datacenter_attrition_reboots_a_whole_region() {
+    let report = SimulationBuilder::new()
+        // 2 dc × 1 zone × 2 machines × 1 proc = 4 processes, 2 per datacenter.
+        .cluster(LocalityConfig::new(2, 1, 2, 1), || {
+            Box::new(LocalityProcess {
+                expected_collocated: 0,
+            })
+        })
+        .workload(TimedWorkload(Duration::from_secs(25)))
+        .enable_chaos([Chaos::Attrition {
+            config: Attrition {
+                // Exactly one datacenter's worth of processes may be dead.
+                max_dead: 2,
+                prob_graceful: 0.3,
+                prob_crash: 0.5,
+                prob_wipe: 0.2,
+                recovery_delay_ms: None,
+                grace_period_ms: None,
+                scope: AttritionScope::PerDatacenter,
+            },
+            mode: ChaosMode::Random,
+        }])
+        .chaos_duration(Duration::from_secs(10))
+        .set_iterations(5)
+        .set_debug_seeds(vec![1, 2, 3, 4, 5])
+        .run();
+
+    assert_eq!(
+        report.failed_runs, 0,
+        "datacenter-scoped attrition should not deadlock or fail"
+    );
+}
+
+// ============================================================================
 // Test: per-seed range topology (randomized cluster shape) runs clean.
 // ============================================================================
 


### PR DESCRIPTION
## What

Make the network chaos layer topology-aware. The engine gains a read-only `ip -> LocalityInfo` map (`SimWorld::set_localities`, installed automatically from the `.cluster()` topology), four new partition strategy arms (`IsolateZone`, `IsolateDatacenter`, `AsymmetricSend`, `AsymmetricRecv`), distance-based link latency (`LinkLatencyConfig` on `NetworkConfiguration`, with a `.link_latency()` builder hook), and `AttritionScope::PerDatacenter`.

## Why

The locality system from #121 only drove correlated reboots; partitions and latency were locality-blind and the automatic rotation only ever produced bidirectional cuts. This closes both gaps while keeping FDB's layering: the mechanism layer stays IP-keyed, only the decision layer consults locality.

Closes #156

## Notes

Seed-to-behavior mapping shifts for existing seeds, twice: `random_for_seed` now draws strategies from 0..7 instead of 0..3, and the candidate IP list in the partition rotation is now sorted before selection. The second change fixes a real nondeterminism bug: the list came from a `HashSet`, so `IsolateSingle`/`UniformSize` picks were not reproducible across processes. Sim binaries were smoke-run (`topology`, `transport`, `axum-web`) on top of the regular suite.

Distance latency and the chaos `max_pair_latency` share the per-pair memoized budget and are summed at first contact; the chaos draw stays first so runs without a `LinkLatencyConfig` keep their historical RNG sequence. Locality-shaped arms degrade to `Random` selection without a topology, so they are safe for every seed.

`LocalityInfo`/`DomainLevel` moved from `runner::locality` to a top-level `locality` module so the engine never imports from the runner; crate-root re-exports are unchanged, and `LinkLatencyConfig`, `LinkClass`, and `PartitionStrategy` are now re-exported at the root as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CR3ZGUAsfNdLgY3uJS7hby
