### PR TITLE
fix(explorer): enforce reproducible exploration lifecycles

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -90,6 +90,7 @@
   - [Bounded Workers](./part5-building-on-top/04-bounded-workers.md)
   - [Exemplars and Continuations](./part5-building-on-top/05-exemplars-continuations.md)
   - [Multi-Seed Exploration](./part5-building-on-top/06-multi-seed.md)
+  - [Exploring a Consensus Protocol](./part5-building-on-top/07-exploring-consensus.md)
 
 ---
 

--- a/book/src/appendix/01-assertion-reference.md
+++ b/book/src/appendix/01-assertion-reference.md
@@ -124,20 +124,20 @@ assert_sometimes_less_than!(
 );
 ```
 
-**Watermark tracking**: For `sometimes` numeric assertions, the explorer tracks the best value observed so far. When a new evaluation **improves** the watermark (higher for `gt`/`ge`, lower for `lt`/`le`), a fork is triggered to explore timelines that might push the metric even further.
+**Watermark tracking**: For `sometimes` numeric assertions, the explorer tracks the best value observed so far. When a new evaluation **improves** the watermark (higher for `gt`/`ge`, lower for `lt`/`le`), it creates a replay anchor for timelines that might push the metric even further.
 
 ## Compound Assertions
 
 These macros track multi-dimensional properties across multiple conditions or identity keys.
 
-| Macro | Category | Description | Panics? | Forks in exploration? |
+| Macro | Category | Description | Panics? | Guides exploration? |
 |-------|----------|-------------|---------|----------------------|
 | `assert_sometimes_all!` | BooleanSometimesAll | All named booleans should sometimes be true simultaneously | No | Yes, on frontier advance |
 | `assert_sometimes_each!` | EachBucket | Per-identity bucketed assertion with optional quality watermarks | No | Yes, on new bucket or quality improvement |
 
 ### `assert_sometimes_all!(message, [(name, bool), ...])`
 
-Tracks a **frontier**: the maximum number of conditions that have been simultaneously true. When the frontier advances (more conditions true at once than ever before), a fork is triggered.
+Tracks a **frontier**: the maximum number of conditions that have been simultaneously true. When the frontier advances (more conditions true at once than ever before), a replay anchor is created.
 
 ```rust
 assert_sometimes_all!("all_nodes_healthy", [
@@ -147,17 +147,17 @@ assert_sometimes_all!("all_nodes_healthy", [
 ]);
 ```
 
-If previously at most 2 of the 3 conditions were true at once, and now all 3 are true, the frontier advances from 2 to 3 and a fork is triggered.
+If previously at most 2 of the 3 conditions were true at once, and now all 3 are true, the frontier advances from 2 to 3 and a replay anchor is created.
 
 ### `assert_sometimes_each!(message, [(key, value), ...])` / `assert_sometimes_each!(message, [(key, value), ...], [(quality_key, quality_value), ...])`
 
 Each unique combination of identity keys gets its own **bucket**. A new bucket is a discovery. If quality keys are provided, the explorer also tracks quality watermarks per bucket, and a quality improvement is a fresh discovery (registering a healthier exemplar for the same state).
 
 ```rust
-// Identity keys only -- fork on first discovery of each (lock, depth) combo
+// Identity keys only -- guide on first discovery of each (lock, depth) combo
 assert_sometimes_each!("gate", [("lock", lock_id), ("depth", depth)]);
 
-// With quality watermarks -- also fork when health improves for a known bucket
+// With quality watermarks -- also guide when health improves for a known bucket
 assert_sometimes_each!("descended", [("to_floor", floor)], [("health", hp)]);
 ```
 

--- a/book/src/part2-foundations/11-executor.md
+++ b/book/src/part2-foundations/11-executor.md
@@ -138,12 +138,14 @@ drops `Runnable`s until the queue is empty. Dropping a `Runnable` cancels
 the task and drops its future, and any tasks that drop wakes land in the
 same queue and are consumed by the same loop.
 
-## Fork safety
+## Exploration process safety
 
-The multiverse explorer forks the process *while tasks are being polled*
-(assertion macros are fork points). Two rules keep that sound: everything is
-single-threaded, and the ready-queue lock is never held across a task poll,
-so a forked child never inherits a held lock.
+The explorer only forks between complete timelines, after the deterministic
+executor and all of its tasks have been dropped. Assertion macros record
+discovery coordinates; they are not fork points. Forked workers are still an
+explicit performance mode because unrelated host threads and resources may
+exist outside the simulation. The default `workers: 0` mode runs continuations
+sequentially in-process and is the conservative choice for deterministic CI.
 
 ## Verifying it yourself
 

--- a/book/src/part3-building/12-assertions.md
+++ b/book/src/part3-building/12-assertions.md
@@ -22,7 +22,7 @@ Assertions in moonpool serve two purposes that reinforce each other.
 
 **First, they verify correctness.** An `assert_always!` is a property that must hold every time it is checked. If it fails even once across thousands of iterations, there is a bug. The system tracks pass and fail counts, giving you a precise success rate rather than a binary pass/fail.
 
-**Second, they guide exploration.** When you enable multiverse mode (covered in Part VI), certain assertions become active signals to the explorer. An `assert_sometimes!` that fires true for the first time tells the explorer "this is interesting, branch from here." The explorer snapshots that moment and spawns new timelines from it. This is what turns a random walk through state space into a directed search.
+**Second, they guide exploration.** When you enable multiverse mode (covered in Part VI), certain assertions become active signals to the explorer. An `assert_sometimes!` that fires true for the first time tells the explorer "this is interesting, continue from here." The explorer records a replay recipe to that RNG coordinate, then runs new timelines that reproduce the prefix and diverge afterward. This is what turns a random walk through state space into a directed search.
 
 The same assertion does both jobs. You write it once, thinking about correctness. The exploration framework uses it automatically to find more bugs.
 

--- a/book/src/part3-building/13-assertion-concepts.md
+++ b/book/src/part3-building/13-assertion-concepts.md
@@ -33,9 +33,9 @@ assert_reachable!("recovery path exercised");
 
 Where invariants validate, discovery assertions prove coverage. They answer questions like: Did our simulation actually trigger a failover? Did a leader election happen? Did the retry path execute? Without discovery assertions, a simulation could run thousands of iterations exercising only the happy path and report zero failures. Everything looks green, but nothing interesting was tested.
 
-Discovery assertions become **exploration amplifiers** in multiverse mode. When `assert_sometimes!` fires true for the first time, the explorer snapshots the simulation state and branches from that point. Why? Because reaching that state was hard, and there are likely more interesting states reachable from it.
+Discovery assertions become **exploration amplifiers** in multiverse mode. When `assert_sometimes!` fires true for the first time, the explorer records the seed and RNG position that reached it. Follow-up timelines replay that prefix and diverge just afterward. Reaching the state was hard, and there are likely more interesting states reachable from it.
 
-Consider a bug that requires a failover (probability 1/1000) followed by a specific timing condition during recovery (probability 1/1000). Without exploration amplification, finding this bug requires roughly 1,000,000 random iterations. With a sometimes-assertion on the failover that triggers branching, the explorer takes a shortcut: find the failover once in ~1000 iterations, snapshot it, then find the timing condition in ~1000 more iterations from that checkpoint. The effective probability drops from multiplicative to additive.
+Consider a bug that requires a failover (probability 1/1000) followed by a specific timing condition during recovery (probability 1/1000). Without exploration amplification, finding this bug requires roughly 1,000,000 random iterations. With a sometimes-assertion on the failover, the explorer takes a shortcut: find the failover once in ~1000 iterations, retain its replay prefix, then try roughly 1000 continuations from that prefix. The effective probability drops from multiplicative to additive.
 
 This is why discovery assertions have "superpowers" in moonpool. They are not just coverage markers. They are active participants in the search for bugs.
 

--- a/book/src/part3-building/14-always-sometimes.md
+++ b/book/src/part3-building/14-always-sometimes.md
@@ -47,7 +47,7 @@ assert_sometimes!(
 
 If the condition is never true after all iterations complete, the post-run validation reports a coverage violation. But unlike always-violations, coverage violations are statistical. They become meaningful only after enough iterations.
 
-The real power of `assert_sometimes!` shows up in multiverse mode. When the condition fires true for the first time in a timeline, the explorer snapshots that moment and branches. New timelines start from that interesting state. This is what transforms sometimes-assertions from passive coverage checks into active exploration amplifiers.
+The real power of `assert_sometimes!` shows up in multiverse mode. When the condition fires true for the first time, the explorer records a replay anchor. New timelines reconstruct that prefix and diverge after the interesting state. This transforms sometimes-assertions from passive coverage checks into active exploration amplifiers.
 
 Think of it this way: `assert_sometimes!` is how you tell the explorer "this state is worth investigating." The explorer does the rest.
 

--- a/book/src/part5-building-on-top/01-exploration.md
+++ b/book/src/part5-building-on-top/01-exploration.md
@@ -44,7 +44,7 @@ Follow those instructions and you arrive at the exact same timeline, determinist
 
 2. **The Frontier Controller** describes the exploration loop: recipes, discovery journals, the one-expansion rule, and how barren branches die without any budget accounting.
 
-3. **Bounded Workers** covers the physical execution model: `fork()` as a snapshot optimization rather than a tree structure, single-owner novelty, crash isolation, and macOS portability.
+3. **Bounded Workers** covers the physical execution model: `fork()` as a bounded job-execution optimization rather than a tree structure, single-owner novelty, crash isolation, and macOS portability.
 
 4. **Exemplars and Continuations** shows how the controller remembers semantic states, retains multiple exemplars per state, and schedules continuations from the under-explored frontier — the machinery that carries the dungeon workload to floor 8.
 

--- a/book/src/part5-building-on-top/02-exploration-problem.md
+++ b/book/src/part5-building-on-top/02-exploration-problem.md
@@ -12,7 +12,7 @@ With independent random seeds, the probability of both events occurring is rough
 
 This is the **Sequential Luck Problem**: a bug requiring N unlikely events in sequence has probability that decreases **multiplicatively**. Two events at 1/1000 each need ~10^6 trials. Three events need ~10^9. The search space grows exponentially with the depth of the required sequence.
 
-Now consider what happens with checkpoint-and-branch. We run seeds until one of them triggers the failover (about 1000 runs). At that moment, we snapshot the simulation and spawn new timelines from the failover point with different randomness. Each of those new timelines has a 1/1000 chance of hitting the rollback window. We need about 1000 branch timelines, plus the ~1000 root seeds to reach the failover. Total: roughly 2000 timelines instead of 1,000,000.
+Now consider what happens with replay-and-continue. We run seeds until one of them triggers the failover (about 1000 runs). At that moment, we retain the deterministic replay prefix and schedule new timelines that reproduce the failover, then continue with different randomness. Each continuation has a 1/1000 chance of hitting the rollback window. We need about 1000 continuations, plus the ~1000 root seeds to reach the failover. Total: roughly 2000 timelines instead of 1,000,000.
 
 The improvement is not incremental. It changes the complexity from **multiplicative** (p1 * p2) to **additive** (p1 + p2). For three-event bugs, the difference is even more dramatic: ~3000 timelines instead of ~10^9.
 

--- a/book/src/part5-building-on-top/03-frontier-controller.md
+++ b/book/src/part5-building-on-top/03-frontier-controller.md
@@ -51,19 +51,22 @@ Each child replays through *every* state the parent reached — the earlier disc
 
 ## One Expansion Per Run
 
-A run that made at least one discovery is **productive** and is expanded **exactly once**: `branching_factor` children are enqueued, anchored at its latest discovery. This holds no matter how many discoveries the run made. If one timeline discovers 300 code edges and five new assertion states, it is still *one productive execution*, not 305 branching events.
+A run that made at least one semantic assertion discovery is **productive** and is expanded **exactly once**: `branching_factor` children are enqueued, anchored at its latest discovery. This holds no matter how many discoveries the run made. If one timeline discovers five new assertion states, it is still *one productive execution*, not five branching events. Sanitizer code coverage is reported separately and does not create frontier jobs.
 
 A run with an empty journal discovered nothing the multiverse had not already seen. It is not punished, scored, or refilled — its branch simply produces no children and dies. This one rule replaces the entire energy system of the previous explorer (global budgets, per-mark allowances, reallocation pools, productive/barren classification): the only global limits are a per-seed run budget and a frontier size cap.
 
 ```rust,ignore
 ExplorationConfig {
-    workers: 4,             // max concurrent worker processes
+    workers: 0,             // deterministic in-process mode (the default)
     max_runs_per_seed: 8000, // total timelines per root seed
     branching_factor: 4,    // children per productive run
     max_frontier: 1024,     // queued-job cap
     max_recipe_len: 64,     // depth cap in replay segments
 }
 ```
+
+Set `workers` above zero only in a standalone simulation binary when bounded
+parallel `fork()` workers are worth the less reproducible search order.
 
 ## Who Decides Novelty
 

--- a/book/src/part5-building-on-top/07-exploring-consensus.md
+++ b/book/src/part5-building-on-top/07-exploring-consensus.md
@@ -1,0 +1,181 @@
+# Exploring a Consensus Protocol
+
+<!-- toc -->
+
+The explorer is most useful for Paxos, Raft, and replicated logs when it is
+given two different kinds of signal: strict safety invariants that catch bugs,
+and semantic progress assertions that tell the frontier which prefixes are
+worth continuing. Code coverage alone reports that a branch ran; it does not
+provide the RNG-coordinate anchor used to build a recipe.
+
+## Start Conservatively
+
+Use fork-free exploration while validating a new integration:
+
+```rust,ignore
+use moonpool_sim::{ExplorationConfig, SimulationBuilder, WorkloadCount};
+
+let report = SimulationBuilder::new()
+    .processes(3, || Box::new(PaxosNode::new()))
+    .workloads(WorkloadCount::Fixed(1), |_| {
+        Box::new(PaxosWorkload::new())
+    })
+    .invariant(AgreementInvariant::default())
+    .enable_exploration(ExplorationConfig {
+        workers: 0,
+        max_runs_per_seed: 2_000,
+        branching_factor: 4,
+        max_frontier: 512,
+        max_recipe_len: 32,
+    })
+    .until_coverage_stable(10, 1_000)
+    .run();
+```
+
+`workers: 0` makes controller order deterministic and avoids `fork()` while
+the test-driver lifecycle is being audited. Increase the worker count only in
+a standalone simulation binary on Linux or macOS, after confirming the host
+process has no unrelated threads or external resources that a child could
+inherit.
+
+Use `.workload_factory(...)` or `.workloads(...)` for the client driver.
+Exploration rejects a single `.workload(instance)`, `before_iteration` hooks,
+and custom fault-injector instances because those opaque values cannot be
+reconstructed for every continuation. Built-in `Chaos` surfaces are supported.
+Keep authoritative test state inside fresh processes and factory-created
+workloads; do not depend on external clocks, randomness, threads, files, or
+sockets outside Moonpool providers.
+
+## Put Safety in Invariants
+
+Emit stable, structured facts from the Paxos implementation:
+
+```rust,ignore
+tracing::info!(
+    target: "paxos",
+    slot,
+    ballot,
+    value = %value_hash,
+    "value_chosen"
+);
+```
+
+Then check cross-node and cross-time properties with cursor-based invariants.
+For Paxos, the minimum useful set is:
+
+- **Agreement:** two chosen events for the same slot never name different
+  values.
+- **Validity:** every chosen value was proposed by a client.
+- **Acceptor persistence:** after a promise or acceptance survives `sync_all`,
+  a reboot never reveals an older ballot or a conflicting accepted value.
+- **Prefix consistency:** for Multi-Paxos, committed logs on any two nodes agree
+  throughout their common prefix.
+- **Client semantics:** retries do not create two successful outcomes for one
+  non-idempotent command.
+
+The agreement example in [Events and Invariants](../part3-building/17-events-and-invariants.md)
+shows the full `TraceQuery::since` pattern. Run these checks after every
+simulation step; do not wait until the workload finishes, because a later
+state can hide a transient safety violation.
+
+## Add Semantic Replay Anchors
+
+Use discovery assertions for qualitatively different protocol states:
+
+```rust,ignore
+assert_sometimes!(leader_changed, "paxos leader changed");
+assert_sometimes!(promise_rejected, "stale ballot was rejected");
+assert_sometimes!(recovered_acceptor, "acceptor recovered persisted state");
+
+assert_sometimes_all!("failover made progress", [
+    ("old leader unavailable", old_leader_unavailable),
+    ("new quorum formed", new_quorum_formed),
+    ("client completed", client_completed),
+]);
+```
+
+Use watermarks for monotonic depth. They let later runs improve a frontier
+instead of consuming one static discovery:
+
+```rust,ignore
+assert_sometimes_greater_than!(decided_slots, 32, "many slots decided");
+assert_sometimes_greater_than!(ballot_changes, 4, "repeated ballot changes");
+assert_sometimes_greater_than!(retry_depth, 3, "deep client retry chain");
+```
+
+Use `assert_sometimes_each!` for a small, bounded state vocabulary:
+
+```rust,ignore
+assert_sometimes_each!(
+    "paxos transition",
+    [("phase", phase_code), ("fault regime", fault_regime_code)],
+    [("decided slots", decided_slots)]
+);
+```
+
+Keep identity keys coarse. The shared table holds 128 assertion sites and 256
+`sometimes_each` buckets. Bucketing every node, ballot, slot, and value tuple
+will exhaust it quickly and teaches the controller identifiers rather than
+protocol structure. Good identity dimensions are phase, role, quorum state,
+recovery mode, and fault regime; good quality values are decided-slot count,
+ballot depth, retry depth, and inverse replica lag.
+
+## Combine Exploration with Broad Seeds
+
+Exploration is semantic-guided randomized testing, not exhaustive model
+checking or a proof of Paxos safety. Recipes change the counted simulation RNG
+after an anchor, while executor and `select!` ordering remain derived from the
+root seed. Discovery latches are cumulative across seeds, so static boolean
+milestones mostly guide the first seed that reaches them.
+
+Keep broad multi-seed testing enabled. Dynamic buckets and watermarks let later
+seeds contribute new semantic progress, while `UntilCoverageStable` samples
+new root schedules until assertion and code coverage plateau.
+
+## Replay Every Failure
+
+An exploration bug marks its root seed as failed and appears in
+`report.exploration.bug_recipes`. Reproduce it with a fresh builder and fresh
+driver state:
+
+```rust,ignore
+let bug = report
+    .exploration
+    .as_ref()
+    .and_then(|exploration| exploration.bug_recipes.first())
+    .expect("exploration found a bug recipe");
+
+let replay = SimulationBuilder::new()
+    .processes(3, || Box::new(PaxosNode::new()))
+    .workloads(WorkloadCount::Fixed(1), |_| {
+        Box::new(PaxosWorkload::new())
+    })
+    .invariant(AgreementInvariant::default())
+    .replay_timeline(bug.seed, bug.recipe.clone())
+    .run();
+
+assert_eq!(replay.failed_runs, 1);
+```
+
+If replay does not reproduce, audit the integration for direct Tokio calls,
+unseeded collections or randomness, reused workload state, `before_iteration`
+state, and external I/O. A recipe is exact only when the entire test harness is
+deterministic and starts each timeline from the same logical state.
+
+## Current Operational Limits
+
+Before treating explorer results as a CI gate for a consensus system, account
+for these limits:
+
+- Forked workers have no independent wall-clock deadline; blocking code in a
+  child can stall the controller. Moonpool's simulated-time budget only helps
+  when the deterministic executor continues making events.
+- Parallel workers may discover shared assertion novelty in finish order, so
+  search order is not reproducible even though each captured recipe is.
+- A worker crash after claiming a discovery can lose that discovery's journal
+  anchor for the rest of the run.
+- Sanitizer coverage is a reporting and plateau signal, not a frontier anchor.
+
+For a correctness-critical Paxos suite today, use exploration to supplement
+the ordinary multi-seed simulation, keep `workers: 0` for deterministic CI,
+and replay every captured failure before diagnosing it.

--- a/crates/moonpool-explorer/README.md
+++ b/crates/moonpool-explorer/README.md
@@ -1,73 +1,96 @@
 # moonpool-explorer
 
-Fork-based multiverse exploration for deterministic simulation testing.
+Frontier-based exploration for deterministic simulation testing.
 
-## Why: Explore Beyond Single Seeds
+## Why: Explore Beyond Independent Seeds
 
-A single simulation seed finds bugs along one execution path. But bugs hide in rare combinations of events. Multiverse exploration forks child processes at discovery points — when an assertion fires for the first time — and explores alternate timelines with different RNG seeds.
+A single simulation seed follows one execution path. Independent seeds add
+breadth, but bugs that require a sequence of unlikely states remain difficult
+to reach. The explorer turns globally new assertion outcomes into replayable
+frontier jobs, then continues those proven prefixes with fresh deterministic
+randomness.
 
-This is inspired by [Antithesis](https://antithesis.com/)'s approach: use coverage-guided forking to systematically explore the state space.
+## How: Replay and Continue
 
-## How: Fork at Discovery
-
-When an `assert_sometimes!` succeeds for the first time, the explorer:
-
-1. **Forks** child processes with different RNG seeds
-2. Each child **continues** the simulation from the discovery point
-3. Children that discover **new coverage** (via bitmap tracking) get more exploration budget
-4. **Energy budgets** prevent runaway forking
+When an `assert_sometimes!`, `assert_reachable!`, bucket, or guidance watermark
+makes globally new progress, Moonpool records the current RNG call count. The
+controller retains a recipe for that timeline and enqueues bounded
+continuations:
 
 ```text
-Parent (seed 42)
-├── assert_sometimes!("rare event") fires at RNG count 1000
-│   ├── Child A (reseed → 1001) → explores alternate path
-│   ├── Child B (reseed → 1002) → finds new bug!
-│   └── Child C (reseed → 1003) → no new coverage, stops
-└── continues with original seed
+root seed 42
+  └─ discovers "leader changed" at RNG call 1000
+       ├─ replay to 1000, then reseed to A
+       ├─ replay to 1000, then reseed to B ── finds a bug
+       └─ replay to 1000, then reseed to C
 ```
+
+Each worker starts the simulation from the beginning, replays the recipe, and
+diverges after its last breakpoint. Forking is only a bounded process-execution
+optimization between runs; workers do not fork recursively and the explorer
+does not snapshot a live simulation.
 
 ## Architecture
 
 ```text
-moonpool-explorer (this crate)  ── leaf, only depends on libc
-     ^
-moonpool-sim                    ── wires RNG hooks at init
+controller (frontier, exemplars, statistics)
+    ├─ worker: replay one recipe, report journal, exit
+    ├─ worker: replay one recipe, report journal, exit
+    └─ worker: replay one recipe, report journal, exit
 ```
 
-This crate has zero knowledge of moonpool internals. Communication with the simulation RNG uses two function pointers set via `set_rng_hooks()`:
-- `fn() -> u64` — get current RNG call count
-- `fn(u64)` — reseed the RNG
-
-## Key Concepts
-
-- **Coverage bitmap** — 8192-bit vector tracking which code paths have been exercised
-- **Explored map** — Tracks frontier of new coverage across all timelines
-- **Assertion slots** — 128 shared-memory slots for Antithesis-style assertion tracking (boolean, numeric, compound)
-- **Energy budgets** — Three-level system (global, per-mark, realloc pool) prevents runaway forking
-- **Adaptive forking** — Batch-based: fork N children, check coverage yield, return energy from barren marks
-- **Bug recipes** — Deterministic replay paths in `"count@seed -> count@seed"` format
+The controller keeps at most `workers` children live. Set `workers` to `0` for
+fork-free, sequential exploration. The `moonpool-explorer` crate stays unaware
+of Moonpool's network, storage, and process internals; `moonpool-sim` installs
+the RNG and assertion hooks that connect them.
 
 ## Configuration
 
-```rust
-ExplorationConfig {
-    max_depth: 30,              // Maximum fork depth
-    timelines_per_split: 4,     // Timelines per split point (fixed-count mode)
-    global_energy: 50_000,      // Total fork budget
-    adaptive: Some(AdaptiveConfig {
-        batch_size: 20,          // Children per adaptive batch
-        min_timelines: 100,      // Minimum timelines per mark
-        max_timelines: 200,      // Maximum timelines per mark
-        per_mark_energy: 1000,   // Energy budget per fork point
-        warm_min_timelines: None, // Override min_timelines for warm seeds
-    }),
-    parallelism: None,          // Optional multi-core sliding window
-}
+Most users should configure exploration through
+`moonpool_sim::SimulationBuilder`:
+
+```rust,ignore
+use moonpool_sim::{ExplorationConfig, SimulationBuilder};
+
+let report = SimulationBuilder::new()
+    .enable_exploration(ExplorationConfig {
+        workers: 0, // deterministic, fork-free starting point
+        max_runs_per_seed: 8_000,
+        branching_factor: 4,
+        max_frontier: 1_024,
+        max_recipe_len: 64,
+    })
+    .until_coverage_stable(10, 1_000)
+    .workload_factory(|| Box::new(MyWorkload::new()))
+    .run();
 ```
+
+- `max_runs_per_seed` is a ceiling, not a quota. A root run that discovers
+  nothing new ends after one timeline.
+- `branching_factor` controls how many continuations a productive run creates.
+- `max_frontier` bounds queued work, and `max_recipe_len` bounds replay depth.
+- The physical process bound is one controller plus `workers` children.
+- Factory-created workloads and built-in chaos surfaces are required so every
+  continuation starts from reconstructible state.
+
+Bug recipes in `report.exploration` can be replayed with
+`SimulationBuilder::replay_timeline(seed, recipe)` when every timeline starts
+from fresh deterministic test-driver state.
+
+## Platform and Scope
+
+Worker processes require POSIX `fork` support (Linux or macOS). Non-Unix
+targets use in-process exploration. Exploration is assertion-guided randomized
+testing, not exhaustive model checking or a formal proof. Reproducibility also
+requires the system under test to use Moonpool providers rather than external
+time, randomness, threads, or I/O. Use worker processes only from a standalone
+single-threaded simulation binary; raw `fork()` is unsafe when unrelated host
+threads may hold inherited locks.
 
 ## Documentation
 
-- [API Documentation](https://docs.rs/moonpool-explorer)
+- [Moonpool book](https://pierrezemb.github.io/moonpool/)
+- [API documentation](https://docs.rs/moonpool-explorer)
 - [Repository](https://github.com/PierreZ/moonpool)
 
 ## License

--- a/crates/moonpool-explorer/src/controller.rs
+++ b/crates/moonpool-explorer/src/controller.rs
@@ -91,12 +91,47 @@ pub struct ExplorationConfig {
 impl Default for ExplorationConfig {
     fn default() -> Self {
         Self {
-            workers: 4,
+            // Raw fork is opt-in: in-process mode is deterministic and safe in
+            // test harnesses or applications that may already have threads.
+            workers: 0,
             max_runs_per_seed: 512,
             branching_factor: 4,
             max_frontier: 1024,
             max_recipe_len: 64,
         }
+    }
+}
+
+impl ExplorationConfig {
+    /// Validate that the run budget and policy bounds are nonzero.
+    /// `workers == 0` remains valid and selects deterministic, in-process
+    /// execution.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`io::ErrorKind::InvalidInput`] with the invalid field name when
+    /// a run, branching, frontier, or recipe bound is zero.
+    pub fn validate(&self) -> Result<(), io::Error> {
+        for (field, value) in [
+            ("max_runs_per_seed", self.max_runs_per_seed),
+            ("branching_factor", u64::from(self.branching_factor)),
+            (
+                "max_frontier",
+                u64::try_from(self.max_frontier).unwrap_or(u64::MAX),
+            ),
+            (
+                "max_recipe_len",
+                u64::try_from(self.max_recipe_len).unwrap_or(u64::MAX),
+            ),
+        ] {
+            if value == 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("exploration config field `{field}` must be greater than zero"),
+                ));
+            }
+        }
+        Ok(())
     }
 }
 
@@ -177,6 +212,7 @@ impl Explorer {
     ///
     /// Returns an error if shared memory allocation fails.
     pub fn new(config: ExplorationConfig) -> Result<Self, io::Error> {
+        config.validate()?;
         crate::init_assertions()?;
         journal::install_hooks();
         crate::sancov::init_sancov_shared()?;
@@ -616,10 +652,52 @@ mod tests {
     #[test]
     fn default_config_is_bounded() {
         let config = ExplorationConfig::default();
-        assert!(config.workers >= 1);
+        config.validate().expect("default config should be valid");
+        assert_eq!(config.workers, 0);
         assert!(config.max_runs_per_seed > 0);
         assert!(config.branching_factor > 0);
         assert!(config.max_frontier > 0);
         assert!(config.max_recipe_len > 0);
+    }
+
+    #[test]
+    fn zero_exploration_bounds_are_rejected() {
+        let invalid = [
+            ExplorationConfig {
+                max_runs_per_seed: 0,
+                ..ExplorationConfig::default()
+            },
+            ExplorationConfig {
+                branching_factor: 0,
+                ..ExplorationConfig::default()
+            },
+            ExplorationConfig {
+                max_frontier: 0,
+                ..ExplorationConfig::default()
+            },
+            ExplorationConfig {
+                max_recipe_len: 0,
+                ..ExplorationConfig::default()
+            },
+        ];
+
+        for config in invalid {
+            let error = config.validate().expect_err("zero bound must be rejected");
+            assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+        }
+    }
+
+    #[test]
+    fn zero_workers_is_valid() {
+        let config = ExplorationConfig {
+            workers: 0,
+            max_runs_per_seed: 1,
+            branching_factor: 1,
+            max_frontier: 1,
+            max_recipe_len: 1,
+        };
+        config
+            .validate()
+            .expect("in-process minimum should be valid");
     }
 }

--- a/crates/moonpool-explorer/src/sancov.rs
+++ b/crates/moonpool-explorer/src/sancov.rs
@@ -1,44 +1,29 @@
 //! LLVM `SanitizerCoverage` (`inline-8bit-counters`) for code edge coverage.
 //!
 //! This module hooks into LLVM's `SanitizerCoverage` instrumentation to track
-//! which code edges the simulation actually executes. The explorer uses this
-//! as a second coverage signal — alongside the assertion-path fork bitmap —
-//! to decide whether a forked timeline discovered something new. Together,
-//! the two signals make the adaptive loop significantly more precise at
-//! distinguishing productive forks from barren ones.
+//! which code edges the simulation actually executes. Moonpool uses the
+//! cumulative edge count for reporting and `UntilCoverageStable` plateau
+//! detection. Frontier expansion itself is assertion-guided because only an
+//! assertion discovery carries the RNG call-count anchor needed by a replay
+//! recipe.
 //!
 //! All public functions are no-ops when sancov instrumentation is not
 //! present (i.e., `COUNTERS_PTR` is null).
 //!
-//! # Why two coverage systems?
+//! # Coverage and exploration guidance
 //!
-//! The explorer has two independent coverage tracking mechanisms:
-//!
-//! ```text
-//! System                Where it lives         What it tracks
-//! ────────────────────  ─────────────────────  ─────────────────────────────────
-//! Fork bitmap           coverage.rs            Which assert_sometimes! /
-//!   (8192 bits)                                assert_sometimes_each! fired.
-//!                                              Hash-based, high collision rate.
-//!
-//! Sancov edge coverage  sancov.rs (this file)  Which branches/loops/conditions
-//!   (one u8 per edge)                          in the Rust source were executed.
-//!                                              LLVM-instrumented, no collisions.
-//! ```
-//!
-//! The fork bitmap answers "did we trigger a new assertion path?" while
-//! sancov answers "did we execute new code?". Two timelines can trigger
-//! the exact same assertions but take radically different code paths through
-//! the system under test — sancov catches that.
-//!
-//! Both signals feed into the adaptive loop's `batch_has_new` flag in
-//! [`split_loop`](crate::split_loop). A timeline is considered productive
-//! if it contributes new bits to **either** system:
+//! Moonpool keeps two complementary progress signals:
 //!
 //! ```text
-//! batch_has_new |= fork_bitmap.has_new_bits()    // assertion-level
-//! batch_has_new |= has_new_sancov_coverage()      // code-edge-level
+//! Signal                  What it tracks                    What consumes it
+//! ──────────────────────  ────────────────────────────────  ─────────────────────
+//! Assertion discoveries   Semantic states and watermarks    Frontier controller
+//! Sancov edge coverage    Executed branches and conditions  Reports and plateau
 //! ```
+//!
+//! A timeline can add code coverage without creating a frontier job. Add
+//! semantic `assert_sometimes!`, `assert_sometimes_each!`, or numeric guidance
+//! assertions at states from which the explorer should continue.
 //!
 //! # How LLVM inline-8bit-counters work
 //!
@@ -113,23 +98,21 @@
 //!                                                ▼ has_new_coverage_inner()
 //!                                            HISTORY map ── global max per edge
 //!                                                │
-//!                                            batch_has_new = true if any
-//!                                            bucketed > history[i]
+//!                                                ▼
+//!                                            cumulative reporting
 //! ```
 //!
 //! Three shared memory regions:
 //!
-//! - **Transfer buffer** ([`SANCOV_TRANSFER`]): child writes raw counters
+//! - **Transfer buffer** (`SANCOV_TRANSFER`): child writes raw counters
 //!   via [`copy_counters_to_shared`] before `_exit()`. In sequential mode,
 //!   one buffer is reused. In parallel mode, each concurrent child gets
 //!   its own pool slot instead.
 //!
 //! - **History map** (`SANCOV_HISTORY`): global maximum of bucketed values
-//!   per edge. Never reset within a seed. Preserved across seeds by
-//!   [`prepare_next_seed()`](crate::prepare_next_seed) (cumulative, like
-//!   the explored map).
+//!   per edge. It stays cumulative across seeds within one explorer run.
 //!
-//! - **Pool** ([`SANCOV_POOL`]): parallel mode allocates
+//! - **Pool** (`SANCOV_POOL`): worker mode allocates
 //!   `slot_count × edge_count` bytes. Each concurrent child writes to its
 //!   own slot. Parent reads the slot after `waitpid()`. Allocated lazily
 //!   by [`get_or_init_sancov_pool`].
@@ -176,31 +159,20 @@
 //! - [`has_new_sancov_coverage`]: reads from the transfer buffer (sequential)
 //! - [`has_new_sancov_coverage_from`]: reads from a specific pool slot (parallel)
 //!
-//! Novelty feeds into `batch_has_new` in [`split_loop`](crate::split_loop)
-//! alongside the fork bitmap's
-//! [`has_new_bits()`](crate::coverage::ExploredMap::has_new_bits).
+//! # Integration with workers
 //!
-//! # Integration with the fork loop
-//!
-//! This module hooks into [`split_loop`](crate::split_loop) at five points:
+//! The frontier controller uses this module at four points:
 //!
 //! ```text
-//! setup_child()          After fork: reset_bss_counters() so child
-//!                        captures only its OWN edges. Reset pool pointers
-//!                        so nested splits allocate fresh pools.
+//! begin seed/job          reset_bss_counters() so the run captures its edges
 //!
-//! exit_child()           Before _exit(): copy_counters_to_shared() so
+//! worker exit             copy_counters_to_shared() so
 //!                        the parent can read the child's coverage.
 //!
-//! Sequential reap        After waitpid: has_new_sancov_coverage() checks
-//!                        the transfer buffer for novelty.
+//! in-process completion   has_new_sancov_coverage() merges the transfer buffer
 //!
-//! Parallel reap          After waitpid: has_new_sancov_coverage_from(slot)
-//!                        checks the child's pool slot for novelty.
-//!
-//! batch_has_new          Both coverage signals are OR'd together:
-//!                        batch_has_new |= sancov_novelty
-//!                        A barren/productive decision uses BOTH signals.
+//! worker reap             has_new_sancov_coverage_from(slot) merges that worker
+//!                        slot into cumulative history
 //! ```
 //!
 //! # Why binary targets? (sancov requires `main()`)
@@ -223,11 +195,8 @@
 //! Coverage stats flow through the reporting pipeline:
 //!
 //! - [`sancov_edge_count`] and [`sancov_edges_covered`] provide the raw numbers
-//! - [`ExplorationStats`](crate::shared_stats::ExplorationStats) includes
-//!   `sancov_edges_total` and `sancov_edges_covered`
-//! - `ExplorationReport` carries them to the `SimulationReport`
-//! - The terminal display shows a "Code Cov" progress bar alongside
-//!   the "Exploration" (fork bitmap) progress bar
+//! - `moonpool-sim` carries them into its `ExplorationReport`
+//! - The terminal display shows a "Code Cov" progress bar
 //! - Percentage = `edges_covered / edges_total`
 //!
 //! # Running code coverage
@@ -261,11 +230,6 @@
 //!   ├── per-reap:
 //!   │     has_new_sancov_coverage()   bucket + compare against history
 //!   │
-//!   ├── prepare_next_seed():
-//!   │     clear_transfer_buffer()     zero transfer buffer
-//!   │     reset_bss_counters()        zero BSS array
-//!   │     (history preserved)         cumulative across seeds
-//!   │
 //!   └── cleanup_sancov_shared()      free transfer + history + pool
 //! ```
 
@@ -292,7 +256,7 @@ static COUNTERS_LEN: AtomicUsize = AtomicUsize::new(0);
 thread_local! {
     /// MAP_SHARED buffer for child→parent counter transfer.
     ///
-    /// Public so `split_loop.rs` can redirect per-child in parallel mode.
+    /// Redirected to a worker's pool slot after `fork`.
     static SANCOV_TRANSFER: Cell<*mut u8> = const { Cell::new(std::ptr::null_mut()) };
 
     /// MAP_SHARED global max map (history of highest bucketed values).
@@ -300,12 +264,12 @@ thread_local! {
 
     /// MAP_SHARED pool base for parallel mode (one slot per concurrent child).
     ///
-    /// Public so `setup_child()` can reset for nested splits.
+    /// Initialized once for the bounded worker pool.
     static SANCOV_POOL: Cell<*mut u8> = const { Cell::new(std::ptr::null_mut()) };
 
     /// Number of slots in the sancov pool.
     ///
-    /// Public so `setup_child()` can reset for nested splits.
+    /// Number of initialized bounded-worker slots.
     static SANCOV_POOL_SLOTS: Cell<usize> = const { Cell::new(0) };
 
     /// Owners of the transfer and history pointers above.
@@ -541,7 +505,7 @@ pub fn sancov_edges_covered() -> usize {
 ///
 /// Unlike [`sancov_edges_covered`], this reads the LLVM-instrumented counters
 /// directly in the current process — no `SANCOV_HISTORY`, no fork. Each call
-/// folds the current counters into a persistent "seen" mask ([`SANCOV_SEEN`])
+/// folds the current counters into a persistent internal "seen" mask
 /// and returns the size of the union. Folding (rather than counting raw
 /// non-zero bytes) is essential: the 8-bit counters wrap at 256 and are not
 /// reset between seeds in the sequential path, so a hot edge whose cumulative

--- a/crates/moonpool-sim-examples/src/bin/sim/dungeon_explore.rs
+++ b/crates/moonpool-sim-examples/src/bin/sim/dungeon_explore.rs
@@ -11,7 +11,7 @@ fn main() {
     moonpool_sim::init_sim_tracing(tracing::Level::WARN);
 
     let report = moonpool_sim::SimulationBuilder::new()
-        .workload(moonpool_sim_examples::dungeon::DungeonWorkload::default())
+        .workload_factory(|| Box::new(moonpool_sim_examples::dungeon::DungeonWorkload::default()))
         .enable_exploration(moonpool_sim::ExplorationConfig {
             workers: 4,
             max_runs_per_seed: 24_000,

--- a/crates/moonpool-sim-examples/src/bin/sim/maze_explore.rs
+++ b/crates/moonpool-sim-examples/src/bin/sim/maze_explore.rs
@@ -9,7 +9,7 @@ fn main() {
     moonpool_sim::init_sim_tracing(tracing::Level::WARN);
 
     let report = moonpool_sim::SimulationBuilder::new()
-        .workload(moonpool_sim_examples::maze::MazeWorkload::default())
+        .workload_factory(|| Box::new(moonpool_sim_examples::maze::MazeWorkload::default()))
         .enable_exploration(moonpool_sim::ExplorationConfig {
             workers: 0,
             max_runs_per_seed: 600,

--- a/crates/moonpool-sim/README.md
+++ b/crates/moonpool-sim/README.md
@@ -55,7 +55,7 @@ Moonpool provides 15 Antithesis-style assertion macros for comprehensive propert
 
 **Numeric assertions** — track watermarks and thresholds:
 - `assert_always_greater_than!`, `assert_always_less_than!` (and `_or_equal_to` variants) — numeric invariants
-- `assert_sometimes_greater_than!`, `assert_sometimes_less_than!` (and `_or_equal_to` variants) — watermark tracking with fork-on-improvement
+- `assert_sometimes_greater_than!`, `assert_sometimes_less_than!` (and `_or_equal_to` variants) — watermark tracking with replay anchors on improvement
 
 **Compound assertions** — multi-condition discovery:
 - `assert_sometimes_all!` — frontier tracking across multiple named conditions
@@ -71,9 +71,15 @@ This transforms testing from "check known behaviors" to "explore the unknown unt
 
 ## Multiverse Exploration
 
-Beyond multi-seed testing, moonpool-sim integrates with `moonpool-explorer` for fork-based exploration. When an assertion discovers new behavior, the explorer forks child processes with different RNG seeds to explore alternate timelines from that discovery point.
+Beyond multi-seed testing, moonpool-sim integrates with `moonpool-explorer` for frontier-based exploration. When an assertion discovers new behavior, the explorer records an RNG-coordinate recipe. Bounded workers replay that prefix from the beginning and continue with different deterministic randomness.
 
-Adaptive energy budgets and coverage bitmaps guide exploration toward productive branches, while energy limits prevent runaway forking.
+The controller expands productive runs once, retains a few semantic-state exemplars, and caps total runs, queued jobs, and recipe depth. Code-edge coverage is reported and drives plateau detection; semantic assertions provide the replay anchors that guide the frontier.
+
+This is assertion-guided randomized testing, not exhaustive model checking.
+Exploration requires `.workload_factory()` or `.workloads()` plus built-in
+chaos surfaces; opaque workload instances, `before_iteration` hooks, and custom
+fault-injector instances are rejected because Moonpool cannot reconstruct them
+for every continuation.
 
 ## Documentation
 

--- a/crates/moonpool-sim/src/chaos/assertions.rs
+++ b/crates/moonpool-sim/src/chaos/assertions.rs
@@ -231,10 +231,9 @@ pub fn assertion_results() -> HashMap<String, AssertionStats> {
 
 /// Request that the next call to [`reset_assertion_results`] be skipped.
 ///
-/// Used by multi-seed runs: the between-seed reset preserves pass/fail counts
-/// (selectively, under exploration, via the explorer's `prepare_next_seed`; or
-/// by accumulation without it), so the full zero in `SimWorld::create` must be
-/// suppressed.
+/// Used by multi-seed and exploration runs: the between-run reset preserves
+/// cumulative pass/fail counts and discovery latches, so the full zero in
+/// `SimWorld::create` must be suppressed.
 pub fn skip_next_assertion_reset() {
     SKIP_NEXT_ASSERTION_RESET.with(|c| c.set(true));
 }
@@ -436,7 +435,7 @@ macro_rules! assert_always_or_unreachable {
 
 /// Assert a condition that should sometimes be true, tracking stats and triggering exploration.
 ///
-/// Does not panic. On first success, triggers a fork to explore alternate timelines.
+/// Does not panic. Its first success creates a replay anchor for exploration.
 #[macro_export]
 macro_rules! assert_sometimes {
     ($condition:expr, $message:expr) => {
@@ -451,7 +450,7 @@ macro_rules! assert_sometimes {
 
 /// Assert that a code path is reachable (should be reached at least once).
 ///
-/// Does not panic. On first reach, triggers a fork.
+/// Does not panic. Its first reach creates a replay anchor for exploration.
 #[macro_export]
 macro_rules! assert_reachable {
     ($message:expr) => {
@@ -687,7 +686,7 @@ macro_rules! assert_always_less_than_or_equal_to {
     };
 }
 
-/// Assert that `val > threshold` sometimes holds. Forks on watermark improvement.
+/// Assert that `val > threshold` sometimes holds. Guides on watermark improvement.
 #[macro_export]
 macro_rules! assert_sometimes_greater_than {
     ($val:expr, $thresh:expr, $message:expr) => {
@@ -702,7 +701,7 @@ macro_rules! assert_sometimes_greater_than {
     };
 }
 
-/// Assert that `val >= threshold` sometimes holds. Forks on watermark improvement.
+/// Assert that `val >= threshold` sometimes holds. Guides on watermark improvement.
 #[macro_export]
 macro_rules! assert_sometimes_greater_than_or_equal_to {
     ($val:expr, $thresh:expr, $message:expr) => {
@@ -717,7 +716,7 @@ macro_rules! assert_sometimes_greater_than_or_equal_to {
     };
 }
 
-/// Assert that `val < threshold` sometimes holds. Forks on watermark improvement.
+/// Assert that `val < threshold` sometimes holds. Guides on watermark improvement.
 #[macro_export]
 macro_rules! assert_sometimes_less_than {
     ($val:expr, $thresh:expr, $message:expr) => {
@@ -732,7 +731,7 @@ macro_rules! assert_sometimes_less_than {
     };
 }
 
-/// Assert that `val <= threshold` sometimes holds. Forks on watermark improvement.
+/// Assert that `val <= threshold` sometimes holds. Guides on watermark improvement.
 #[macro_export]
 macro_rules! assert_sometimes_less_than_or_equal_to {
     ($val:expr, $thresh:expr, $message:expr) => {
@@ -771,8 +770,8 @@ macro_rules! assert_sometimes_all {
 /// Per-value bucketed sometimes assertion with optional quality watermarks.
 ///
 /// Each unique combination of identity keys gets its own bucket. On first
-/// discovery of a new bucket, a fork is triggered for exploration. If quality
-/// keys are provided, re-forks when quality improves.
+/// discovery of a new bucket creates a replay anchor for exploration. If
+/// quality keys are provided, improvements create new anchors.
 ///
 /// # Usage
 ///

--- a/crates/moonpool-sim/src/executor/mod.rs
+++ b/crates/moonpool-sim/src/executor/mod.rs
@@ -93,11 +93,11 @@
 //!
 //! # Fork safety
 //!
-//! The fork-based explorer ([`moonpool-explorer`]) forks the process while
-//! tasks are being polled (assertion macros are fork points). Two rules keep
-//! that sound: everything is single-threaded, and **the queue lock is never
-//! held across `runnable.run()`**; wakes fired during a poll re-acquire the
-//! lock, and a child process inherits no held locks.
+//! The explorer only forks between complete simulation timelines, when no
+//! executor exists and no task is being polled. Forked workers are nevertheless
+//! opt-in: a host process with unrelated threads may leave library locks held
+//! in the child. The default explorer configuration therefore runs in-process;
+//! enable workers only in a standalone, single-threaded simulation binary.
 //!
 //! [`moonpool-explorer`]: https://docs.rs/moonpool-explorer
 
@@ -399,8 +399,8 @@ impl Executor {
 
     /// Poll ready tasks in seeded-random order until none is runnable.
     ///
-    /// The queue lock is released around every `runnable.run()` (fork
-    /// safety; wakes fired during a poll re-acquire it to enqueue).
+    /// The queue lock is released around every `runnable.run()`; wakes fired
+    /// during a poll re-acquire it to enqueue.
     fn run_until_stalled(&mut self) {
         let mut polls: u64 = 0;
 

--- a/crates/moonpool-sim/src/lib.rs
+++ b/crates/moonpool-sim/src/lib.rs
@@ -20,7 +20,7 @@
 //! - [`SimulationBuilder`]: Configure and run simulations
 //! - [`chaos`]: Fault injection (buggify, 14 assertion macros, invariants)
 //! - [`storage`]: Storage simulation with fault injection
-//! - Multiverse exploration via `moonpool-explorer` (re-exported as [`ExplorationConfig`], [`AdaptiveConfig`])
+//! - Multiverse exploration via `moonpool-explorer` (configured with [`ExplorationConfig`])
 //!
 //! ## Fault Injection Overview
 //!
@@ -41,63 +41,31 @@
 //! | Torn writes | configurable | Write atomicity, journaling |
 //! | Sync failures | configurable | Durability guarantees |
 //!
-//! ## Coverage-Preserving Multi-Seed Exploration
+//! ## Frontier-Based Multi-Seed Exploration
 //!
-//! When exploration is enabled, multiple seeds share coverage context. The
-//! explored map (coverage bitmap union) and assertion watermarks are preserved
-//! between seeds so each subsequent seed focuses energy on genuinely new
-//! branches rather than re-treading already-discovered paths.
+//! Exploration retains replay recipes for globally new assertion outcomes.
+//! Productive timelines enqueue bounded continuations that replay to the last
+//! discovery and then diverge with fresh deterministic randomness. Assertion
+//! novelty and code-coverage history are cumulative across root seeds, so a
+//! seed that discovers nothing new stops after its root timeline.
 //!
-//! A **warm start** mechanism reduces wasted forks: on seeds after the first,
-//! marks whose first probe batch finds zero new coverage bits stop after
-//! `warm_min_timelines` forks instead of the full `min_timelines`.
-//!
-//! ```text
-//!  Seed 1 (cold start)           Seed 2 (warm start)          Seed 3 (warm start)
-//!  energy: 400K                  energy: 400K                 energy: 400K
-//!
-//!  root ─┬─ mark A ──> 400       root ─┬─ mark A ──> 30      root ─┬─ mark A ──> 30
-//!        │  (new bits!) forks           │  (barren!) skip           │  (barren!) skip
-//!        │                              │                           │
-//!        ├─ mark B ──> 400              ├─ mark B ──> 30            ├─ mark B ──> 30
-//!        │  (new bits!) forks           │  (barren!) skip           │  (barren!) skip
-//!        │                              │                           │
-//!        └─ mark C ──> 400              ├─ mark C ──> 30            ├─ mark C ──> 30
-//!           (new bits!) forks           │  (barren!) skip           │  (barren!) skip
-//!                                       │                           │
-//!                                       └─ mark D ──> 400          └─ mark E ──> 400
-//!                                          (NEW bits!) forks           (NEW bits!) forks
-//!                        │                               │                            │
-//!       ┌────────────────┘              ┌────────────────┘           ┌────────────────┘
-//!       v                               v                            v
-//!  ┌──────────┐  ──preserved──>  ┌──────────┐  ──preserved──>  ┌──────────┐
-//!  │ explored │  coverage map    │ explored │  coverage map    │ explored │
-//!  │ map:     │  + watermarks    │ map:     │  + watermarks    │ map:     │
-//!  │ A,B,C    │                  │ A,B,C,D  │                  │ A,B,C,D,E│
-//!  └──────────┘                  └──────────┘                  └──────────┘
-//!
-//!  Total: each seed spends most energy on NEW discoveries.
-//!  Warm marks (A,B,C on seed 2) exit after warm_min_timelines (30)
-//!  instead of min_timelines (400), saving ~95% energy per barren mark.
-//! ```
+//! Workers are short-lived child processes, bounded by `workers`; set it to
+//! zero for sequential, fork-free exploration. Every worker reconstructs the
+//! timeline from its root seed and recipe rather than snapshotting a live
+//! simulation.
 //!
 //! ```ignore
 //! SimulationBuilder::new()
-//!     .set_iterations(3)  // 3 root seeds with coverage forwarding
 //!     .enable_exploration(ExplorationConfig {
-//!         max_depth: 120,
-//!         timelines_per_split: 4,
-//!         global_energy: 400_000,  // per-seed energy budget
-//!         adaptive: Some(AdaptiveConfig {
-//!             batch_size: 30,
-//!             min_timelines: 400,
-//!             max_timelines: 1_000,
-//!             per_mark_energy: 10_000,
-//!             warm_min_timelines: Some(30),  // quick skip for barren warm marks
-//!         }),
-//!         parallelism: Some(Parallelism::HalfCores),
+//!         workers: 0,
+//!         max_runs_per_seed: 8_000,
+//!         branching_factor: 4,
+//!         max_frontier: 1_024,
+//!         max_recipe_len: 64,
 //!     })
-//!     .workload(my_workload);
+//!     .until_coverage_stable(10, 1_000)
+//!     .workload_factory(|| Box::new(MyWorkload::default()))
+//!     .run();
 //! ```
 
 #![deny(missing_docs)]

--- a/crates/moonpool-sim/src/runner/builder.rs
+++ b/crates/moonpool-sim/src/runner/builder.rs
@@ -277,12 +277,38 @@ impl SimulationBuilder {
     ///
     /// The instance is reused across iterations (the `run()` method is called
     /// each iteration on the same struct). Gets `client_id = 0`, `client_count = 1`.
+    /// This form is intentionally rejected when exploration is enabled because
+    /// an arbitrary trait object cannot be reconstructed with fresh state for
+    /// each continuation. Use [`Self::workload_factory`] or [`Self::workloads`]
+    /// for exploration.
     #[must_use]
     pub fn workload(mut self, w: impl Workload) -> Self {
         self.entries.push(WorkloadEntry::Instance(
             Some(Box::new(w)),
             ClientId::default(),
         ));
+        self
+    }
+
+    /// Add one workload reconstructed from a factory for every timeline.
+    ///
+    /// Unlike [`Self::workload`], this never reuses a previously-run workload
+    /// value. Use this form for exploration so every root and continuation
+    /// timeline starts with fresh test-driver state and captured bug recipes
+    /// can be replayed from the same lifecycle boundary.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// builder.workload_factory(|| Box::new(ClientWorkload::new()))
+    /// ```
+    #[must_use]
+    pub fn workload_factory(mut self, factory: impl Fn() -> Box<dyn Workload> + 'static) -> Self {
+        self.entries.push(WorkloadEntry::Factory {
+            count: WorkloadCount::Fixed(1),
+            client_id: ClientId::default(),
+            factory: Box::new(move |_| factory()),
+        });
         self
     }
 
@@ -646,17 +672,35 @@ impl SimulationBuilder {
         self
     }
 
-    /// Enable fork-based multiverse exploration.
+    /// Enable frontier-based multiverse exploration.
     ///
-    /// When enabled, the simulation will fork child processes at assertion
-    /// discovery points to explore alternate timelines with different seeds.
-    /// Requires the `exploration` feature.
+    /// When enabled, globally new assertion outcomes create replay recipes.
+    /// Bounded worker processes replay those timelines and continue them with
+    /// different deterministic seeds. Set `config.workers` to zero for
+    /// sequential, fork-free exploration. Requires the `exploration` feature.
+    ///
+    /// Exploration requires factory-created workloads and built-in [`Chaos`]
+    /// surfaces. Instance workloads, `before_iteration` hooks, and custom fault
+    /// injector instances are rejected because the runner cannot reconstruct
+    /// those values with fresh state for every continuation timeline.
+    ///
+    /// # Panics
+    ///
+    /// Panics when the configuration contains a zero exploration bound. The
+    /// simulation also fails fast from [`Self::run`] if exploration is combined
+    /// with instance workloads, `before_iteration` hooks, or custom fault
+    /// injector instances, because those values cannot be reconstructed for
+    /// each continuation timeline. Use [`Self::workload_factory`] or
+    /// [`Self::workloads`] and built-in [`Chaos`] surfaces instead.
     #[cfg(feature = "exploration")]
     #[must_use]
     pub fn enable_exploration(
         mut self,
         config: crate::chaos::exploration_glue::ExplorationConfig,
     ) -> Self {
+        if let Err(error) = config.validate() {
+            panic!("invalid exploration configuration: {error}");
+        }
         self.exploration_config = Some(config);
         self
     }
@@ -839,6 +883,37 @@ impl SimulationBuilder {
             convergence_timeout: false,
             saturation: None,
         })
+    }
+
+    /// Enforce the fresh-state boundary required by exploration recipes.
+    ///
+    /// Factory entries are reconstructed by `resolve_entries` for every root
+    /// and continuation. The rejected inputs are opaque mutable values whose
+    /// pristine state cannot be recovered after one timeline has run.
+    fn validate_exploration_lifecycle(&self) {
+        if self.exploration_config.is_none() {
+            return;
+        }
+
+        assert!(
+            !self
+                .entries
+                .iter()
+                .any(|entry| matches!(entry, WorkloadEntry::Instance(..))),
+            "exploration requires fresh workloads for every timeline; use \
+             SimulationBuilder::workload_factory or SimulationBuilder::workloads instead of \
+             SimulationBuilder::workload"
+        );
+        assert!(
+            self.before_iteration_hooks.is_empty(),
+            "exploration does not support before_iteration hooks because they cannot be \
+             reconstructed for every timeline; move reset state into a workload factory"
+        );
+        assert!(
+            self.fault_injectors.is_empty(),
+            "exploration does not support custom fault injector instances because they cannot be \
+             reconstructed for every timeline; use built-in Chaos surfaces"
+        );
     }
 
     /// Check whether the `UntilCoverageStable` saturation condition has been
@@ -1169,8 +1244,12 @@ impl SimulationBuilder {
     ///
     /// # Panics
     ///
-    /// Panics if a simulation invariant fails or a workload panics.
+    /// Panics if a simulation invariant fails, a workload panics, or exploration
+    /// is configured with lifecycle state that cannot be reconstructed for each
+    /// timeline (an instance workload, a `before_iteration` hook, or a custom
+    /// fault injector instance).
     pub fn run(mut self) -> SimulationReport {
+        self.validate_exploration_lifecycle();
         if self.entries.is_empty() {
             return Self::empty_report();
         }
@@ -1349,6 +1428,11 @@ impl SimulationBuilder {
                 Err(_) => true,
             }
         });
+        if explorer.seed_stats().bug_found > 0 {
+            state
+                .metrics_collector
+                .mark_current_iteration_failed_by_exploration(seed);
+        }
         state.explorer = Some(explorer);
     }
 
@@ -1725,6 +1809,35 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "exploration")]
+    fn test_exploration_config() -> crate::ExplorationConfig {
+        crate::ExplorationConfig {
+            workers: 0,
+            max_runs_per_seed: 1,
+            branching_factor: 1,
+            max_frontier: 1,
+            max_recipe_len: 1,
+        }
+    }
+
+    #[cfg(feature = "exploration")]
+    struct TestFaultInjector;
+
+    #[cfg(feature = "exploration")]
+    #[async_trait]
+    impl FaultInjector for TestFaultInjector {
+        fn name(&self) -> &'static str {
+            "test_fault"
+        }
+
+        async fn inject(
+            &mut self,
+            _ctx: &crate::runner::fault_injector::FaultContext,
+        ) -> SimulationResult<()> {
+            Ok(())
+        }
+    }
+
     #[test]
     fn test_simulation_builder_basic() {
         let report = SimulationBuilder::new()
@@ -1738,6 +1851,59 @@ mod tests {
         assert_eq!(report.failed_runs, 0);
         assert!((report.success_rate() - 100.0).abs() < f64::EPSILON);
         assert_eq!(report.seeds_used, vec![1, 2, 3]);
+    }
+
+    #[cfg(feature = "exploration")]
+    #[test]
+    fn exploration_accepts_factory_workloads_and_builtin_chaos() {
+        let builder = SimulationBuilder::new()
+            .workload_factory(|| Box::new(BasicWorkload))
+            .enable_chaos([Chaos::Network(ChaosMode::Random)])
+            .enable_exploration(test_exploration_config());
+
+        builder.validate_exploration_lifecycle();
+    }
+
+    #[cfg(feature = "exploration")]
+    #[test]
+    #[should_panic(expected = "max_frontier")]
+    fn exploration_rejects_zero_config_bound() {
+        let mut config = test_exploration_config();
+        config.max_frontier = 0;
+
+        let _builder = SimulationBuilder::new().enable_exploration(config);
+    }
+
+    #[cfg(feature = "exploration")]
+    #[test]
+    #[should_panic(expected = "exploration requires fresh workloads for every timeline")]
+    fn exploration_rejects_instance_workloads() {
+        SimulationBuilder::new()
+            .workload(BasicWorkload)
+            .enable_exploration(test_exploration_config())
+            .validate_exploration_lifecycle();
+    }
+
+    #[cfg(feature = "exploration")]
+    #[test]
+    #[should_panic(expected = "exploration does not support before_iteration hooks")]
+    fn exploration_rejects_before_iteration_hooks() {
+        SimulationBuilder::new()
+            .workload_factory(|| Box::new(BasicWorkload))
+            .before_iteration(|| {})
+            .enable_exploration(test_exploration_config())
+            .validate_exploration_lifecycle();
+    }
+
+    #[cfg(feature = "exploration")]
+    #[test]
+    #[should_panic(expected = "exploration does not support custom fault injector instances")]
+    fn exploration_rejects_custom_fault_injectors() {
+        SimulationBuilder::new()
+            .workload_factory(|| Box::new(BasicWorkload))
+            .fault(TestFaultInjector)
+            .enable_exploration(test_exploration_config())
+            .validate_exploration_lifecycle();
     }
 
     struct FailingWorkload;

--- a/crates/moonpool-sim/src/runner/metrics.rs
+++ b/crates/moonpool-sim/src/runner/metrics.rs
@@ -71,6 +71,43 @@ impl MetricsCollector {
         self.faulty_seeds.push(seed);
     }
 
+    /// Reclassify the current root iteration when one of its exploration
+    /// timelines finds a bug.
+    ///
+    /// Exploration is part of the root seed's test result, so the public
+    /// iteration counts must still add up to `iterations`: one productive
+    /// seed with several failing continuations is one failed iteration, not
+    /// one successful root plus several extra failures.
+    #[cfg(feature = "exploration")]
+    pub(crate) fn mark_current_iteration_failed_by_exploration(&mut self, seed: u64) {
+        let Some(last_result) = self.individual_metrics.last_mut() else {
+            return;
+        };
+        let Ok(metrics) = last_result else {
+            return;
+        };
+
+        self.successful_runs = self.successful_runs.saturating_sub(1);
+        self.failed_runs += 1;
+        self.aggregated_metrics.wall_time = self
+            .aggregated_metrics
+            .wall_time
+            .saturating_sub(metrics.wall_time);
+        self.aggregated_metrics.simulated_time = self
+            .aggregated_metrics
+            .simulated_time
+            .saturating_sub(metrics.simulated_time);
+        self.aggregated_metrics.events_processed = self
+            .aggregated_metrics
+            .events_processed
+            .saturating_sub(metrics.events_processed);
+        *last_result = Err(SimulationError::InvalidState(format!(
+            "exploration found a failing timeline (root seed {seed})"
+        )));
+        self.faulty_seeds.push(seed);
+        tracing::error!(seed, "exploration found a failing timeline");
+    }
+
     /// Add faulty seeds reported by an external exploration phase.
     pub(crate) fn add_faulty_seeds(&mut self, mut seeds: Vec<u64>) {
         self.faulty_seeds.append(&mut seeds);

--- a/crates/moonpool-sim/tests/coverage_plateau.rs
+++ b/crates/moonpool-sim/tests/coverage_plateau.rs
@@ -94,7 +94,7 @@ fn test_plateau_with_exploration() {
                 max_recipe_len: 8,
             })
             .until_coverage_stable(3, 100)
-            .workload(ThreeAlwaysHitWorkload),
+            .workload_factory(|| Box::new(ThreeAlwaysHitWorkload)),
     );
 
     assert!(

--- a/crates/moonpool-sim/tests/exploration/tests.rs
+++ b/crates/moonpool-sim/tests/exploration/tests.rs
@@ -4,9 +4,14 @@
 //! Since worker mode uses `fork()`, each test must run in its own process
 //! (nextest default).
 
+use std::cell::{Cell, RefCell};
+use std::collections::HashMap;
+
 use async_trait::async_trait;
+use futures::io::{AsyncReadExt, AsyncWriteExt};
 use moonpool_sim::{
-    ExplorationConfig, SimContext, SimulationBuilder, SimulationReport, SimulationResult, Workload,
+    ExplorationConfig, Invariant, NetworkProvider, Process, SimContext, SimulationBuilder,
+    SimulationError, SimulationReport, SimulationResult, TcpListenerTrait, TraceQuery, Workload,
 };
 
 /// Helper to run a simulation and return the report.
@@ -128,6 +133,150 @@ impl Workload for EachBucketWorkload {
     }
 }
 
+/// A tiny consensus node: receiving a one-byte term nominates this node as
+/// leader for that term and acknowledges the request over the simulated TCP
+/// connection.
+struct ElectionNode;
+
+#[async_trait]
+impl Process for ElectionNode {
+    fn name(&self) -> &'static str {
+        "election_node"
+    }
+
+    async fn run(&mut self, ctx: &SimContext) -> SimulationResult<()> {
+        let listener = ctx.network().bind(ctx.my_ip()).await?;
+        loop {
+            let accepted = moonpool_sim::select! {
+                biased;
+                result = listener.accept() => result,
+                () = ctx.shutdown().cancelled() => return Ok(()),
+            };
+            let Ok((mut stream, _)) = accepted else {
+                continue;
+            };
+            let mut term = [0_u8; 1];
+            if stream.read_exact(&mut term).await.is_err() {
+                continue;
+            }
+            tracing::info!(
+                term = u64::from(term[0]),
+                leader = %ctx.my_ip(),
+                "exploration_leader_elected"
+            );
+            stream.write_all(b"ack").await.map_err(|error| {
+                SimulationError::InvalidState(format!("election ack failed: {error}"))
+            })?;
+        }
+    }
+}
+
+/// Paxos-style safety check: one term must never have two distinct leaders.
+struct OneLeaderPerTerm {
+    cursor: Cell<usize>,
+    leaders: RefCell<HashMap<u64, String>>,
+}
+
+impl OneLeaderPerTerm {
+    fn new() -> Self {
+        Self {
+            cursor: Cell::new(0),
+            leaders: RefCell::new(HashMap::new()),
+        }
+    }
+}
+
+impl Invariant for OneLeaderPerTerm {
+    fn name(&self) -> &'static str {
+        "one_leader_per_term"
+    }
+
+    fn observe(&self, query: &dyn TraceQuery, _sim_time_ms: u64) {
+        let mut leaders = self.leaders.borrow_mut();
+        for event in query.since("exploration_leader_elected", &self.cursor) {
+            let term = event
+                .u64("term")
+                .expect("leader election event carries a term");
+            let leader = event
+                .str("leader")
+                .expect("leader election event carries a leader")
+                .to_owned();
+            if let Some(previous) = leaders.get(&term) {
+                moonpool_sim::assert_always!(
+                    previous == &leader,
+                    "exploration: one leader per term"
+                );
+            } else {
+                leaders.insert(term, leader);
+            }
+        }
+    }
+
+    fn reset(&mut self) {
+        self.cursor.set(0);
+        self.leaders.borrow_mut().clear();
+    }
+}
+
+/// Contact one node through the real simulated-network Process path and wait
+/// until its leader event has been emitted.
+async fn nominate(ctx: &SimContext, node: &str, term: u8) -> SimulationResult<()> {
+    let mut stream = ctx.network().connect(node).await?;
+    stream.write_all(&[term]).await.map_err(|error| {
+        SimulationError::InvalidState(format!("nomination write failed: {error}"))
+    })?;
+    let mut ack = [0_u8; 3];
+    stream.read_exact(&mut ack).await.map_err(|error| {
+        SimulationError::InvalidState(format!("nomination ack failed: {error}"))
+    })?;
+    if ack != *b"ack" {
+        return Err(SimulationError::InvalidState(
+            "invalid nomination acknowledgement".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+/// A fresh-per-timeline workload with two sequential rare gates. The first
+/// leader is safe; passing both gates nominates a second leader in the same
+/// term, which the invariant catches.
+struct GuidedElectionWorkload;
+
+#[async_trait]
+impl Workload for GuidedElectionWorkload {
+    fn name(&self) -> &'static str {
+        "guided_election"
+    }
+
+    async fn run(&mut self, ctx: &SimContext) -> SimulationResult<()> {
+        let nodes = ctx.topology().all_process_ips();
+        if nodes.len() != 3 {
+            return Err(SimulationError::InvalidState(format!(
+                "expected three election nodes, found {}",
+                nodes.len()
+            )));
+        }
+
+        nominate(ctx, &nodes[0], 1).await?;
+        moonpool_sim::assert_sometimes!(true, "exploration: leader elected");
+
+        let competing_ballot = moonpool_sim::sim_random_range(0_u8..10) == 0;
+        moonpool_sim::assert_sometimes!(competing_ballot, "exploration: competing ballot opened");
+        if competing_ballot {
+            let competing_quorum = moonpool_sim::sim_random_range(0_u8..10) == 0;
+            moonpool_sim::assert_sometimes!(
+                competing_quorum,
+                "exploration: competing ballot reached quorum"
+            );
+            if competing_quorum {
+                nominate(ctx, &nodes[1], 1).await?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -157,8 +306,10 @@ fn test_exploration_basic() {
         SimulationBuilder::new()
             .set_iterations(1)
             .enable_exploration(test_config(0, 10))
-            .workload(AssertOnceWorkload {
-                message: "triggers exploration",
+            .workload_factory(|| {
+                Box::new(AssertOnceWorkload {
+                    message: "triggers exploration",
+                })
             }),
     );
 
@@ -194,11 +345,14 @@ fn test_bug_capture_and_recipe() {
         SimulationBuilder::new()
             .set_iterations(1)
             .enable_exploration(test_config(1, 10))
-            .workload(ChildBugWorkload),
+            .workload_factory(|| Box::new(ChildBugWorkload)),
     );
 
-    // The root (in-process) run succeeds; bugs appear in exploration runs.
-    assert_eq!(report.successful_runs, 1);
+    // The root timeline succeeds, but a bug in any continuation makes its
+    // root seed a failed iteration in the top-level report.
+    assert_eq!(report.successful_runs, 0);
+    assert_eq!(report.failed_runs, 1);
+    assert_eq!(report.seeds_failing, report.seeds_used);
 
     let exp = report.exploration.expect("exploration report missing");
     assert!(
@@ -228,10 +382,12 @@ fn test_workers_bounded() {
         SimulationBuilder::new()
             .set_iterations(1)
             .enable_exploration(config)
-            .workload(ChildBugWorkload),
+            .workload_factory(|| Box::new(ChildBugWorkload)),
     );
 
-    assert_eq!(report.successful_runs, 1);
+    assert_eq!(report.successful_runs, 0);
+    assert_eq!(report.failed_runs, 1);
+    assert_eq!(report.seeds_failing, report.seeds_used);
     let exp = report.exploration.expect("exploration report missing");
     assert!(
         exp.max_active_workers <= workers,
@@ -256,7 +412,7 @@ fn test_in_process_exploration_deterministic() {
                 .set_iterations(2)
                 .set_debug_seeds(vec![1111, 2222])
                 .enable_exploration(test_config(0, 8))
-                .workload(PlantedBugWorkload),
+                .workload_factory(|| Box::new(PlantedBugWorkload)),
         )
     };
     let first = run();
@@ -300,7 +456,7 @@ fn test_planted_bug_recipe_replays() {
             .set_iterations(1)
             .set_debug_seeds(vec![4242])
             .enable_exploration(config)
-            .workload(PlantedBugWorkload),
+            .workload_factory(|| Box::new(PlantedBugWorkload)),
     );
 
     let exp = report.exploration.expect("exploration report missing");
@@ -321,7 +477,7 @@ fn test_planted_bug_recipe_replays() {
     let replay = run_simulation(
         SimulationBuilder::new()
             .replay_timeline(bug.seed, bug.recipe.clone())
-            .workload(PlantedBugWorkload),
+            .workload_factory(|| Box::new(PlantedBugWorkload)),
     );
     assert_eq!(
         replay.failed_runs, 1,
@@ -337,7 +493,7 @@ fn test_sometimes_each_drives_exploration() {
         SimulationBuilder::new()
             .set_iterations(1)
             .enable_exploration(test_config(0, 10))
-            .workload(EachBucketWorkload),
+            .workload_factory(|| Box::new(EachBucketWorkload)),
     );
 
     assert_eq!(report.successful_runs, 1);
@@ -349,4 +505,53 @@ fn test_sometimes_each_drives_exploration() {
         exp.discoveries
     );
     assert!(exp.expansions > 0, "expected bucket-driven expansions");
+}
+
+/// A Process/network/invariant path representative of consensus testing:
+/// semantic guidance finds a split-brain timeline, and its recipe reproduces
+/// from fresh nodes and a fresh workload reference model.
+#[test]
+fn test_process_network_guidance_recipe_replays_split_brain() {
+    let build = || {
+        SimulationBuilder::new()
+            .processes(3, || Box::new(ElectionNode))
+            // Factory registration is important for replay: every explored
+            // timeline must start with a fresh test driver.
+            .workload_factory(|| Box::new(GuidedElectionWorkload))
+            .invariant(OneLeaderPerTerm::new())
+    };
+
+    let mut config = test_config(0, 300);
+    config.branching_factor = 4;
+    let report = run_simulation(
+        build()
+            .set_debug_seeds(vec![4242])
+            .set_iterations(1)
+            .enable_exploration(config),
+    );
+
+    let exploration = report.exploration.expect("exploration report missing");
+    let bug = exploration
+        .bug_recipes
+        .first()
+        .expect("guided exploration should find the planted split brain");
+    assert!(
+        bug.recipe.len() >= 2,
+        "the two sequential guidance gates should produce a multi-segment recipe: {}",
+        moonpool_sim::format_timeline(&bug.recipe)
+    );
+
+    let replay = run_simulation(build().replay_timeline(bug.seed, bug.recipe.clone()));
+    assert_eq!(
+        replay.failed_runs, 1,
+        "replayed consensus timeline must reproduce the split-brain invariant failure"
+    );
+    assert!(
+        replay
+            .assertion_violations
+            .iter()
+            .any(|message| message.contains("exploration: one leader per term")),
+        "replay should identify the consensus invariant: {:?}",
+        replay.assertion_violations
+    );
 }


### PR DESCRIPTION
## Summary
- enforce fresh workload state for exploration timelines
- fail fast on invalid exploration configuration and unsupported lifecycle inputs
- report explored failures at the root simulation level
- add a process/network/invariant replay test and Paxos guidance
- make fork-free deterministic exploration the safe default

## Validation
- nix develop --command cargo fmt --check
- nix develop --command cargo clippy --all-targets -- -D warnings
- nix develop --command cargo nextest run (537 passed)
- nix develop --command mdbook build book/
- strict moonpool-explorer rustdoc
- moonpool-sim no-default-features Clippy
- moonpool-sim wasm32 no-default-features check