### PR TITLE
fix(moonpool-sim): make replay lifecycle ordering deterministic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,4 @@ async_fn_in_trait = "allow"
 
 [workspace.lints.clippy]
 pedantic = { level = "warn", priority = -1 }
+disallowed_types = "deny"

--- a/book/src/appendix/01-assertion-reference.md
+++ b/book/src/appendix/01-assertion-reference.md
@@ -195,7 +195,7 @@ These are only meaningful with enough iterations for statistical coverage. A sin
 | `record_always_violation()` | Increment the thread-local violation counter (called by always-type macros) |
 | `reset_always_violations()` | Reset the violation counter (called at the start of each iteration) |
 | `has_always_violations() -> bool` | Check if any always-type violation occurred this iteration |
-| `get_assertion_results() -> HashMap<String, AssertionStats>` | Read all assertion statistics from shared memory |
+| `assertion_results() -> BTreeMap<String, AssertionStats>` | Read all assertion statistics from shared memory in deterministic key order |
 | `reset_assertion_results()` | Zero the shared memory assertion table (between iterations) |
 | `skip_next_assertion_reset()` | Prevent the next reset (used by multi-seed exploration) |
 | `panic_on_assertion_violations(report)` | Panic if the report contains any assertion violations |

--- a/book/src/appendix/06-sim-compatibility.md
+++ b/book/src/appendix/06-sim-compatibility.md
@@ -70,10 +70,10 @@ Every random decision must be seeded by the simulation. A single ungoverned `thr
 
 | Forbidden | Use instead |
 |-----------|-------------|
-| `HashMap` / `HashSet` with default `RandomState` | `BTreeMap` / `BTreeSet`, or `HashMap` with a fixed `BuildHasher` |
-| Iterating a `HashMap` and acting on order | Sort keys explicitly, or use an ordered map |
+| `HashMap` / `HashSet` | `BTreeMap` / `BTreeSet` |
+| Iterating an unordered dependency collection | Copy into a `Vec` and sort before acting on it |
 
-`HashMap`'s default hasher randomizes iteration order per process. That is fatal under fork-based exploration where children must replay the parent's behavior.
+`HashMap`'s default hasher randomizes iteration order per process. That is fatal under replay and fork-based exploration. Moonpool enforces this internally with Clippy's `disallowed_types` lint so unordered standard collections cannot silently re-enter simulation infrastructure.
 
 ## 7. Type bounds
 

--- a/book/src/part1-why/03-mocks-to-simulation.md
+++ b/book/src/part1-why/03-mocks-to-simulation.md
@@ -41,7 +41,7 @@ Not every simulated implementation needs full fidelity. There is a spectrum.
 
 **No-op**: the simplest fake. `sleep` returns immediately, `send` discards the message. Useful for testing pure logic that happens to call I/O functions.
 
-**In-memory**: messages go into a queue, disk writes go into a HashMap. Fast, deterministic, but does not model timing, failures, or ordering.
+**In-memory**: messages go into a queue, disk writes go into a `BTreeMap`. Fast and deterministic, but does not model timing, failures, or ordering.
 
 **Controlled simulation**: messages are delayed by randomized amounts, connections drop according to a fault schedule, disk writes can be torn or corrupted. This is where bugs hide, because the system must handle not just the happy path but all the ways the real world deviates from it. Critically, these trait-based fakes scale across the entire codebase. You write each implementation once, and every component that uses the trait gets simulation for free. No per-test mock setup. No maintenance burden that grows with the test suite.
 

--- a/book/src/part2-foundations/09-process.md
+++ b/book/src/part2-foundations/09-process.md
@@ -37,7 +37,7 @@ The factory is called once per process per boot. Three processes with two reboot
 
 This is the rule you must internalize: **all in-memory state is lost on reboot**.
 
-If your Process has a `HashMap<String, Vec<u8>>` field tracking client sessions, that map is gone after a reboot. The new instance from the factory starts empty. Only data written to the simulated storage layer survives.
+If your Process has a `BTreeMap<String, Vec<u8>>` field tracking client sessions, that map is gone after a reboot. The new instance from the factory starts empty. Only data written to the simulated storage layer survives.
 
 This matches reality. When a server process crashes and restarts, it does not magically recover its heap. It reads persistent state from disk and rebuilds from there.
 

--- a/book/src/part3-building/02-defining-process.md
+++ b/book/src/part3-building/02-defining-process.md
@@ -31,7 +31,7 @@ impl Process for KvServer {
     async fn run(&mut self, ctx: &SimContext) -> SimulationResult<()> {
         let listener = ctx.network().bind(ctx.my_ip()).await?;
 
-        let mut store: HashMap<String, Vec<u8>> = HashMap::new();
+        let mut store: BTreeMap<String, Vec<u8>> = BTreeMap::new();
 
         loop {
             if ctx.shutdown().is_cancelled() {
@@ -65,7 +65,7 @@ Walk through this line by line.
 
 **Binding the listener**: `ctx.network().bind(ctx.my_ip())` creates a TCP listener on the process's assigned IP. In the simulated world, this registers the IP for incoming connections. No real ports are opened.
 
-**The store**: A plain `HashMap` that lives on the stack. When this process crashes, the HashMap vanishes. When the factory creates a new instance, it starts with an empty map. This is the "all in-memory state is lost on reboot" principle in action.
+**The store**: A plain `BTreeMap` that lives on the stack. When this process crashes, the map vanishes. When the factory creates a new instance, it starts empty. This is the "all in-memory state is lost on reboot" principle in action; the ordered map also keeps iteration deterministic.
 
 **The main loop**: We loop forever, checking the shutdown token each iteration. `ctx.shutdown().is_cancelled()` returns `true` during graceful reboots, giving us a chance to break cleanly. For crash reboots, the framework cancels the entire future, so we never reach this check.
 
@@ -80,7 +80,7 @@ the provider boundary directly:
 ```rust
 async fn handle_connection(
     mut stream: SimTcpStream,
-    store: &mut HashMap<String, Vec<u8>>,
+    store: &mut BTreeMap<String, Vec<u8>>,
 ) {
     let mut buf = vec![0u8; 4096];
     loop {

--- a/book/src/part3-building/03-writing-workload.md
+++ b/book/src/part3-building/03-writing-workload.md
@@ -19,7 +19,7 @@ struct KvWorkload {
     /// Number of operations per run
     num_ops: usize,
     /// Reference model: what we expect the server to contain
-    model: HashMap<String, Vec<u8>>,
+    model: BTreeMap<String, Vec<u8>>,
     /// Keys we use for operations
     keys: Vec<String>,
 }

--- a/book/src/part3-building/04-simulation-builder.md
+++ b/book/src/part3-building/04-simulation-builder.md
@@ -104,7 +104,7 @@ impl Invariant for AgreementInvariant {
     fn check(&self, state: &StateHandle, _sim_time_ms: u64) {
         if let Some(model) = state.get::<ConsensusModel>("consensus_model") {
             for (slot, values) in &model.committed_values {
-                let unique: HashSet<_> = values.iter().collect();
+                let unique: BTreeSet<_> = values.iter().collect();
                 assert_always!(unique.len() <= 1, "agreement violated");
             }
         }

--- a/book/src/part3-building/17-events-and-invariants.md
+++ b/book/src/part3-building/17-events-and-invariants.md
@@ -91,13 +91,13 @@ Each node emits `tracing::info!(slot, value, "commit")` whenever it commits. The
 
 ```rust
 use std::cell::{Cell, RefCell};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use moonpool_sim::{Invariant, TraceQuery, assert_always};
 
 #[derive(Default)]
 pub struct AgreementInvariant {
     cursor: Cell<usize>,
-    committed: RefCell<HashMap<u64, u64>>,
+    committed: RefCell<BTreeMap<u64, u64>>,
 }
 
 impl Invariant for AgreementInvariant {

--- a/book/src/part3-building/23-pitfalls.md
+++ b/book/src/part3-building/23-pitfalls.md
@@ -95,11 +95,11 @@ effects through the scheduler and invokes the wakers after releasing its lock.
 Never wake while holding the world lock because a waker may immediately poll and
 re-enter the same component.
 
-## HashMap Iteration Non-Determinism
+## Unordered Collection Non-Determinism
 
 `std::collections::HashMap` does not guarantee iteration order, and the order can vary between runs. If your workload iterates a `HashMap` and the iteration order affects behavior (choosing which account to process, which message to send), you have introduced non-determinism.
 
-**Fix**: Use `BTreeMap` when iteration order matters, or collect into a `Vec` and sort before iterating.
+**Fix**: Use `BTreeMap` / `BTreeSet`, or collect dependency-owned unordered data into a `Vec` and sort before iterating. Moonpool's own workspace denies `HashMap` and `HashSet` through Clippy so this class of replay leak fails CI.
 
 ## Forgetting to Emit Events for Invariants
 

--- a/book/src/part4-integration/02-mock-boundaries.md
+++ b/book/src/part4-integration/02-mock-boundaries.md
@@ -57,7 +57,7 @@ Not every dependency needs full simulation. Think of fakes on a spectrum:
 
 **External HTTP APIs**: Canned responses with injectable failures. Your Stripe client fake returns a known charge object, but `buggify!()` returns a 429 or network timeout 10% of the time.
 
-**Cache**: Trait fake with partial cluster modeling if you need it, simple HashMap if you don't. Inject evictions and connection failures.
+**Cache**: Trait fake with partial cluster modeling if you need it, simple `BTreeMap` if you don't. Inject evictions and connection failures.
 
 ## Rules of Engagement
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,4 @@
+disallowed-types = [
+    { path = "std::collections::HashMap", reason = "randomized iteration order breaks deterministic replay", replacement = "std::collections::BTreeMap" },
+    { path = "std::collections::HashSet", reason = "randomized iteration order breaks deterministic replay", replacement = "std::collections::BTreeSet" },
+]

--- a/crates/moonpool-explorer/src/controller.rs
+++ b/crates/moonpool-explorer/src/controller.rs
@@ -47,7 +47,7 @@
 //! left to try. Physical process count is bounded by `1 + workers` at all
 //! times; the logical exploration space is unbounded.
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::{BTreeMap, VecDeque};
 use std::io;
 
 use crate::journal::{self, DiscoveryEvent};
@@ -191,7 +191,7 @@ pub struct Explorer {
     runs_started: u64,
     frontier: VecDeque<ExploreJob>,
     states: Vec<StateEntry>,
-    state_index: HashMap<u64, usize>,
+    state_index: BTreeMap<u64, usize>,
     continuation_round: u64,
     stats: ExplorationStats,
     bug_recipes: Vec<Recipe>,
@@ -199,7 +199,7 @@ pub struct Explorer {
     // --- worker pool (None = in-process mode) ---
     slots: Option<SlotPool>,
     #[cfg(unix)]
-    active: HashMap<libc::pid_t, (usize, ExploreJob)>,
+    active: BTreeMap<libc::pid_t, (usize, ExploreJob)>,
     free_slots: Vec<usize>,
 }
 
@@ -233,13 +233,13 @@ impl Explorer {
             runs_started: 0,
             frontier: VecDeque::new(),
             states: Vec::new(),
-            state_index: HashMap::new(),
+            state_index: BTreeMap::new(),
             continuation_round: 0,
             stats: ExplorationStats::default(),
             bug_recipes: Vec::new(),
             slots,
             #[cfg(unix)]
-            active: HashMap::new(),
+            active: BTreeMap::new(),
             free_slots,
         })
     }
@@ -421,7 +421,7 @@ impl Explorer {
         {
             let Some((pid, status)) = worker::wait_any() else {
                 // No children left (ECHILD): drop any stale bookkeeping.
-                for (_, (slot, _)) in self.active.drain() {
+                for (_, (slot, _)) in std::mem::take(&mut self.active) {
                     self.free_slots.push(slot);
                 }
                 return;

--- a/crates/moonpool-sim-examples/src/tonic_grpc.rs
+++ b/crates/moonpool-sim-examples/src/tonic_grpc.rs
@@ -349,6 +349,7 @@ impl Workload for EchoWorkload {
             }
         }
 
+        channel.close();
         tracing::info!("workload finished all rounds");
         Ok(())
     }

--- a/crates/moonpool-sim-examples/tests/tonic_determinism.rs
+++ b/crates/moonpool-sim-examples/tests/tonic_determinism.rs
@@ -1,0 +1,92 @@
+//! Cross-run determinism regression for tonic over `ReconnectingChannel`.
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use moonpool_sim::{
+    Attrition, AttritionScope, Chaos, ChaosMode, SIM_FAULT_EVENT_NAME, SimulationBuilder,
+};
+use moonpool_sim_examples::tonic_grpc::{EchoProcess, EchoWorkload};
+
+type TraceEntry = (u64, u64, String, String, String);
+
+const EVENT_NAMES: &[&str] = &[
+    "grpc server listening",
+    "accepted connection",
+    "grpc server shutting down",
+    "workload starting",
+    "starting round",
+    "round completed successfully",
+    "workload finished all rounds",
+    "echo_served",
+    "echo_stream_started",
+    "stream completed",
+    "stream aborted (buggified)",
+    "calling unmounted Shout service",
+    "unmounted service correctly rejected",
+    SIM_FAULT_EVENT_NAME,
+];
+
+fn run_once(seed: u64) -> Vec<TraceEntry> {
+    let trace = Arc::new(Mutex::new(Vec::new()));
+    let captured = Arc::clone(&trace);
+
+    let report = SimulationBuilder::new()
+        .processes(1, || Box::new(EchoProcess))
+        .workload(EchoWorkload)
+        .invariant_fn("tonic replay trace", move |query, _| {
+            let mut events = EVENT_NAMES
+                .iter()
+                .flat_map(|name| query.snapshot(name))
+                .map(|event| {
+                    (
+                        event.seq,
+                        event.time_ms,
+                        event.source,
+                        event.name,
+                        format!("{:?}", event.fields),
+                    )
+                })
+                .collect::<Vec<_>>();
+            events.sort_by_key(|event| event.0);
+            *captured
+                .lock()
+                .expect("Mutex poisoned: prior test panicked") = events;
+        })
+        .enable_chaos([
+            Chaos::Network(ChaosMode::Random),
+            Chaos::Attrition {
+                config: Attrition {
+                    max_dead: 1,
+                    prob_graceful: 0.3,
+                    prob_crash: 0.5,
+                    prob_wipe: 0.2,
+                    recovery_delay_ms: None,
+                    grace_period_ms: None,
+                    scope: AttritionScope::PerProcess,
+                },
+                mode: ChaosMode::Random,
+            },
+        ])
+        .chaos_duration(Duration::from_secs(10))
+        .set_debug_seeds(vec![seed])
+        .set_iterations(1)
+        .run();
+    assert_eq!(report.failed_runs, 0, "seed {seed} must succeed");
+
+    let events = trace
+        .lock()
+        .expect("Mutex poisoned: prior test panicked")
+        .clone();
+    assert!(!events.is_empty(), "seed {seed} must emit trace events");
+    events
+}
+
+#[test]
+fn tonic_replay_is_independent_of_earlier_in_process_runs() {
+    for seed in [1_u64, 42] {
+        assert_eq!(run_once(seed), run_once(seed), "warm-up seed {seed}");
+    }
+
+    assert_eq!(run_once(12_345), run_once(12_345), "target seed");
+}

--- a/crates/moonpool-sim/src/chaos/assertions.rs
+++ b/crates/moonpool-sim/src/chaos/assertions.rs
@@ -33,7 +33,7 @@
 //! | `assert_sometimes_each!` | yes | no | on discovery/quality |
 
 use std::cell::Cell;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 // =============================================================================
 // Thread-local violation tracking (Antithesis-style: never panic)
@@ -207,9 +207,9 @@ pub fn on_sometimes_each(msg: &str, keys: &[(&str, i64)], quality: &[(&str, i64)
 /// Reads from shared memory assertion slots. Returns a snapshot of assertion
 /// results for reporting and validation.
 #[must_use]
-pub fn assertion_results() -> HashMap<String, AssertionStats> {
+pub fn assertion_results() -> BTreeMap<String, AssertionStats> {
     let slots = moonpool_assertions::assertion_read_all();
-    let mut results = HashMap::new();
+    let mut results = BTreeMap::new();
 
     for slot in &slots {
         let total =

--- a/crates/moonpool-sim/src/chaos/buggify.rs
+++ b/crates/moonpool-sim/src/chaos/buggify.rs
@@ -201,7 +201,7 @@ mod tests {
             .collect();
         let unique = sequences
             .iter()
-            .collect::<std::collections::HashSet<_>>()
+            .collect::<std::collections::BTreeSet<_>>()
             .len();
         assert!(
             unique > 1,

--- a/crates/moonpool-sim/src/chaos/state_handle.rs
+++ b/crates/moonpool-sim/src/chaos/state_handle.rs
@@ -1,6 +1,6 @@
 //! Type-safe shared state for cross-workload mutable values.
 //!
-//! `StateHandle` provides an `Arc<RwLock<HashMap>>`-backed store using
+//! `StateHandle` provides an `Arc<RwLock<BTreeMap>>`-backed store using
 //! `Box<dyn Any + Send + Sync>` so workloads can publish and consume typed
 //! values across tasks within a simulation iteration. It is **not** an event
 //! log — for event timelines and invariants see the
@@ -18,7 +18,7 @@
 //! ```
 
 use std::any::Any;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::sync::{Arc, RwLock};
 
 /// Shared state handle for cross-workload publish/get communication.
@@ -28,7 +28,7 @@ use std::sync::{Arc, RwLock};
 /// storage.
 #[derive(Clone, Default)]
 pub struct StateHandle {
-    inner: Arc<RwLock<HashMap<String, Box<dyn Any + Send + Sync>>>>,
+    inner: Arc<RwLock<BTreeMap<String, Box<dyn Any + Send + Sync>>>>,
 }
 
 impl StateHandle {

--- a/crates/moonpool-sim/src/executor/mod.rs
+++ b/crates/moonpool-sim/src/executor/mod.rs
@@ -85,9 +85,11 @@
 //! Dropping the executor kills every remaining task, replicating the
 //! "dropping the per-iteration tokio runtime kills leaked tasks" contract
 //! that isolates simulation iterations. The mechanism (borrowed from
-//! async-executor): a registry keeps one waker per live task; `Drop` wakes
-//! them all, which schedules every parked task into the ready queue, then
-//! pops and drops `Runnable`s until the queue is empty. Dropping a
+//! async-executor): an ordered registry keeps one waker per live task; `Drop`
+//! wakes them in task-id order, which schedules every parked task into the
+//! ready queue, then pops and drops `Runnable`s until the queue is empty.
+//! Stable cancellation order matters because future destructors may wake or
+//! spawn other tasks. Dropping a
 //! `Runnable` cancels its task and drops the future, and if that drop wakes
 //! further tasks they land in the queue and are consumed by the same loop.
 //!
@@ -106,7 +108,7 @@ mod join;
 pub use join::{JoinHandle, YieldNow, until_stalled, yield_now};
 
 use std::cell::{Cell, RefCell};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::future::Future;
 use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
@@ -175,8 +177,8 @@ struct Shared {
     /// chosen by seeded `swap_remove`, not FIFO order.
     queue: Mutex<Vec<ExecRunnable>>,
     /// One waker per live (spawned, not yet completed/cancelled) task,
-    /// keyed by `TaskMeta::id`; consumed by kill-on-drop.
-    wakers: Mutex<HashMap<u64, Waker>>,
+    /// keyed by `TaskMeta::id`; ordered for deterministic kill-on-drop.
+    wakers: Mutex<BTreeMap<u64, Waker>>,
     /// Next task id.
     next_id: AtomicU64,
 }
@@ -345,7 +347,7 @@ impl Executor {
         Self {
             shared: Arc::new(Shared {
                 queue: Mutex::new(Vec::new()),
-                wakers: Mutex::new(HashMap::new()),
+                wakers: Mutex::new(BTreeMap::new()),
                 next_id: AtomicU64::new(0),
             }),
             rng: ChaCha8Rng::seed_from_u64(seed ^ EXEC_RNG_SALT),
@@ -466,13 +468,10 @@ impl Drop for Executor {
 
         // Wake every live task: completed tasks ignore it, parked tasks get
         // their Runnable scheduled into the queue.
-        let wakers: Vec<Waker> = self
-            .shared
-            .wakers
-            .lock()
-            .drain()
-            .map(|(_, waker)| waker)
-            .collect();
+        let wakers: Vec<Waker> = {
+            let mut registered = self.shared.wakers.lock();
+            std::mem::take(&mut *registered).into_values().collect()
+        };
         for waker in wakers {
             waker.wake();
         }

--- a/crates/moonpool-sim/src/network/sim/engine.rs
+++ b/crates/moonpool-sim/src/network/sim/engine.rs
@@ -1,7 +1,7 @@
 //! Stateful network simulation independent from the global event scheduler.
 
 use std::{
-    collections::{BTreeMap, HashSet, VecDeque},
+    collections::{BTreeMap, BTreeSet, VecDeque},
     net::IpAddr,
     task::Waker,
     time::Duration,
@@ -75,9 +75,9 @@ pub(crate) struct NetworkSimulation {
     last_bit_flip_time: Duration,
     next_operation_id: u64,
     next_accept_waiter_id: u64,
-    completed_operations: HashSet<NetworkOperationId>,
-    failed_operations: HashSet<NetworkOperationId>,
-    failed_accepts: HashSet<AcceptWaiterId>,
+    completed_operations: BTreeSet<NetworkOperationId>,
+    failed_operations: BTreeSet<NetworkOperationId>,
+    failed_accepts: BTreeSet<AcceptWaiterId>,
     accept_reservations: BTreeMap<AcceptWaiterId, AcceptReservation>,
     operation_waiters: WakerRegistry<NetworkOperationId>,
 }
@@ -91,9 +91,9 @@ impl NetworkSimulation {
             last_bit_flip_time: Duration::ZERO,
             next_operation_id: 0,
             next_accept_waiter_id: 0,
-            completed_operations: HashSet::new(),
-            failed_operations: HashSet::new(),
-            failed_accepts: HashSet::new(),
+            completed_operations: BTreeSet::new(),
+            failed_operations: BTreeSet::new(),
+            failed_accepts: BTreeSet::new(),
             accept_reservations: BTreeMap::new(),
             operation_waiters: WakerRegistry::default(),
         }
@@ -584,7 +584,7 @@ impl NetworkSimulation {
             chaos.bit_flip_max_bits,
         );
         let mut result = data.to_vec();
-        let mut positions = HashSet::new();
+        let mut positions = BTreeSet::new();
         for _ in 0..count {
             let raw_byte = sim_random::<u64>();
             let raw_bit = sim_random::<u64>();
@@ -1096,7 +1096,7 @@ impl NetworkSimulation {
             .values()
             .filter(|connection| !connection.flags.is_closed())
             .filter_map(|connection| connection.local_ip)
-            .collect::<HashSet<_>>()
+            .collect::<BTreeSet<_>>()
             .into_iter()
             .collect::<Vec<_>>();
         ips.sort_unstable();

--- a/crates/moonpool-sim/src/observability/layer.rs
+++ b/crates/moonpool-sim/src/observability/layer.rs
@@ -23,7 +23,7 @@
 //! single-threaded so the mutex is uncontended.
 
 use std::cell::Cell;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use parking_lot::Mutex;
@@ -44,7 +44,7 @@ struct EventStore {
     /// Monotonic sequence counter assigned to each captured event.
     seq_counter: u64,
     /// Captured events grouped by their name (the tracing message).
-    by_name: HashMap<String, Vec<TraceEvent>>,
+    by_name: BTreeMap<String, Vec<TraceEvent>>,
     /// Latest known sim time. Advanced by `SimulationLayerHandle::set_sim_time_ms`
     /// (orchestrator pushes after each `sim.step()`) and read at capture time.
     last_sim_time_ms: u64,
@@ -54,7 +54,7 @@ impl EventStore {
     fn new() -> Self {
         Self {
             seq_counter: 0,
-            by_name: HashMap::new(),
+            by_name: BTreeMap::new(),
             last_sim_time_ms: 0,
         }
     }

--- a/crates/moonpool-sim/src/runner/builder.rs
+++ b/crates/moonpool-sim/src/runner/builder.rs
@@ -3,7 +3,7 @@
 //! This module provides the main `SimulationBuilder` type for setting up
 //! and executing simulation experiments.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::time::Duration;
 
 use super::wall_clock::Instant;
@@ -80,7 +80,7 @@ struct FinalReportInputs {
 struct ConvergenceState<'a> {
     iteration_control: &'a IterationControl,
     iteration_count: usize,
-    reached_sometimes: &'a std::collections::HashSet<String>,
+    reached_sometimes: &'a std::collections::BTreeSet<String>,
     all_sometimes_count: usize,
     /// Whether fork-based exploration is active (selects sancov history vs
     /// the live BSS counter reader for the code-coverage signal).
@@ -121,7 +121,7 @@ impl RunState {
             bug_recipes: Vec::new(),
             #[cfg(feature = "exploration")]
             per_seed_timelines: Vec::new(),
-            reached_sometimes: std::collections::HashSet::new(),
+            reached_sometimes: std::collections::BTreeSet::new(),
             prev_signal: 0,
             converged: false,
             plateau_count: 0,
@@ -160,7 +160,7 @@ struct RunState {
     #[cfg(feature = "exploration")]
     per_seed_timelines: Vec<u64>,
     // Saturation tracking (`UntilCoverageStable`).
-    reached_sometimes: std::collections::HashSet<String>,
+    reached_sometimes: std::collections::BTreeSet<String>,
     /// Previous progress-signal value (code edges, or reached-assertion count
     /// in the no-sancov fallback). Both signals are monotonic non-decreasing.
     prev_signal: usize,
@@ -1174,7 +1174,7 @@ impl SimulationBuilder {
     /// Scan all assertion slots from shared memory: insert the messages of
     /// every satisfied coverage assertion into `reached`, warn for incomplete
     /// sites, and return the number of unique observed coverage contracts.
-    fn scan_assertion_slots(reached: &mut std::collections::HashSet<String>) -> usize {
+    fn scan_assertion_slots(reached: &mut std::collections::BTreeSet<String>) -> usize {
         let slots = moonpool_assertions::assertion_read_all();
         for slot in &slots {
             if let Some(kind) = moonpool_assertions::AssertKind::from_u8(slot.kind)
@@ -1219,7 +1219,7 @@ impl SimulationBuilder {
                 })
             })
             .map(|s| s.msg.clone())
-            .collect::<std::collections::HashSet<_>>()
+            .collect::<std::collections::BTreeSet<_>>()
             .len()
     }
 
@@ -1233,7 +1233,7 @@ impl SimulationBuilder {
             individual_metrics: Vec::new(),
             seeds_used: Vec::new(),
             seeds_failing: Vec::new(),
-            assertion_results: HashMap::new(),
+            assertion_results: BTreeMap::new(),
             assertion_violations: Vec::new(),
             coverage_violations: Vec::new(),
             exploration: None,
@@ -1776,9 +1776,9 @@ fn build_bucket_summaries(
     buckets: &[moonpool_assertions::EachBucket],
 ) -> Vec<super::report::BucketSiteSummary> {
     use super::report::BucketSiteSummary;
-    use std::collections::HashMap;
+    use std::collections::BTreeMap;
 
-    let mut sites: HashMap<u32, BucketSiteSummary> = HashMap::new();
+    let mut sites: BTreeMap<u32, BucketSiteSummary> = BTreeMap::new();
 
     for bucket in buckets {
         let entry = sites

--- a/crates/moonpool-sim/src/runner/locality.rs
+++ b/crates/moonpool-sim/src/runner/locality.rs
@@ -18,7 +18,7 @@
 //! .cluster(LocalityConfig::new(3, 3, 3, 1), || Box::new(MyNode::new()))
 //! ```
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::net::IpAddr;
 
 use crate::locality::{DomainLevel, LocalityInfo};
@@ -98,7 +98,7 @@ impl LocalityConfig {
 /// a datacenter).
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct MachineRegistry {
-    ip_locality: HashMap<IpAddr, LocalityInfo>,
+    ip_locality: BTreeMap<IpAddr, LocalityInfo>,
 }
 
 impl MachineRegistry {
@@ -106,7 +106,7 @@ impl MachineRegistry {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            ip_locality: HashMap::new(),
+            ip_locality: BTreeMap::new(),
         }
     }
 

--- a/crates/moonpool-sim/src/runner/metrics.rs
+++ b/crates/moonpool-sim/src/runner/metrics.rs
@@ -1,6 +1,6 @@
 //! Cross-iteration metrics and final report assembly.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::time::Duration;
 
 use crate::chaos::AssertionStats;
@@ -144,7 +144,7 @@ impl MetricsCollector {
 pub(crate) struct GenerateReportInputs {
     pub(crate) iteration_count: usize,
     pub(crate) seeds_used: Vec<u64>,
-    pub(crate) assertion_results: HashMap<String, AssertionStats>,
+    pub(crate) assertion_results: BTreeMap<String, AssertionStats>,
     pub(crate) assertion_violations: Vec<String>,
     pub(crate) coverage_violations: Vec<String>,
     pub(crate) exploration: Option<ExplorationReport>,

--- a/crates/moonpool-sim/src/runner/report.rs
+++ b/crates/moonpool-sim/src/runner/report.rs
@@ -2,7 +2,7 @@
 //!
 //! This module provides types for collecting and reporting simulation results.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::fmt;
 use std::time::Duration;
 
@@ -174,7 +174,7 @@ pub struct SimulationReport {
     /// failed seeds
     pub seeds_failing: Vec<u64>,
     /// Aggregated assertion results across all iterations
-    pub assertion_results: HashMap<String, AssertionStats>,
+    pub assertion_results: BTreeMap<String, AssertionStats>,
     /// Always-type assertion violations (definite bugs).
     pub assertion_violations: Vec<String>,
     /// Coverage assertion violations (sometimes/reachable not satisfied).

--- a/crates/moonpool-sim/src/runner/tags.rs
+++ b/crates/moonpool-sim/src/runner/tags.rs
@@ -17,7 +17,7 @@
 //!     ])
 //! ```
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::net::IpAddr;
 
 /// Distribution specification for a single tag dimension.
@@ -71,7 +71,7 @@ impl TagDistribution {
     /// `values[i % values.len()]` for each dimension.
     #[must_use]
     pub fn resolve(&self, index: usize) -> ProcessTags {
-        let mut tags = HashMap::new();
+        let mut tags = BTreeMap::new();
         for dim in &self.dimensions {
             if !dim.values.is_empty() {
                 let value = &dim.values[index % dim.values.len()];
@@ -85,7 +85,7 @@ impl TagDistribution {
 /// Resolved tags for a specific process instance.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct ProcessTags {
-    tags: HashMap<String, String>,
+    tags: BTreeMap<String, String>,
 }
 
 impl ProcessTags {
@@ -114,7 +114,7 @@ impl ProcessTags {
 /// and find IPs matching tag queries.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct TagRegistry {
-    ip_tags: HashMap<IpAddr, ProcessTags>,
+    ip_tags: BTreeMap<IpAddr, ProcessTags>,
 }
 
 impl TagRegistry {
@@ -122,7 +122,7 @@ impl TagRegistry {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            ip_tags: HashMap::new(),
+            ip_tags: BTreeMap::new(),
         }
     }
 

--- a/crates/moonpool-sim/src/sim/world.rs
+++ b/crates/moonpool-sim/src/sim/world.rs
@@ -1,7 +1,7 @@
 //! Global deterministic scheduler and lifecycle coordination.
 
 use std::{
-    collections::{BTreeMap, HashSet},
+    collections::{BTreeMap, BTreeSet},
     net::IpAddr,
     sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard, Weak},
     task::Waker,
@@ -61,7 +61,7 @@ pub(crate) struct SimInner {
     pub(crate) wakers: Wakers,
     timer_schedules: BTreeMap<u64, ScheduleId>,
     pub(crate) next_task_id: u64,
-    pub(crate) awakened_tasks: HashSet<u64>,
+    pub(crate) awakened_tasks: BTreeSet<u64>,
     pub(crate) events_processed: u64,
     pub(crate) last_processed_event: Option<Event>,
     pub(crate) pending_faults: Vec<SimFaultRecord>,
@@ -79,7 +79,7 @@ impl SimInner {
             wakers: Wakers::default(),
             timer_schedules: BTreeMap::new(),
             next_task_id: 0,
-            awakened_tasks: HashSet::new(),
+            awakened_tasks: BTreeSet::new(),
             events_processed: 0,
             last_processed_event: None,
             pending_faults: Vec::new(),
@@ -456,7 +456,7 @@ impl SimWorld {
     #[must_use]
     pub fn assertion_results(
         &self,
-    ) -> std::collections::HashMap<String, crate::chaos::AssertionStats> {
+    ) -> std::collections::BTreeMap<String, crate::chaos::AssertionStats> {
         crate::chaos::assertion_results()
     }
 

--- a/crates/moonpool-sim/src/storage/config.rs
+++ b/crates/moonpool-sim/src/storage/config.rs
@@ -547,7 +547,7 @@ mod buggify_knob_tests {
 
     #[test]
     fn buggify_knobs_vary_across_seeds() {
-        let distinct: std::collections::HashSet<_> = (0..50_u64).map(buggified_knobs).collect();
+        let distinct: std::collections::BTreeSet<_> = (0..50_u64).map(buggified_knobs).collect();
         assert!(
             distinct.len() > 1,
             "buggify knob spikes should vary across seeds"

--- a/crates/moonpool-sim/src/storage/sim/state.rs
+++ b/crates/moonpool-sim/src/storage/sim/state.rs
@@ -1,7 +1,7 @@
 //! State owned exclusively by the simulated storage engine.
 
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap},
+    collections::{BTreeMap, BTreeSet},
     net::IpAddr,
     time::Duration,
 };
@@ -91,8 +91,8 @@ pub(crate) struct StorageState {
     pub(crate) next_handle_id: u64,
     pub(crate) next_operation_id: u64,
     pub(crate) config: StorageConfiguration,
-    pub(crate) per_process_configs: HashMap<IpAddr, StorageConfiguration>,
-    pub(crate) disk_episodes: HashMap<IpAddr, DiskDegradationState>,
+    pub(crate) per_process_configs: BTreeMap<IpAddr, StorageConfiguration>,
+    pub(crate) disk_episodes: BTreeMap<IpAddr, DiskDegradationState>,
     pub(crate) files: BTreeMap<FileId, FileState>,
     pub(crate) handles: BTreeMap<HandleId, HandleState>,
     pub(crate) path_to_file: BTreeMap<String, FileId>,
@@ -106,8 +106,8 @@ impl StorageState {
             next_handle_id: 0,
             next_operation_id: 0,
             config,
-            per_process_configs: HashMap::new(),
-            disk_episodes: HashMap::new(),
+            per_process_configs: BTreeMap::new(),
+            disk_episodes: BTreeMap::new(),
             files: BTreeMap::new(),
             handles: BTreeMap::new(),
             path_to_file: BTreeMap::new(),

--- a/crates/moonpool-sim/tests/executor.rs
+++ b/crates/moonpool-sim/tests/executor.rs
@@ -159,7 +159,7 @@ fn different_seeds_explore_different_schedules() {
     let orders: Vec<Vec<u64>> = (0..8).map(completion_order).collect();
     let distinct = orders
         .iter()
-        .collect::<std::collections::HashSet<_>>()
+        .collect::<std::collections::BTreeSet<_>>()
         .len();
     assert!(
         distinct > 1,
@@ -207,6 +207,45 @@ fn dropping_the_executor_cancels_parked_tasks() {
         "executor drop must cancel the parked task and drop its future"
     );
     assert!(!completed.load(Ordering::Relaxed), "task must not complete");
+}
+
+#[test]
+fn executor_shutdown_cancels_tasks_in_stable_order() {
+    /// Records the task whose parked future is being cancelled.
+    struct DropRecord {
+        id: u64,
+        order: Arc<Mutex<Vec<u64>>>,
+    }
+
+    impl Drop for DropRecord {
+        fn drop(&mut self) {
+            self.order.lock().push(self.id);
+        }
+    }
+
+    fn cancellation_order() -> Vec<u64> {
+        let order = Arc::new(Mutex::new(Vec::new()));
+        let mut executor = Executor::new(11);
+        executor.block_on(async {
+            for id in 0..16u64 {
+                let record = DropRecord {
+                    id,
+                    order: Arc::clone(&order),
+                };
+                drop(spawn(&format!("parked-{id}"), async move {
+                    let _record = record;
+                    std::future::pending::<()>().await;
+                }));
+            }
+            until_stalled().await;
+        });
+        drop(executor);
+        order.lock().clone()
+    }
+
+    let expected = (0..16u64).rev().collect::<Vec<_>>();
+    assert_eq!(cancellation_order(), expected);
+    assert_eq!(cancellation_order(), expected);
 }
 
 #[test]

--- a/crates/moonpool-sim/tests/exploration/tests.rs
+++ b/crates/moonpool-sim/tests/exploration/tests.rs
@@ -5,7 +5,7 @@
 //! (nextest default).
 
 use std::cell::{Cell, RefCell};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use async_trait::async_trait;
 use futures::io::{AsyncReadExt, AsyncWriteExt};
@@ -174,14 +174,14 @@ impl Process for ElectionNode {
 /// Paxos-style safety check: one term must never have two distinct leaders.
 struct OneLeaderPerTerm {
     cursor: Cell<usize>,
-    leaders: RefCell<HashMap<u64, String>>,
+    leaders: RefCell<BTreeMap<u64, String>>,
 }
 
 impl OneLeaderPerTerm {
     fn new() -> Self {
         Self {
             cursor: Cell::new(0),
-            leaders: RefCell::new(HashMap::new()),
+            leaders: RefCell::new(BTreeMap::new()),
         }
     }
 }

--- a/crates/moonpool-sim/tests/leader_election.rs
+++ b/crates/moonpool-sim/tests/leader_election.rs
@@ -22,7 +22,7 @@
 //! reports `failed_runs > 0`.
 
 use std::cell::Cell;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -41,14 +41,14 @@ struct SplitBrainInvariant {
     cursor: Cell<usize>,
     /// `term -> first leader observed`. State persists across `observe` calls
     /// within a seed; cleared by `reset()` at the start of each seed.
-    seen: std::cell::RefCell<HashMap<u64, String>>,
+    seen: std::cell::RefCell<BTreeMap<u64, String>>,
 }
 
 impl SplitBrainInvariant {
     fn new() -> Self {
         Self {
             cursor: Cell::new(0),
-            seen: std::cell::RefCell::new(HashMap::new()),
+            seen: std::cell::RefCell::new(BTreeMap::new()),
         }
     }
 }

--- a/crates/moonpool-wasm-demo/src/timeline.rs
+++ b/crates/moonpool-wasm-demo/src/timeline.rs
@@ -1,6 +1,6 @@
 use std::{
     cell::Cell,
-    collections::HashMap,
+    collections::BTreeMap,
     sync::{Arc, Mutex},
 };
 
@@ -107,8 +107,8 @@ pub(crate) fn finish(seed: u64, handle: &RecorderHandle) -> RunResult {
         return RunResult::empty(seed);
     }
 
-    let acknowledgements: HashMap<_, _> = data.acked.iter().copied().collect();
-    let failures: HashMap<_, _> = data.failed.iter().copied().collect();
+    let acknowledgements: BTreeMap<_, _> = data.acked.iter().copied().collect();
+    let failures: BTreeMap<_, _> = data.failed.iter().copied().collect();
     let mut issued = data.issued.clone();
     issued.sort_by_key(|&(_, time)| time);
 


### PR DESCRIPTION
Closes #171.\n\nMakes executor shutdown cancellation deterministic, replaces unordered standard collections across the workspace, and denies HashMap/HashSet through Clippy. Adds dedicated tonic cross-run determinism coverage with warm-up seeds and explicit channel closure.\n\nValidation:\n- cargo fmt\n- cargo clippy --workspace --all-targets -- -D warnings\n- cargo nextest run (553 passed)\n- mdbook build book/\n- moonpool-sim no-default-features Clippy\n- moonpool-sim wasm32 check\n- Paros issue reproduction passes against the local patch