### PR TITLE
feat(explorer): strengthen semantic guidance

### DIFF
--- a/book/src/llms.md
+++ b/book/src/llms.md
@@ -443,8 +443,8 @@ anchors.
 | A boolean situation should occur | `assert_sometimes!` | First true encounter is a discovery |
 | Mark an already-entered path as interesting | `assert_reachable!` | Encounter is a discovery |
 | A numeric bound must always hold | `assert_always_{greater,less}_than...!` | Numeric safety violation |
-| Drive a quantity higher or lower | `assert_sometimes_{greater,less}_than...!` | Every better watermark can guide deeper search |
-| Several conditions should coincide | `assert_sometimes_all!` | Guides whenever more conditions are simultaneously true |
+| Drive a quantity toward a numeric goal | `assert_sometimes_{greater,less}_than...!` | Every better `left - right` comparison distance can guide deeper search |
+| Several conditions should coincide | `assert_sometimes_all!` | Guides on frontier advances and new partial truth combinations |
 | Explore a bounded vocabulary of states | `assert_sometimes_each!` | New identity bucket and better per-bucket quality guide search |
 
 The exact numeric safety macros are
@@ -501,19 +501,16 @@ moonpool_sim::assert_sometimes_all!("protocol: failover completed", [
 ```
 
 This macro guides on frontier improvement: a run with two of three facts is
-more useful than a run with one. It does not currently create a simple final
-coverage violation for failing to reach all three, so add a separate campaign
-contract if completion is mandatory:
+more useful than a run with one. It also distinguishes bounded partial truth
+combinations, so "only old leader unavailable" and "only new quorum formed"
+can both become replayable states even though each has frontier one. The final
+report and adaptive coverage gate remain incomplete until all propositions are
+true together; do not duplicate it with a separate boolean completion check.
 
-```rust,ignore
-moonpool_sim::assert_sometimes!(
-    old_leader_unavailable && new_quorum_formed && client_completed,
-    "protocol: failover fully completed"
-);
-```
-
-The current frontier compares the number of true propositions, not which
-subset was true. Use bounded bucket identities when the subset itself matters.
+Partial combinations use a 64-bit per-site bitmap. This is bounded guidance,
+not exhaustive subset accounting: collisions may merge optional hints. Use
+`assert_sometimes_each!` with a deliberately small identity vocabulary when
+exact per-value reporting matters.
 
 ### Numeric guidance
 
@@ -535,9 +532,12 @@ moonpool_sim::assert_sometimes_less_than!(
 );
 ```
 
-Choose direction carefully. Greater/greater-or-equal guidance maximizes the
-observed value; less/less-or-equal guidance minimizes it. Values are converted
-to `i64`, so avoid relying on larger unsigned ranges.
+Choose direction carefully. Greater/greater-or-equal guidance maximizes
+`left - right`; less/less-or-equal guidance minimizes it. The human report
+still displays the best observed left operand. Tracking the distance means a
+dynamic threshold cannot report false progress merely because both operands
+grew. Values are converted to `i64`, so avoid relying on larger unsigned
+ranges.
 
 The first numeric evaluation establishes a watermark discovery even when the
 comparison has not passed yet. Later improvements can therefore guide a search

--- a/book/src/part3-building/15-numeric-assertions.md
+++ b/book/src/part3-building/15-numeric-assertions.md
@@ -34,7 +34,7 @@ assert_sometimes_less_than!(p99_latency, 100, "p99 should sometimes drop below 1
 
 Like their boolean counterparts, these are coverage assertions. If the goal is never achieved after all iterations, the validation reports a coverage violation.
 
-The difference from boolean sometimes is in how they interact with the explorer. **Sometimes-numeric assertions signal a discovery on watermark improvement.** The framework tracks the best value observed, and when a new observation beats the previous best, the explorer remembers a replayable exemplar of that state and schedules continuations from it — monotonic progress states get preferred treatment in continuation scheduling.
+The difference from boolean sometimes is in how they interact with the explorer. **Sometimes-numeric assertions signal a discovery when the comparison distance improves.** Guidance tracks `left - right`, while the report still shows the best value of `left`. Including both operands matters when the threshold changes during a run: a larger left value is not progress toward `left > right` if the right value grew even faster.
 
 This creates a ratchet. Suppose you write:
 
@@ -46,14 +46,14 @@ The first time committed_transactions reaches 50, the explorer branches. Then it
 
 ## Watermark Mechanics
 
-Every numeric assertion, whether always or sometimes, maintains a watermark in shared memory. The watermark is the best value of the left operand observed so far:
+Every numeric assertion, whether always or sometimes, maintains a reporting watermark in shared memory. This watermark is the best value of the left operand observed so far:
 
 - For assertions that track the **highest** value (`maximize=true`): `assert_always_less_than!`, `assert_always_less_than_or_equal_to!`, `assert_sometimes_greater_than!`, `assert_sometimes_greater_than_or_equal_to!`. These seek the boundary from below (always) or ratchet upward (sometimes).
 - For assertions that track the **lowest** value (`maximize=false`): `assert_always_greater_than!`, `assert_always_greater_than_or_equal_to!`, `assert_sometimes_less_than!`, `assert_sometimes_less_than_or_equal_to!`. These seek the boundary from above (always) or ratchet downward (sometimes).
 
 The watermark lives in the shared assertion region, so in multiverse mode every timeline sees the same current best. When one timeline improves it, the improvement is immediately visible to all subsequent timelines. This means the explorer collectively pushes toward the boundary rather than each timeline searching independently.
 
-For sometimes-numeric assertions, a second watermark tracks the value at the last signalled discovery. A new discovery only fires when the value improves **past** that mark (guarded by an atomic compare-and-swap, so it fires exactly once globally). This prevents the same assertion from flooding the journal with tiny incremental improvements.
+For sometimes-numeric assertions, a second watermark tracks the best comparison distance, `left - right`, seen by the explorer. Greater-than goals maximize this distance; less-than goals minimize it. A new discovery only fires when that distance improves past the shared mark, so a moving threshold cannot falsely steer exploration in the wrong direction.
 
 ## Use Cases
 

--- a/book/src/part3-building/16-compound-assertions.md
+++ b/book/src/part3-building/16-compound-assertions.md
@@ -21,7 +21,9 @@ assert_sometimes_all!("cluster_fully_operational", [
 
 The assertion tracks a **frontier**: the maximum number of sub-goals that have been simultaneously true. It starts at zero. The first time any sub-goal is true, the frontier advances to 1. When two are true at once, it advances to 2. When all four are true simultaneously, the frontier reaches 4 and the assertion is fully satisfied.
 
-Each frontier advance is a discovery the explorer schedules continuations from. This creates a progression: the explorer first finds states where one sub-goal is met, then continues from there to find states where two are met, and so on. The exploration naturally follows the path of increasing difficulty.
+Each frontier advance is a discovery the explorer schedules continuations from. Distinct truth combinations are useful too: `leader_elected` alone and `replicas_synced` alone both have frontier 1, but they may lead to very different futures. Moonpool therefore records new partial combinations as structured state discoveries even when their true-count does not beat the frontier. A bounded 64-bit bitmap per assertion keeps this extra guidance cheap; hash collisions can discard an optional hint but cannot affect assertion correctness or the reported frontier.
+
+This creates a progression without collapsing every same-cardinality state: the explorer can retain several ways to satisfy one sub-goal, then continue toward two, three, and finally all of them. Reports show the frontier as `reached/target` and keep the assertion in `MISS` until the full target is reached.
 
 This is powerful for multi-step objectives. Consider a distributed transaction system. The full operation requires: prepare all participants, get all votes, commit, and acknowledge to the client. As a sometimes-all assertion:
 

--- a/book/src/part5-building-on-top/03-frontier-controller.md
+++ b/book/src/part5-building-on-top/03-frontier-controller.md
@@ -43,15 +43,18 @@ During a run, every globally-new discovery is recorded into a per-run journal: w
 root run (seed 42):
   journal: [floor 2 entered @ call 812, key found @ call 1490]
 
-expansion, anchored at the LATEST discovery (call 1490):
-  child recipes: 1490@S1, 1490@S2, 1490@S3, 1490@S4
+expansion, anchored at the highest-priority discovery:
+  progress > structured state novelty > one-shot coverage
+  latest call count breaks ties inside a class
 ```
 
-Each child replays through *every* state the parent reached — the earlier discoveries are locked into the prefix — and diverges just past the deepest one.
+Numeric watermark, compound frontier, and bucket-quality improvements are progress. New `assert_sometimes_each!` buckets and partial `assert_sometimes_all!` combinations are structured state novelty. A first boolean sometimes/reachable pass is one-shot coverage. This ordering prevents a late, easy coverage hit from pulling immediate children away from an earlier step toward a difficult goal. Every discovery still gets its own retained exemplar for later continuation scheduling.
+
+The journal is bounded to 256 entries. Repeated events for one semantic state are coalesced to its best anchor. If the journal fills, stronger discoveries replace the weakest retained coverage events, so early noise cannot permanently hide late progress after the shared novelty latch has fired.
 
 ## One Expansion Per Run
 
-A run that made at least one semantic assertion discovery is **productive** and is expanded **exactly once**: `branching_factor` children are enqueued, anchored at its latest discovery. This holds no matter how many discoveries the run made. If one timeline discovers five new assertion states, it is still *one productive execution*, not five branching events. Sanitizer code coverage is reported separately and does not create frontier jobs.
+A run that made at least one semantic assertion discovery is **productive** and is expanded **exactly once**: `branching_factor` children are enqueued, anchored at its highest-priority discovery. This holds no matter how many discoveries the run made. If one timeline discovers five new assertion states, it is still *one productive execution*, not five branching events. Sanitizer code coverage is reported separately and does not create frontier jobs.
 
 A run with an empty journal discovered nothing the multiverse had not already seen. It is not punished, scored, or refilled — its branch simply produces no children and dies. This one rule replaces the entire energy system of the previous explorer (global budgets, per-mark allowances, reallocation pools, productive/barren classification): the only global limits are a per-seed run budget and a frontier size cap.
 
@@ -70,7 +73,7 @@ parallel `fork()` workers are worth the less reproducible search order.
 
 ## Who Decides Novelty
 
-Discovery detection lives in the shared assertion region (`moonpool-assertions`): each distinct discovery — a slot's first pass, a new bucket, a watermark improvement — is guarded by an atomic compare-and-swap latch. Whichever timeline wins the CAS journals the discovery; every other timeline, in any process, sees "already known". There is no check-then-merge race and no coverage bitmap to reconcile: the latch *is* the novelty decision, made exactly once, and the controller is the single owner of everything built on top of it (frontier, exemplars, statistics, bug recipes).
+Discovery detection lives in the shared assertion region (`moonpool-assertions`): first passes, new buckets, comparison-distance improvements, compound-frontier advances, and partial truth combinations are guarded by atomic shared state. Whichever timeline records the transition journals it; every other timeline, in any process, sees "already known". There is no check-then-merge race, and the controller is the single owner of everything built on top of these signals (frontier, exemplars, statistics, bug recipes).
 
 ## Bug Recipes
 

--- a/book/src/part5-building-on-top/05-exemplars-continuations.md
+++ b/book/src/part5-building-on-top/05-exemplars-continuations.md
@@ -6,7 +6,7 @@ Expansion alone is momentum: a productive run spawns a few children, and if a ch
 
 ## Semantic States
 
-Every discovery carries a **state id**: the assertion message hash for slot assertions, or the bucket hash (message plus identity keys) for `assert_sometimes_each!`. This is the Castlevania lesson from the problem chapter, applied through the macros you already write: the workload's assertions project the huge concrete state space into a tractable set of semantic buckets.
+Every discovery carries a **state id**: the assertion message hash for ordinary slot assertions, the site-plus-truth-combination hash for partial `assert_sometimes_all!` states, or the bucket hash (message plus identity keys) for `assert_sometimes_each!`. This is the Castlevania lesson from the problem chapter, applied through the macros you already write: the workload's assertions project the huge concrete state space into a tractable set of semantic buckets.
 
 ```rust,ignore
 assert_sometimes_each!("descended",

--- a/crates/moonpool-assertions/src/hooks.rs
+++ b/crates/moonpool-assertions/src/hooks.rs
@@ -38,6 +38,8 @@ pub enum DiscoveryKind {
     BucketFirst = 3,
     /// An `assert_sometimes_each!` bucket's quality score improved.
     BucketQuality = 4,
+    /// A new partial truth combination was observed at a `sometimes_all` site.
+    BooleanCombination = 5,
 }
 
 impl DiscoveryKind {
@@ -50,6 +52,7 @@ impl DiscoveryKind {
             2 => Some(Self::FrontierAdvance),
             3 => Some(Self::BucketFirst),
             4 => Some(Self::BucketQuality),
+            5 => Some(Self::BooleanCombination),
             _ => None,
         }
     }
@@ -67,10 +70,11 @@ pub struct DiscoveryHooks {
     /// accounting region.
     ///
     /// `state_id` identifies the semantic state that was discovered: the
-    /// assertion message hash for slot assertions, or the bucket hash
-    /// (message plus identity keys) for `sometimes_each` buckets. Watermark
-    /// and quality improvements reuse their site's id: the id names the
-    /// *place* in the semantic state space, the kind says how it advanced.
+    /// assertion message hash for ordinary slot assertions, a hash of the site
+    /// and truth combination for [`DiscoveryKind::BooleanCombination`], or the
+    /// bucket hash (message plus identity keys) for `sometimes_each` buckets.
+    /// Watermark and quality improvements reuse their site's id: the id names
+    /// the *place* in the semantic state space, the kind says how it advanced.
     pub on_discovery: fn(kind: DiscoveryKind, state_id: u64),
 }
 

--- a/crates/moonpool-assertions/src/slots.rs
+++ b/crates/moonpool-assertions/src/slots.rs
@@ -11,7 +11,7 @@
 //! it, so concurrent readers never observe a partially initialized slot.
 //!
 //! On a "discovery" (first Sometimes/Reachable pass, numeric watermark
-//! improvement, or frontier advance) the accounting calls
+//! improvement, frontier advance, or new partial boolean combination) the accounting calls
 //! [`crate::hooks::on_discovery`]. Each discovery is guarded by an atomic
 //! latch so it fires exactly once globally. With no hook installed this is a
 //! no-op (pure accounting); the exploration backend wires it to a per-run
@@ -111,12 +111,16 @@ pub struct AssertionSlot {
     pub watermark: i64,
     /// Watermark value at the last signalled discovery (for improvement detection).
     pub discovery_watermark: i64,
+    /// Bounded bloom bitmap of partial combinations seen by `sometimes_all`.
+    pub combination_bits: u64,
     /// Frontier: number of simultaneously true bools (for `BooleanSometimesAll`).
     pub frontier: u8,
+    /// Number of propositions in a `BooleanSometimesAll` assertion.
+    pub frontier_target: u8,
     /// Publication state: zero = unused, one = initializing, two = ready.
     published: u8,
     /// Padding for alignment.
-    pad: [u8; 6],
+    pad: [u8; 5],
     /// Assertion message string (null-terminated).
     pub msg: [u8; SLOT_MSG_LEN],
 }
@@ -143,6 +147,27 @@ pub fn msg_hash(msg: &str) -> u32 {
         h = h.wrapping_mul(0x0100_0193);
     }
     h
+}
+
+/// Stable fingerprint for one complete set of named boolean observations.
+fn boolean_combination_fingerprint(named_bools: &[(&str, bool)]) -> u64 {
+    let mut hash = 0xcbf2_9ce4_8422_2325_u64;
+    for (name, value) in named_bools {
+        for byte in name.as_bytes() {
+            hash ^= u64::from(*byte);
+            hash = hash.wrapping_mul(0x0100_0000_01b3);
+        }
+        hash ^= 0xff;
+        hash = hash.wrapping_mul(0x0100_0000_01b3);
+        hash ^= u64::from(*value);
+        hash = hash.wrapping_mul(0x0100_0000_01b3);
+    }
+    hash
+}
+
+/// Mix a site and proposition fingerprint into one semantic state id.
+fn boolean_combination_state_id(site_hash: u32, fingerprint: u64) -> u64 {
+    fingerprint ^ u64::from(site_hash).wrapping_mul(0x9e37_79b9_7f4a_7c15)
 }
 
 /// Update a monotonic watermark, returning whether this call advanced it.
@@ -249,8 +274,10 @@ unsafe fn find_or_alloc_slot(
         (*slot).fail_count = 0;
         (*slot).watermark = if maximize == 1 { i64::MIN } else { i64::MAX };
         (*slot).discovery_watermark = if maximize == 1 { i64::MIN } else { i64::MAX };
+        (*slot).combination_bits = 0;
         (*slot).frontier = 0;
-        (*slot).pad = [0; 6];
+        (*slot).frontier_target = 0;
+        (*slot).pad = [0; 5];
         (*slot).msg = msg_buf;
 
         published.store(SLOT_READY, Ordering::Release);
@@ -392,10 +419,14 @@ pub fn assertion_numeric(
         let wm = &*(&raw const (*slot).watermark).cast::<AtomicI64>();
         update_watermark(wm, left, maximize);
 
-        // For NumericSometimes: signal discovery when watermark improves past discovery_watermark
+        // Numeric guidance follows the comparison distance (`left - right`),
+        // matching Antithesis: a changing threshold must influence whether an
+        // observation is actually closer to satisfying the property. The
+        // public watermark above deliberately remains the best `left` value
+        // for human-readable reporting.
         if kind == AssertKind::NumericSometimes {
             let fw = &*(&raw const (*slot).discovery_watermark).cast::<AtomicI64>();
-            if update_watermark(fw, left, maximize) {
+            if update_watermark(fw, left.saturating_sub(right), maximize) {
                 crate::hooks::on_discovery(
                     crate::hooks::DiscoveryKind::WatermarkImprovement,
                     u64::from(hash),
@@ -407,9 +438,10 @@ pub fn assertion_numeric(
 
 /// Compound boolean assertion backing function (sometimes-all).
 ///
-/// Counts how many of the named booleans are simultaneously true.
-/// Maintains a frontier (max count seen). Signals a discovery when the frontier
-/// advances.
+/// Counts how many of the named booleans are simultaneously true. Maintains a
+/// frontier (max count seen) and a bounded bitmap of distinct partial truth
+/// combinations. Signals a discovery when the frontier advances or a new
+/// same-frontier combination is observed.
 ///
 /// This is a no-op if the assertion table is not initialized.
 pub fn assertion_sometimes_all(msg: &str, named_bools: &[(&str, bool)]) {
@@ -432,6 +464,9 @@ pub fn assertion_sometimes_all(msg: &str, named_bools: &[(&str, bool)]) {
     // via `unwrap_or(u8::MAX)` so we never panic.
     let true_count =
         u8::try_from(named_bools.iter().filter(|(_, v)| *v).count()).unwrap_or(u8::MAX);
+    let target = u8::try_from(named_bools.len()).unwrap_or(u8::MAX);
+    let fingerprint = boolean_combination_fingerprint(named_bools);
+    let combination_bit = 1_u64 << (fingerprint & 63);
 
     // Safety: slot points to valid memory.
     unsafe {
@@ -439,12 +474,28 @@ pub fn assertion_sometimes_all(msg: &str, named_bools: &[(&str, bool)]) {
         let pc = &*(&raw const (*slot).pass_count).cast::<AtomicU64>();
         pc.fetch_add(1, Ordering::Relaxed);
 
-        // Signal discovery only for the caller that advances the shared frontier.
+        let frontier_target = &*(&raw const (*slot).frontier_target).cast::<AtomicU8>();
+        frontier_target.fetch_max(target, Ordering::Relaxed);
+
+        // Record the partial combination even when a frontier advance wins the
+        // discovery for this encounter. That prevents the same combination
+        // from producing a redundant event on its next encounter. A 64-bit
+        // bloom bitmap bounds guidance per site; collisions lose optional
+        // combination hints but never assertion accounting or frontier data.
+        let combinations = &*(&raw const (*slot).combination_bits).cast::<AtomicU64>();
+        let previous_combinations = combinations.fetch_or(combination_bit, Ordering::Relaxed);
+        let new_combination = previous_combinations & combination_bit == 0;
+
         let fr = &*(&raw const (*slot).frontier).cast::<AtomicU8>();
         if true_count > fr.fetch_max(true_count, Ordering::Relaxed) {
             crate::hooks::on_discovery(
                 crate::hooks::DiscoveryKind::FrontierAdvance,
                 u64::from(hash),
+            );
+        } else if true_count > 0 && new_combination {
+            crate::hooks::on_discovery(
+                crate::hooks::DiscoveryKind::BooleanCombination,
+                boolean_combination_state_id(hash, fingerprint),
             );
         }
     }
@@ -495,7 +546,14 @@ pub fn assertion_read_all() -> Vec<AssertionSlotSnapshot> {
                         .load(Ordering::Relaxed),
                     watermark: (&*std::ptr::addr_of!((*slot).watermark).cast::<AtomicI64>())
                         .load(Ordering::Relaxed),
+                    combinations_seen: (&*std::ptr::addr_of!((*slot).combination_bits)
+                        .cast::<AtomicU64>())
+                        .load(Ordering::Relaxed)
+                        .count_ones(),
                     frontier: (&*std::ptr::addr_of!((*slot).frontier).cast::<AtomicU8>())
+                        .load(Ordering::Relaxed),
+                    frontier_target: (&*std::ptr::addr_of!((*slot).frontier_target)
+                        .cast::<AtomicU8>())
                         .load(Ordering::Relaxed),
                 })
             })
@@ -518,13 +576,31 @@ pub struct AssertionSlotSnapshot {
     pub fail_count: u64,
     /// Best watermark value (for numeric assertions).
     pub watermark: i64,
+    /// Number of distinct partial-combination bloom bits observed.
+    pub combinations_seen: u32,
     /// Frontier value (for `BooleanSometimesAll`).
     pub frontier: u8,
+    /// Frontier target (the number of `BooleanSometimesAll` propositions).
+    pub frontier_target: u8,
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::RefCell;
+
+    thread_local! {
+        static TEST_DISCOVERIES: RefCell<Vec<(crate::hooks::DiscoveryKind, u64)>> =
+            const { RefCell::new(Vec::new()) };
+    }
+
+    fn record_discovery(kind: crate::hooks::DiscoveryKind, state_id: u64) {
+        TEST_DISCOVERIES.with(|events| events.borrow_mut().push((kind, state_id)));
+    }
+
+    fn take_discoveries() -> Vec<(crate::hooks::DiscoveryKind, u64)> {
+        TEST_DISCOVERIES.with(|events| std::mem::take(&mut *events.borrow_mut()))
+    }
 
     #[test]
     fn test_msg_hash_deterministic() {
@@ -553,8 +629,9 @@ mod tests {
         // Verify AssertionSlot size for shared memory layout stability.
         // msg_hash(4) + kind(1) + must_hit(1) + maximize(1) + discovered(1) +
         // pass_count(8) + fail_count(8) + watermark(8) + discovery_watermark(8) +
-        // frontier(1) + published(1) + _pad(6) + msg(64) = 112
-        assert_eq!(std::mem::size_of::<AssertionSlot>(), 112);
+        // combination_bits(8) + frontier(1) + frontier_target(1) + published(1) +
+        // _pad(5) + msg(64) = 120
+        assert_eq!(std::mem::size_of::<AssertionSlot>(), 120);
     }
 
     #[test]
@@ -644,18 +721,93 @@ mod tests {
     }
 
     #[test]
-    fn test_sometimes_all_frontier_only_moves_forward() {
+    fn numeric_guidance_tracks_comparison_distance_when_threshold_moves() {
         crate::region::init();
+        crate::hooks::set_discovery_hooks(crate::hooks::DiscoveryHooks {
+            on_discovery: record_discovery,
+        });
+        let _ = take_discoveries();
+
+        assertion_numeric(
+            AssertKind::NumericSometimes,
+            AssertCmp::Gt,
+            true,
+            10,
+            5,
+            "dynamic threshold",
+        );
+        // The left operand improves, but the comparison distance falls from
+        // 5 to -10, so this must not guide the explorer in the wrong direction.
+        assertion_numeric(
+            AssertKind::NumericSometimes,
+            AssertCmp::Gt,
+            true,
+            20,
+            30,
+            "dynamic threshold",
+        );
+        assertion_numeric(
+            AssertKind::NumericSometimes,
+            AssertCmp::Gt,
+            true,
+            21,
+            10,
+            "dynamic threshold",
+        );
+
+        let discoveries = take_discoveries();
+        assert_eq!(discoveries.len(), 2);
+        assert!(
+            discoveries
+                .iter()
+                .all(|(kind, _)| { *kind == crate::hooks::DiscoveryKind::WatermarkImprovement })
+        );
+        let slots = assertion_read_all();
+        assert_eq!(slots[0].watermark, 21, "reports still show best left value");
+
+        crate::hooks::clear_discovery_hooks();
+        crate::region::clear();
+    }
+
+    #[test]
+    fn sometimes_all_tracks_frontier_target_and_distinct_partial_combinations() {
+        crate::region::init();
+        crate::hooks::set_discovery_hooks(crate::hooks::DiscoveryHooks {
+            on_discovery: record_discovery,
+        });
+        let _ = take_discoveries();
 
         assertion_sometimes_all("frontier", &[("a", true), ("b", false), ("c", false)]);
-        assertion_sometimes_all("frontier", &[("a", false), ("b", false), ("c", false)]);
+        // Same score as the first encounter, different proposition. Count-only
+        // guidance used to collapse these two semantically different states.
+        assertion_sometimes_all("frontier", &[("a", false), ("b", true), ("c", false)]);
+        assertion_sometimes_all("frontier", &[("a", true), ("b", false), ("c", false)]);
         assertion_sometimes_all("frontier", &[("a", true), ("b", true), ("c", false)]);
 
         let slots = assertion_read_all();
         assert_eq!(slots.len(), 1);
         assert_eq!(slots[0].frontier, 2);
-        assert_eq!(slots[0].pass_count, 3);
+        assert_eq!(slots[0].frontier_target, 3);
+        assert_eq!(slots[0].combinations_seen, 3);
+        assert_eq!(slots[0].pass_count, 4);
 
+        let discoveries = take_discoveries();
+        assert_eq!(
+            discoveries
+                .iter()
+                .filter(|(kind, _)| *kind == crate::hooks::DiscoveryKind::FrontierAdvance)
+                .count(),
+            2
+        );
+        assert_eq!(
+            discoveries
+                .iter()
+                .filter(|(kind, _)| *kind == crate::hooks::DiscoveryKind::BooleanCombination)
+                .count(),
+            1
+        );
+
+        crate::hooks::clear_discovery_hooks();
         crate::region::clear();
     }
 }

--- a/crates/moonpool-explorer/README.md
+++ b/crates/moonpool-explorer/README.md
@@ -12,10 +12,10 @@ randomness.
 
 ## How: Replay and Continue
 
-When an `assert_sometimes!`, `assert_reachable!`, bucket, or guidance watermark
-makes globally new progress, Moonpool records the current RNG call count. The
-controller retains a recipe for that timeline and enqueues bounded
-continuations:
+When an `assert_sometimes!`, `assert_reachable!`, bucket, partial truth
+combination, or guidance watermark makes globally new progress, Moonpool
+records the current RNG call count. The controller retains a recipe for that
+timeline and enqueues bounded continuations:
 
 ```text
 root seed 42

--- a/crates/moonpool-explorer/src/controller.rs
+++ b/crates/moonpool-explorer/src/controller.rs
@@ -35,8 +35,8 @@
 //!    in-process when `workers == 0`).
 //! 3. A run whose journal is non-empty (it made globally-new discoveries) is
 //!    expanded **exactly once**: `branching_factor` children are enqueued,
-//!    anchored at the run's latest discovery. Every discovery also registers
-//!    a bounded exemplar for its semantic state.
+//!    anchored at its highest-priority discovery (latest breaks ties). Every
+//!    discovery also registers a bounded exemplar for its semantic state.
 //! 4. A run with an empty journal produced nothing new; its branch dies.
 //! 5. When the frontier drains and budget remains, the controller schedules
 //!    continuations from the least-visited known state (ties prefer
@@ -471,18 +471,17 @@ impl Explorer {
         }
 
         // Barren run: nothing globally new — the branch dies here.
-        let Some(anchor_event) = events.iter().max_by_key(|e| e.call_count) else {
+        let Some(anchor_event) = select_anchor(events) else {
             return;
         };
-        let anchor_event = *anchor_event;
 
         for event in events {
             self.register_state(&job.recipe, event);
         }
 
-        // One expansion per productive run, anchored at the latest discovery:
-        // children replay through every state this run reached and diverge
-        // just past the deepest one.
+        // One expansion per productive run, anchored at the most useful
+        // discovery. This keeps late plain-coverage noise from pulling the
+        // immediate branch away from earlier monotonic progress.
         if job.recipe.len() < self.config.max_recipe_len {
             self.stats.expansions += 1;
             self.expand_from(
@@ -635,6 +634,18 @@ fn derive_seed(
     hash
 }
 
+/// Choose the semantic discovery that should drive immediate expansion.
+///
+/// Progress toward an assertion goal outranks structured state novelty, which
+/// outranks a one-shot coverage hit. Within the same class, the latest replay
+/// coordinate preserves the deepest prefix.
+fn select_anchor(events: &[DiscoveryEvent]) -> Option<DiscoveryEvent> {
+    events
+        .iter()
+        .max_by_key(|event| (event.guidance_priority(), event.call_count))
+        .copied()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -699,5 +710,23 @@ mod tests {
         config
             .validate()
             .expect("in-process minimum should be valid");
+    }
+
+    #[test]
+    fn semantic_progress_outranks_later_plain_coverage() {
+        let events = [
+            DiscoveryEvent {
+                call_count: 12,
+                kind: moonpool_assertions::DiscoveryKind::WatermarkImprovement,
+                state_id: 1,
+            },
+            DiscoveryEvent {
+                call_count: 900,
+                kind: moonpool_assertions::DiscoveryKind::SometimesPass,
+                state_id: 2,
+            },
+        ];
+
+        assert_eq!(select_anchor(&events), Some(events[0]));
     }
 }

--- a/crates/moonpool-explorer/src/journal.rs
+++ b/crates/moonpool-explorer/src/journal.rs
@@ -23,10 +23,11 @@ use moonpool_assertions::DiscoveryKind;
 
 /// Maximum number of discovery events retained per run.
 ///
-/// A run that makes more discoveries than this keeps the first
-/// `MAX_JOURNAL_ENTRIES`. One run is expanded at most once regardless of how
-/// many discoveries it made, so truncation only loses exemplar anchors, never
-/// exploration momentum.
+/// Entries are coalesced by semantic state. If more distinct states are
+/// discovered, the journal retains the highest-priority, deepest anchors:
+/// monotonic progress first, then structured state novelty, then one-shot
+/// coverage. This prevents early coverage noise from permanently hiding a
+/// later progress anchor after the accounting layer's global latch has fired.
 pub const MAX_JOURNAL_ENTRIES: usize = 256;
 
 /// One globally-new discovery observed during a run.
@@ -54,6 +55,22 @@ impl DiscoveryEvent {
                 | DiscoveryKind::BucketQuality
         )
     }
+
+    /// Semantic priority used for bounded journaling and branch selection.
+    pub(crate) fn guidance_priority(&self) -> u8 {
+        if self.is_progress() {
+            2
+        } else {
+            u8::from(matches!(
+                self.kind,
+                DiscoveryKind::BucketFirst | DiscoveryKind::BooleanCombination
+            ))
+        }
+    }
+
+    fn retention_key(&self) -> (u8, u64) {
+        (self.guidance_priority(), self.call_count)
+    }
 }
 
 thread_local! {
@@ -76,18 +93,43 @@ pub fn set_rng_count_hook(get_count: fn() -> u64) {
 pub(crate) fn install_hooks() {
     fn on_discovery(kind: DiscoveryKind, state_id: u64) {
         let call_count = RNG_COUNT_HOOK.with(Cell::get)();
-        JOURNAL.with(|j| {
-            let mut journal = j.borrow_mut();
-            if journal.len() < MAX_JOURNAL_ENTRIES {
-                journal.push(DiscoveryEvent {
-                    call_count,
-                    kind,
-                    state_id,
-                });
-            }
+        record(DiscoveryEvent {
+            call_count,
+            kind,
+            state_id,
         });
     }
     moonpool_assertions::set_discovery_hooks(moonpool_assertions::DiscoveryHooks { on_discovery });
+}
+
+/// Coalesce or retain one discovery according to semantic priority.
+fn record(event: DiscoveryEvent) {
+    JOURNAL.with(|journal| {
+        let mut journal = journal.borrow_mut();
+        if let Some(existing) = journal
+            .iter_mut()
+            .find(|existing| existing.state_id == event.state_id)
+        {
+            if event.retention_key() > existing.retention_key() {
+                *existing = event;
+            }
+            return;
+        }
+        if journal.len() < MAX_JOURNAL_ENTRIES {
+            journal.push(event);
+            return;
+        }
+        let Some((weakest_index, weakest)) = journal
+            .iter()
+            .enumerate()
+            .min_by_key(|(_, candidate)| candidate.retention_key())
+        else {
+            return;
+        };
+        if event.retention_key() > weakest.retention_key() {
+            journal[weakest_index] = event;
+        }
+    });
 }
 
 /// Clear the journal before a run.
@@ -138,8 +180,69 @@ mod tests {
         };
         assert!(!mk(DiscoveryKind::SometimesPass).is_progress());
         assert!(!mk(DiscoveryKind::BucketFirst).is_progress());
+        assert!(!mk(DiscoveryKind::BooleanCombination).is_progress());
         assert!(mk(DiscoveryKind::WatermarkImprovement).is_progress());
         assert!(mk(DiscoveryKind::FrontierAdvance).is_progress());
         assert!(mk(DiscoveryKind::BucketQuality).is_progress());
+        assert!(
+            mk(DiscoveryKind::WatermarkImprovement).guidance_priority()
+                > mk(DiscoveryKind::BooleanCombination).guidance_priority()
+        );
+        assert!(
+            mk(DiscoveryKind::BooleanCombination).guidance_priority()
+                > mk(DiscoveryKind::SometimesPass).guidance_priority()
+        );
+    }
+
+    #[test]
+    fn journal_coalesces_a_state_to_its_best_latest_anchor() {
+        clear();
+        record(DiscoveryEvent {
+            call_count: 10,
+            kind: DiscoveryKind::BucketFirst,
+            state_id: 7,
+        });
+        record(DiscoveryEvent {
+            call_count: 20,
+            kind: DiscoveryKind::BucketQuality,
+            state_id: 7,
+        });
+        record(DiscoveryEvent {
+            call_count: 30,
+            kind: DiscoveryKind::SometimesPass,
+            state_id: 7,
+        });
+
+        assert_eq!(
+            take(),
+            vec![DiscoveryEvent {
+                call_count: 20,
+                kind: DiscoveryKind::BucketQuality,
+                state_id: 7,
+            }]
+        );
+    }
+
+    #[test]
+    fn full_journal_retains_late_progress_over_coverage_noise() {
+        clear();
+        for state_id in 0..u64::try_from(MAX_JOURNAL_ENTRIES).expect("journal bound fits in u64") {
+            record(DiscoveryEvent {
+                call_count: state_id,
+                kind: DiscoveryKind::SometimesPass,
+                state_id,
+            });
+        }
+        record(DiscoveryEvent {
+            call_count: 1,
+            kind: DiscoveryKind::WatermarkImprovement,
+            state_id: u64::MAX,
+        });
+
+        let events = take();
+        assert_eq!(events.len(), MAX_JOURNAL_ENTRIES);
+        assert!(events.iter().any(|event| {
+            event.state_id == u64::MAX && event.kind == DiscoveryKind::WatermarkImprovement
+        }));
     }
 }

--- a/crates/moonpool-explorer/src/lib.rs
+++ b/crates/moonpool-explorer/src/lib.rs
@@ -25,10 +25,10 @@
 //!
 //! Discovery     A globally-new interesting state: the first pass of an
 //!               assert_sometimes!/assert_reachable!, a new
-//!               assert_sometimes_each! bucket, a numeric watermark or
-//!               frontier or quality improvement. Guarded by CAS latches in
-//!               the shared assertion region, so each distinct discovery is
-//!               observed exactly once across all timelines and seeds.
+//!               assert_sometimes_each! bucket, a partial truth combination,
+//!               or a numeric/frontier/quality improvement. Guarded by atomic
+//!               state in the shared assertion region, so each recorded
+//!               transition is observed once across all timelines and seeds.
 //!
 //! Journal       The list of discoveries one run made, each stamped with the
 //!               RNG call count where it happened.

--- a/crates/moonpool-explorer/src/worker.rs
+++ b/crates/moonpool-explorer/src/worker.rs
@@ -204,6 +204,11 @@ mod tests {
                 kind: DiscoveryKind::BucketQuality,
                 state_id: 42,
             },
+            DiscoveryEvent {
+                call_count: 123,
+                kind: DiscoveryKind::BooleanCombination,
+                state_id: 77,
+            },
         ];
         pool.clear_slot(0);
         pool.clear_slot(1);

--- a/crates/moonpool-sim/src/chaos/assertions.rs
+++ b/crates/moonpool-sim/src/chaos/assertions.rs
@@ -285,58 +285,64 @@ pub fn validate_assertion_contracts() -> (Vec<String>, Vec<String>) {
                         .push(format!("assert_always!('{}') was never reached", slot.msg));
                 }
             }
-            Some(moonpool_assertions::AssertKind::AlwaysOrUnreachable) => {
-                if slot.fail_count > 0 {
-                    always_violations.push(format!(
-                        "assert_always_or_unreachable!('{}') failed {} times out of {}",
-                        slot.msg, slot.fail_count, total
-                    ));
-                }
+            Some(moonpool_assertions::AssertKind::AlwaysOrUnreachable) if slot.fail_count > 0 => {
+                always_violations.push(format!(
+                    "assert_always_or_unreachable!('{}') failed {} times out of {}",
+                    slot.msg, slot.fail_count, total
+                ));
             }
-            Some(moonpool_assertions::AssertKind::Sometimes) => {
-                if total > 0 && slot.pass_count == 0 {
-                    coverage_violations.push(format!(
-                        "assert_sometimes!('{}') has 0% success rate ({} checks)",
-                        slot.msg, total
-                    ));
-                }
+            Some(moonpool_assertions::AssertKind::Sometimes)
+                if total > 0 && slot.pass_count == 0 =>
+            {
+                coverage_violations.push(format!(
+                    "assert_sometimes!('{}') has 0% success rate ({} checks)",
+                    slot.msg, total
+                ));
             }
-            Some(moonpool_assertions::AssertKind::Reachable) => {
-                if slot.pass_count == 0 {
-                    coverage_violations.push(format!(
-                        "assert_reachable!('{}') was never reached",
-                        slot.msg
-                    ));
-                }
+            Some(moonpool_assertions::AssertKind::Reachable) if slot.pass_count == 0 => {
+                coverage_violations.push(format!(
+                    "assert_reachable!('{}') was never reached",
+                    slot.msg
+                ));
             }
-            Some(moonpool_assertions::AssertKind::Unreachable) => {
-                if slot.pass_count > 0 {
-                    always_violations.push(format!(
-                        "assert_unreachable!('{}') was reached {} times",
-                        slot.msg, slot.pass_count
-                    ));
-                }
+            Some(moonpool_assertions::AssertKind::Unreachable) if slot.pass_count > 0 => {
+                always_violations.push(format!(
+                    "assert_unreachable!('{}') was reached {} times",
+                    slot.msg, slot.pass_count
+                ));
             }
-            Some(moonpool_assertions::AssertKind::NumericAlways) => {
-                if slot.fail_count > 0 {
-                    always_violations.push(format!(
-                        "numeric assert_always ('{}') failed {} times out of {}",
-                        slot.msg, slot.fail_count, total
-                    ));
-                }
+            Some(moonpool_assertions::AssertKind::NumericAlways) if slot.fail_count > 0 => {
+                always_violations.push(format!(
+                    "numeric assert_always ('{}') failed {} times out of {}",
+                    slot.msg, slot.fail_count, total
+                ));
             }
-            Some(moonpool_assertions::AssertKind::NumericSometimes) => {
-                if total > 0 && slot.pass_count == 0 {
-                    coverage_violations.push(format!(
-                        "numeric assert_sometimes ('{}') has 0% success rate ({} checks)",
-                        slot.msg, total
-                    ));
-                }
+            Some(moonpool_assertions::AssertKind::NumericSometimes)
+                if total > 0 && slot.pass_count == 0 =>
+            {
+                coverage_violations.push(format!(
+                    "numeric assert_sometimes ('{}') has 0% success rate ({} checks)",
+                    slot.msg, total
+                ));
             }
-            Some(moonpool_assertions::AssertKind::BooleanSometimesAll) | None => {
-                // BooleanSometimesAll: no simple pass/fail violation contract
-                // (the frontier tracking is the guidance mechanism)
+            Some(moonpool_assertions::AssertKind::BooleanSometimesAll)
+                if slot.frontier_target > 0 && slot.frontier < slot.frontier_target =>
+            {
+                coverage_violations.push(format!(
+                    "assert_sometimes_all!('{}') reached frontier {}/{}",
+                    slot.msg, slot.frontier, slot.frontier_target
+                ));
             }
+            Some(
+                moonpool_assertions::AssertKind::AlwaysOrUnreachable
+                | moonpool_assertions::AssertKind::Sometimes
+                | moonpool_assertions::AssertKind::Reachable
+                | moonpool_assertions::AssertKind::Unreachable
+                | moonpool_assertions::AssertKind::NumericAlways
+                | moonpool_assertions::AssertKind::NumericSometimes
+                | moonpool_assertions::AssertKind::BooleanSometimesAll,
+            )
+            | None => {}
         }
     }
 
@@ -866,5 +872,29 @@ mod tests {
         let violations = validate_assertion_contracts();
         // May or may not be empty, but should not panic
         let _ = violations;
+    }
+
+    #[test]
+    fn sometimes_all_contract_requires_every_proposition() {
+        moonpool_assertions::init();
+        moonpool_assertions::reset();
+        moonpool_assertions::assertion_sometimes_all(
+            "compound contract",
+            &[("a", true), ("b", false)],
+        );
+
+        let (_, coverage) = validate_assertion_contracts();
+        assert_eq!(
+            coverage,
+            vec!["assert_sometimes_all!('compound contract') reached frontier 1/2"]
+        );
+
+        moonpool_assertions::assertion_sometimes_all(
+            "compound contract",
+            &[("a", true), ("b", true)],
+        );
+        let (_, coverage) = validate_assertion_contracts();
+        assert!(coverage.is_empty());
+        moonpool_assertions::clear();
     }
 }

--- a/crates/moonpool-sim/src/runner/builder.rs
+++ b/crates/moonpool-sim/src/runner/builder.rs
@@ -1171,10 +1171,9 @@ impl SimulationBuilder {
         }
     }
 
-    /// Scan all assertion slots from shared memory: insert the messages
-    /// of every "passed" Sometimes/Reachable slot into `reached`, log a
-    /// warning for every still-unreached slot, and return the count of
-    /// unique Sometimes/Reachable message strings observed.
+    /// Scan all assertion slots from shared memory: insert the messages of
+    /// every satisfied coverage assertion into `reached`, warn for incomplete
+    /// sites, and return the number of unique observed coverage contracts.
     fn scan_assertion_slots(reached: &mut std::collections::HashSet<String>) -> usize {
         let slots = moonpool_assertions::assertion_read_all();
         for slot in &slots {
@@ -1183,17 +1182,26 @@ impl SimulationBuilder {
                     kind,
                     moonpool_assertions::AssertKind::Sometimes
                         | moonpool_assertions::AssertKind::Reachable
+                        | moonpool_assertions::AssertKind::BooleanSometimesAll
                 )
             {
-                if slot.pass_count > 0 {
+                let satisfied = match kind {
+                    moonpool_assertions::AssertKind::BooleanSometimesAll => {
+                        slot.frontier_target > 0 && slot.frontier >= slot.frontier_target
+                    }
+                    _ => slot.pass_count > 0,
+                };
+                if satisfied {
                     reached.insert(slot.msg.clone());
                 } else if !reached.contains(&slot.msg) {
                     tracing::warn!(
-                        "UNREACHED slot: kind={:?} msg={:?} pass={} fail={}",
+                        "INCOMPLETE coverage slot: kind={:?} msg={:?} pass={} fail={} frontier={}/{}",
                         kind,
                         slot.msg,
                         slot.pass_count,
-                        slot.fail_count
+                        slot.fail_count,
+                        slot.frontier,
+                        slot.frontier_target
                     );
                 }
             }
@@ -1206,6 +1214,7 @@ impl SimulationBuilder {
                         k,
                         moonpool_assertions::AssertKind::Sometimes
                             | moonpool_assertions::AssertKind::Reachable
+                            | moonpool_assertions::AssertKind::BooleanSometimesAll
                     )
                 })
             })
@@ -1739,7 +1748,7 @@ fn build_assertion_details(
                     }
                 }
                 AssertKind::BooleanSometimesAll => {
-                    if slot.frontier > 0 {
+                    if slot.frontier_target > 0 && slot.frontier >= slot.frontier_target {
                         AssertionStatus::Pass
                     } else {
                         AssertionStatus::Miss
@@ -1754,6 +1763,8 @@ fn build_assertion_details(
                 fail_count: slot.fail_count,
                 watermark: slot.watermark,
                 frontier: slot.frontier,
+                frontier_target: slot.frontier_target,
+                combinations_seen: slot.combinations_seen,
                 status,
             })
         })
@@ -1795,6 +1806,39 @@ mod tests {
 
     use crate::SimulationResult;
     use crate::runner::context::SimContext;
+
+    #[test]
+    fn sometimes_all_is_a_miss_until_the_full_frontier_is_reached() {
+        let partial = moonpool_assertions::AssertionSlotSnapshot {
+            msg: "cluster ready".to_string(),
+            kind: moonpool_assertions::AssertKind::BooleanSometimesAll as u8,
+            must_hit: 1,
+            pass_count: 4,
+            fail_count: 0,
+            watermark: 0,
+            combinations_seen: 3,
+            frontier: 2,
+            frontier_target: 3,
+        };
+
+        let details = build_assertion_details(std::slice::from_ref(&partial));
+        assert_eq!(
+            details[0].status,
+            crate::runner::report::AssertionStatus::Miss
+        );
+        assert_eq!(details[0].frontier_target, 3);
+        assert_eq!(details[0].combinations_seen, 3);
+
+        let complete = moonpool_assertions::AssertionSlotSnapshot {
+            frontier: 3,
+            ..partial
+        };
+        let details = build_assertion_details(&[complete]);
+        assert_eq!(
+            details[0].status,
+            crate::runner::report::AssertionStatus::Pass
+        );
+    }
 
     struct BasicWorkload;
 

--- a/crates/moonpool-sim/src/runner/display.rs
+++ b/crates/moonpool-sim/src/runner/display.rs
@@ -428,9 +428,11 @@ fn write_assertions(w: &mut impl Write, details: &[AssertionDetail], color: bool
             }
             AssertKind::BooleanSometimesAll => {
                 format!(
-                    "{} calls  frontier: {}",
+                    "{} calls  frontier: {}/{}  combinations: {}",
                     fmt_num(detail.pass_count),
                     detail.frontier,
+                    detail.frontier_target,
+                    detail.combinations_seen,
                 )
             }
             _ => {

--- a/crates/moonpool-sim/src/runner/report.rs
+++ b/crates/moonpool-sim/src/runner/report.rs
@@ -137,6 +137,10 @@ pub struct AssertionDetail {
     pub watermark: i64,
     /// Frontier value (for `BooleanSometimesAll`).
     pub frontier: u8,
+    /// Frontier target (number of `BooleanSometimesAll` propositions).
+    pub frontier_target: u8,
+    /// Approximate number of distinct truth combinations observed.
+    pub combinations_seen: u32,
     /// Computed status based on kind and counts.
     pub status: AssertionStatus,
 }
@@ -485,12 +489,14 @@ fn fmt_assertion_detail(f: &mut fmt::Formatter<'_>, detail: &AssertionDetail) ->
         ),
         AssertKind::BooleanSometimesAll => writeln!(
             f,
-            "  {}  [{:<10}]  {:<34}  {} calls  frontier: {}",
+            "  {}  [{:<10}]  {:<34}  {} calls  frontier: {}/{}  combinations: {}",
             status_tag,
             kind_tag,
             quoted_msg,
             fmt_num(detail.pass_count),
-            detail.frontier
+            detail.frontier,
+            detail.frontier_target,
+            detail.combinations_seen
         ),
         _ => writeln!(
             f,


### PR DESCRIPTION
## Summary

- guide numeric assertions by comparison distance instead of the left operand alone
- distinguish partial `assert_sometimes_all!` combinations and enforce complete frontier coverage
- retain and select semantically valuable explorer anchors under journal pressure
- update the book and LLM guidance for the new behavior

## Validation

- `nix develop --command cargo fmt`
- `nix develop --command cargo clippy`
- `nix develop --command cargo nextest run` (543 passed)
- `nix develop --command cargo clippy -p moonpool-sim --no-default-features --all-targets -- -D warnings`
- `nix develop --command cargo check --target wasm32-unknown-unknown -p moonpool-sim --no-default-features`
- `nix develop --command mdbook build book/`