### PR TITLE
build: support the fork-based explorer on macOS in CI and the flake

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -79,6 +79,23 @@ jobs:
             exit 1
           fi
 
+  # The fork-based explorer must keep working on macOS, not just Linux: same
+  # POSIX surface (fork/waitpid/mmap MAP_SHARED), but darwin is the platform
+  # where fork-without-exec and Mach-O sancov sections would regress silently.
+  # Runs the explorer + sim unit tests and one real fork-based exploration
+  # binary (adaptive-explore instruments moonpool_explorer itself, so it also
+  # covers the sancov wrapper pipeline on darwin).
+  macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - name: Run explorer and sim tests
+        run: nix develop --command cargo nextest run -p moonpool-explorer -p moonpool-sim
+      - name: Run fork-based exploration simulation
+        run: nix develop --command cargo xtask sim run adaptive-explore
+
   sim:
     runs-on: ubuntu-latest
     strategy:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ moonpool                          Facade crate (features: sim / tokio / transpor
 ```
 
 The simulation runtime compiles to `wasm32-unknown-unknown` (build `moonpool-sim`
-with `--no-default-features`); only the fork-based explorer is Linux-first.
+with `--no-default-features`); the fork-based explorer runs on Linux and macOS.
 
 ## Which Crate to Use
 

--- a/book/src/part4-integration/05-production.md
+++ b/book/src/part4-integration/05-production.md
@@ -95,20 +95,22 @@ testable.
 ## Where it runs
 
 The provider contract and the production backend compile broadly. The sim
-runtime is portable too, with one boundary: the fork-based explorer is POSIX and
-Linux-first.
+runtime is portable too, with one boundary: the fork-based explorer needs a
+POSIX process model.
 
 | Target | core + tokio | transport | sim runtime | explorer (fork) |
 |--------|:---:|:---:|:---:|:---:|
 | Linux | yes | yes | yes | yes |
-| macOS | yes | yes | yes | best-effort |
+| macOS | yes | yes | yes | yes |
 | `wasm32-unknown-unknown` | task/time only | no (no sockets) | yes, `--no-default-features` | no |
 
 The simulation engine compiles to `wasm32-unknown-unknown` because it derives
 everything from a seeded RNG, a logical clock, and a cooperative scheduler — no
-operating system required. The explorer cannot follow it there, and on macOS its
-`fork`-without-`exec` model is fragile, so treat exploration as a Linux
-amplifier. Everywhere else the full simulator runs via the in-process assertion
-table; you lose multiverse forking, not correctness checking. If a build refuses
-to include the explorer, the fallback is one line:
+operating system required. The explorer cannot follow it there: it is built on
+`fork()`, `waitpid()`, and `MAP_SHARED` memory, which both Linux and macOS
+provide (the explorer stays single-threaded and never touches Apple frameworks,
+so darwin's usual fork-without-exec hazards don't apply — CI runs the fork-based
+exploration suite on macOS). On wasm the full simulator runs via the in-process
+assertion table; you lose multiverse forking, not correctness checking. If a
+build refuses to include the explorer, the fallback is one line:
 `moonpool-sim = { default-features = false }`.

--- a/flake.nix
+++ b/flake.nix
@@ -36,9 +36,6 @@
           buildInputs = with pkgs; [
             # Rust toolchain from oxalica
             rust-toolchain
-            
-            # Build tools
-            gcc
 
             # gRPC example: tonic-prost-build shells out to protoc
             protobuf
@@ -47,18 +44,25 @@
             pkg-config
             openssl
             cargo-nextest
-	    cargo-edit
+            cargo-edit
 
-	    # wasm demo: generate JS/TS bindings for the cdylib. Its version (from
-	    # nixpkgs) MUST match the `wasm-bindgen` crate pin in
-	    # moonpool-wasm-demo/Cargo.toml exactly — a mismatch breaks the bindgen
-	    # step with an opaque "schema version" error. When `nix flake update`
-	    # moves this, re-pin the crate to `wasm-bindgen --version`.
-	    wasm-bindgen-cli
+            # wasm demo: generate JS/TS bindings for the cdylib. Its version (from
+            # nixpkgs) MUST match the `wasm-bindgen` crate pin in
+            # moonpool-wasm-demo/Cargo.toml exactly — a mismatch breaks the bindgen
+            # step with an opaque "schema version" error. When `nix flake update`
+            # moves this, re-pin the crate to `wasm-bindgen --version`.
+            wasm-bindgen-cli
 
-	    # mdbook
-	    mdbook
+            # mdbook
+            mdbook
             mdbook-toc
+          ] ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
+            # C toolchain for linking. Linux-only: darwin's stdenv already
+            # provides clang, and GNU gcc is a heavy, fragile build there.
+            gcc
+          ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
+            # Crate build scripts link against iconv on darwin.
+            libiconv
           ];
 
           shellHook = ''

--- a/moonpool-assertions/src/hooks.rs
+++ b/moonpool-assertions/src/hooks.rs
@@ -3,7 +3,7 @@
 //! The accounting layer ([`crate::slots`], [`crate::buckets`]) calls these hooks
 //! at the exact points where something "new" happens — a first Sometimes/Reachable
 //! pass, a numeric watermark improvement, a frontier advance, or an each-bucket
-//! hit. With no hook installed (the default — wasm, macOS, plain native runs) the
+//! hit. With no hook installed (the default — wasm, plain native runs) the
 //! calls are no-ops and accounting is pure. An exploration backend
 //! (`moonpool-explorer`) installs hooks that mark coverage and dispatch forks.
 //!

--- a/moonpool-assertions/src/lib.rs
+++ b/moonpool-assertions/src/lib.rs
@@ -9,7 +9,7 @@
 //! # How it relates to exploration
 //!
 //! The counts live in a region of memory. By default [`init`] allocates that
-//! region on the heap (single process — wasm, macOS, plain native test runs).
+//! region on the heap (single process — wasm, plain native test runs).
 //! `moonpool-explorer` instead allocates a `MAP_SHARED` region and hands it to
 //! [`install_region`], so the same accounting is visible across `fork`ed
 //! children, and installs a [`DiscoveryHooks`] that turns "a new assertion state


### PR DESCRIPTION
## What

Makes the fork-based explorer a supported platform on macOS, and makes the flake and CI darwin-aware.

The explorer's code was already POSIX-portable — everything it uses (`fork()`, `waitpid()`, `mmap(MAP_SHARED | MAP_ANONYMOUS)`, `sysconf`, `_exit`, the sancov LLVM callbacks) is gated on `cfg(unix)`, and both `aarch64-apple-darwin` and `x86_64-apple-darwin` type-check clean for `moonpool-explorer` and `moonpool-sim`. darwin's fork-without-exec hazards don't apply either: the explorer stays single-threaded and never touches Apple frameworks. What was Linux-only was the tooling around it:

- **flake.nix**: `gcc` is now Linux-only (darwin's stdenv already ships clang; GNU gcc is a heavy, fragile build there) and darwin gets `libiconv`, so `nix develop` works on `aarch64-darwin` / `x86_64-darwin`. Verified by fully instantiating the devShell derivation for all four systems. Also normalizes the mixed tab/space indentation in that block.
- **CI**: new `macos` job on `macos-latest` runs `cargo nextest run -p moonpool-explorer -p moonpool-sim` plus `cargo xtask sim run adaptive-explore` — the latter instruments `moonpool_explorer` itself, so it exercises the real fork/waitpid/shared-memory loop *and* the sancov pipeline (Mach-O sections, module ctors) on darwin.
- **Docs**: the book's portability table promotes macOS explorer support from "best-effort" to "yes" with the reasoning, README drops "Linux-first", and the `moonpool-assertions` doc comments no longer list macOS among platforms that never install exploration hooks.

## Validation

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo nextest run` (667 passed)
- Portability gates: `cargo clippy -p moonpool-sim --no-default-features --all-targets -- -D warnings`, `cargo check --target wasm32-unknown-unknown -p moonpool-sim --no-default-features`
- `cargo check --target aarch64-apple-darwin` / `x86_64-apple-darwin` for `moonpool-explorer` + `moonpool-sim`
- `cargo xtask sim run adaptive-explore` with the sancov wrapper (passes, ~2s)
- `mdbook build book/`
- devShell derivation instantiated for `aarch64-darwin`, `x86_64-darwin`, `aarch64-linux`, `x86_64-linux`

The first run of the new `macos` job on this PR is the real end-to-end proof on darwin hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012LXnstr9KmRsKEBs6mD8Se

---
_Generated by [Claude Code](https://claude.ai/code/session_012LXnstr9KmRsKEBs6mD8Se)_