### PR TITLE
fix: make multi-channel gRPC replay deterministic

### DIFF
--- a/book/src/part3-building/10-network-faults.md
+++ b/book/src/part3-building/10-network-faults.md
@@ -46,6 +46,8 @@ The engine classifies every IP pair through the [`.cluster()`](09-attrition.md#f
 
 Random close injects spontaneous connection failures during I/O operations, at a configurable probability (default 0.001%). When triggered, 30% of closes are **explicit** (the caller gets an error) and 70% are **silent** (the connection just stops working). This ratio, taken from FoundationDB, tests both error-handling paths and timeout-based failure detection.
 
+Fault decisions are sampled only when an operation can make progress. Re-polling a read with no buffered data or a write under backpressure returns `Poll::Pending` without consuming simulation randomness, so runtime-specific spurious polls cannot shift the seed's later fault and latency choices.
+
 A cooldown period prevents cascading closes from overwhelming the system. The goal is to test recovery, not to make the system completely inoperable.
 
 ### Clogging

--- a/book/src/part4-integration/08-hyper-stack.md
+++ b/book/src/part4-integration/08-hyper-stack.md
@@ -170,6 +170,13 @@ clients. Here it would only make reconnect timing depend on something other
 than the seed, so `ChannelConfig` doubles from `initial_reconnect_delay` and
 saturates at `max_reconnect_delay`, full stop.
 
+**Response headers do not read the wall clock.** Hyper normally adds a `Date`
+header from `SystemTime`. That timestamp becomes part of the connection's HPACK
+state, so two otherwise identical gRPC replays can emit different frame sizes
+and perturb later simulated network choices. `H2Server` disables the automatic
+header. A production caller using the builder escape hatch can re-enable it, or
+the service can provide a date from an application-controlled clock.
+
 **A connection has to earn its reset.** The failure count that drives the
 backoff clears only once a connection has survived `initial_reconnect_delay`,
 not the moment the handshake completes. Without that rule, a peer that accepts

--- a/crates/moonpool-hyper/src/server.rs
+++ b/crates/moonpool-hyper/src/server.rs
@@ -116,6 +116,12 @@ impl<P: Providers> H2Server<P> {
     /// takes over from there, including wrapping the stream in
     /// [`HyperIo`] and the service in [`TowerToHyperService`], which is what
     /// [`serve_connection`](Self::serve_connection) would have done.
+    ///
+    /// Hyper's automatic `Date` response header is disabled because it reads
+    /// the system clock outside [`HyperTimer`], making otherwise identical
+    /// simulations produce different HPACK bytes. A production caller that
+    /// needs the header can re-enable it on the returned builder or add it in
+    /// its service.
     #[must_use]
     pub fn builder(&self) -> http2::Builder<HyperExecutor<P::Task>> {
         let mut builder = http2::Builder::new(self.executor.clone());

--- a/crates/moonpool-hyper/src/server.rs
+++ b/crates/moonpool-hyper/src/server.rs
@@ -120,6 +120,7 @@ impl<P: Providers> H2Server<P> {
     pub fn builder(&self) -> http2::Builder<HyperExecutor<P::Task>> {
         let mut builder = http2::Builder::new(self.executor.clone());
         builder.timer(self.timer.clone());
+        builder.auto_date_header(false);
         if let Some(keep_alive) = &self.config.keep_alive {
             builder
                 .keep_alive_interval(keep_alive.interval)

--- a/crates/moonpool-sim-examples/Cargo.toml
+++ b/crates/moonpool-sim-examples/Cargo.toml
@@ -40,6 +40,9 @@ tonic-prost = "0.14"
 [build-dependencies]
 tonic-prost-build = "0.14"
 
+[dev-dependencies]
+tower-service = "0.3"
+
 [[bin]]
 name = "sim-maze-explore"
 path = "src/bin/sim/maze_explore.rs"

--- a/crates/moonpool-sim-examples/tests/tonic_determinism.rs
+++ b/crates/moonpool-sim-examples/tests/tonic_determinism.rs
@@ -1,12 +1,26 @@
 //! Cross-run determinism regression for tonic over `ReconnectingChannel`.
 
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll};
 use std::time::Duration;
 
+use async_trait::async_trait;
+use futures::Stream;
+use moonpool_hyper::{ChannelConfig, ChannelError, H2Server, ReconnectingChannel};
 use moonpool_sim::{
-    Attrition, AttritionScope, Chaos, ChaosMode, SIM_FAULT_EVENT_NAME, SimulationBuilder,
+    Attrition, AttritionScope, Chaos, ChaosMode, NetworkProvider, Process, SIM_FAULT_EVENT_NAME,
+    SimContext, SimProviders, SimulationBuilder, SimulationError, SimulationResult, TaskProvider,
+    TcpListenerTrait, Workload,
 };
+use moonpool_sim_examples::tonic_grpc::proto::echo_client::EchoClient;
+use moonpool_sim_examples::tonic_grpc::proto::echo_server::{Echo, EchoServer};
+use moonpool_sim_examples::tonic_grpc::proto::{EchoRequest, EchoResponse, EchoStreamRequest};
 use moonpool_sim_examples::tonic_grpc::{EchoProcess, EchoWorkload};
+use tonic::{Request, Response, Status};
+use tower_service::Service;
 
 type TraceEntry = (u64, u64, String, String, String);
 
@@ -26,6 +40,238 @@ const EVENT_NAMES: &[&str] = &[
     "unmounted service correctly rejected",
     SIM_FAULT_EVENT_NAME,
 ];
+
+const MULTI_CHANNEL_EVENT_NAMES: &[&str] = &[
+    "multi_channel_server_listening",
+    "multi_channel_connection_accepted",
+    "multi_channel_echo_served",
+    "multi_channel_response_received",
+    "multi_channel_workload_finished",
+];
+
+type GrpcChannel = ReconnectingChannel<SimProviders, tonic::body::Body>;
+
+#[derive(Clone)]
+struct DateCheckingChannel {
+    inner: GrpcChannel,
+    date_seen: Arc<AtomicBool>,
+}
+
+impl Service<http::Request<tonic::body::Body>> for DateCheckingChannel {
+    type Response = http::Response<hyper::body::Incoming>;
+    type Error = ChannelError;
+    type Future =
+        Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Service::poll_ready(&mut self.inner, cx)
+    }
+
+    fn call(&mut self, request: http::Request<tonic::body::Body>) -> Self::Future {
+        let response = Service::call(&mut self.inner, request);
+        let date_seen = Arc::clone(&self.date_seen);
+        Box::pin(async move {
+            let response = response.await?;
+            date_seen.fetch_or(
+                response.headers().contains_key(http::header::DATE),
+                Ordering::Relaxed,
+            );
+            Ok(response)
+        })
+    }
+}
+
+#[derive(Default)]
+struct DeterministicEcho;
+
+#[tonic::async_trait]
+impl Echo for DeterministicEcho {
+    async fn echo(&self, request: Request<EchoRequest>) -> Result<Response<EchoResponse>, Status> {
+        let request = request.into_inner();
+        tracing::info!(seq = request.seq, "multi_channel_echo_served");
+        Ok(Response::new(EchoResponse {
+            text: request.text,
+            seq: request.seq,
+        }))
+    }
+
+    type EchoStreamStream = Pin<Box<dyn Stream<Item = Result<EchoResponse, Status>> + Send>>;
+
+    async fn echo_stream(
+        &self,
+        _request: Request<EchoStreamRequest>,
+    ) -> Result<Response<Self::EchoStreamStream>, Status> {
+        Ok(Response::new(Box::pin(futures::stream::empty())))
+    }
+}
+
+struct MultiChannelEchoProcess;
+
+#[async_trait]
+impl Process for MultiChannelEchoProcess {
+    fn name(&self) -> &'static str {
+        "multi-channel-grpc"
+    }
+
+    async fn run(&mut self, ctx: &SimContext) -> SimulationResult<()> {
+        let listener = ctx.network().bind(ctx.my_ip()).await?;
+        let server = H2Server::new(ctx.providers());
+        let service = EchoServer::new(DeterministicEcho);
+        tracing::info!("multi_channel_server_listening");
+
+        loop {
+            moonpool_sim::select! {
+                accepted = listener.accept() => {
+                    let (stream, _) = accepted?;
+                    tracing::info!("multi_channel_connection_accepted");
+                    let connection = server.serve_connection_with_shutdown(
+                        stream,
+                        service.clone(),
+                        ctx.shutdown().clone().cancelled_owned(),
+                    );
+                    ctx.task()
+                        .spawn_task("multi-channel-grpc-server", async move {
+                            if let Err(error) = connection.await {
+                                tracing::debug!(%error, "multi-channel h2 connection ended");
+                            }
+                        })
+                        .detach();
+                }
+                () = ctx.shutdown().cancelled() => return Ok(()),
+            }
+        }
+    }
+}
+
+struct MultiChannelEchoWorkload;
+
+#[async_trait]
+impl Workload for MultiChannelEchoWorkload {
+    fn name(&self) -> &'static str {
+        "multi-channel-client"
+    }
+
+    async fn run(&mut self, ctx: &SimContext) -> SimulationResult<()> {
+        let server_ips = ctx.topology().all_process_ips();
+        if server_ips.len() != 3 {
+            return Err(SimulationError::InvalidState(format!(
+                "expected three gRPC servers, got {}",
+                server_ips.len()
+            )));
+        }
+
+        let mut channels = Vec::new();
+        let mut lanes = Vec::new();
+        for (server, address) in server_ips.iter().enumerate() {
+            let origin = http::Uri::try_from(format!("http://{address}"))
+                .map_err(|error| SimulationError::InvalidState(format!("bad origin: {error}")))?;
+            for channel_index in 0..2_u64 {
+                let channel = ReconnectingChannel::new(
+                    ctx.providers(),
+                    address.clone(),
+                    ChannelConfig::default(),
+                );
+                let date_seen = Arc::new(AtomicBool::new(false));
+                channels.push(channel.clone());
+                let checked_channel = DateCheckingChannel {
+                    inner: channel.clone(),
+                    date_seen: Arc::clone(&date_seen),
+                };
+                // Establish every persistent connection before driving the
+                // shared lanes concurrently. This mirrors a running cluster
+                // after peer-channel startup without overflowing the
+                // simulation listener's deliberately small pending backlog.
+                let mut startup_error = None;
+                for _ in 0..5 {
+                    match Self::run_lane(
+                        checked_channel.clone(),
+                        origin.clone(),
+                        server as u64,
+                        channel_index,
+                        9,
+                        1,
+                    )
+                    .await
+                    {
+                        Ok(()) => {
+                            startup_error = None;
+                            break;
+                        }
+                        Err(error) => startup_error = Some(error),
+                    }
+                }
+                if let Some(error) = startup_error {
+                    return Err(error);
+                }
+                for lane in 0..2_u64 {
+                    lanes.push(Self::run_lane(
+                        checked_channel.clone(),
+                        origin.clone(),
+                        server as u64,
+                        channel_index,
+                        lane,
+                        3,
+                    ));
+                }
+            }
+        }
+
+        for result in futures::future::join_all(lanes).await {
+            result?;
+        }
+        for channel in channels {
+            channel.close();
+        }
+        tracing::info!("multi_channel_workload_finished");
+        Ok(())
+    }
+}
+
+impl MultiChannelEchoWorkload {
+    async fn run_lane(
+        channel: DateCheckingChannel,
+        origin: http::Uri,
+        server: u64,
+        channel_index: u64,
+        lane: u64,
+        request_count: u64,
+    ) -> SimulationResult<()> {
+        let date_seen = Arc::clone(&channel.date_seen);
+        let mut client = EchoClient::with_origin(channel, origin);
+        for request_index in 0..request_count {
+            let seq = server * 10_000 + channel_index * 1_000 + lane * 100 + request_index;
+            let text = format!("server-{server}-channel-{channel_index}-lane-{lane}");
+            let response = client
+                .echo(Request::new(EchoRequest {
+                    text: text.clone(),
+                    seq,
+                }))
+                .await
+                .map_err(|error| {
+                    SimulationError::InvalidState(format!("gRPC echo failed: {error}"))
+                })?;
+            if date_seen.load(Ordering::Relaxed) {
+                return Err(SimulationError::InvalidState(
+                    "h2 response contained a wall-clock Date header".into(),
+                ));
+            }
+            let response = response.into_inner();
+            if response.seq != seq || response.text != text {
+                return Err(SimulationError::InvalidState(
+                    "gRPC echo response did not match its request".into(),
+                ));
+            }
+            tracing::info!(
+                server,
+                channel = channel_index,
+                lane,
+                request = request_index,
+                "multi_channel_response_received"
+            );
+        }
+        Ok(())
+    }
+}
 
 fn run_once(seed: u64) -> Vec<TraceEntry> {
     let trace = Arc::new(Mutex::new(Vec::new()));
@@ -82,6 +328,54 @@ fn run_once(seed: u64) -> Vec<TraceEntry> {
     events
 }
 
+fn run_multi_channel_once(seed: u64) -> Vec<TraceEntry> {
+    let trace = Arc::new(Mutex::new(Vec::new()));
+    let captured = Arc::clone(&trace);
+
+    let report = SimulationBuilder::new()
+        .processes(3, || Box::new(MultiChannelEchoProcess))
+        .workload(MultiChannelEchoWorkload)
+        .invariant_fn("multi-channel tonic replay trace", move |query, _| {
+            let mut events = MULTI_CHANNEL_EVENT_NAMES
+                .iter()
+                .flat_map(|name| query.snapshot(name))
+                .map(|event| {
+                    (
+                        event.seq,
+                        event.time_ms,
+                        event.source,
+                        event.name,
+                        format!("{:?}", event.fields),
+                    )
+                })
+                .collect::<Vec<_>>();
+            events.sort_by_key(|event| event.0);
+            *captured
+                .lock()
+                .expect("Mutex poisoned: prior test panicked") = events;
+        })
+        .set_debug_seeds(vec![seed])
+        .set_iterations(1)
+        .run();
+    assert_eq!(
+        report.failed_runs, 0,
+        "seed {seed} must succeed:\n{report}\n{:?}",
+        report.individual_metrics
+    );
+
+    let events = trace
+        .lock()
+        .expect("Mutex poisoned: prior test panicked")
+        .clone();
+    assert!(
+        events
+            .iter()
+            .any(|event| event.3 == "multi_channel_workload_finished"),
+        "seed {seed} must finish the multi-channel workload"
+    );
+    events
+}
+
 #[test]
 fn tonic_replay_is_independent_of_earlier_in_process_runs() {
     for seed in [1_u64, 42] {
@@ -89,4 +383,15 @@ fn tonic_replay_is_independent_of_earlier_in_process_runs() {
     }
 
     assert_eq!(run_once(12_345), run_once(12_345), "target seed");
+}
+
+#[test]
+fn multi_channel_grpc_replays_without_wall_clock_headers() {
+    for seed in [1_u64, 42, 12_345] {
+        assert_eq!(
+            run_multi_channel_once(seed),
+            run_multi_channel_once(seed),
+            "multi-channel seed {seed}"
+        );
+    }
 }

--- a/crates/moonpool-sim/src/network/sim/engine.rs
+++ b/crates/moonpool-sim/src/network/sim/engine.rs
@@ -165,6 +165,13 @@ impl NetworkSimulation {
         Ok(limit)
     }
 
+    pub(crate) fn has_readable_data(&self, connection_id: ConnectionId) -> bool {
+        self.state
+            .connections
+            .get(&connection_id)
+            .is_some_and(|connection| !connection.receive_buffer.is_empty())
+    }
+
     pub(crate) fn buffer_send(
         &mut self,
         connection_id: ConnectionId,

--- a/crates/moonpool-sim/src/network/sim/facade.rs
+++ b/crates/moonpool-sim/src/network/sim/facade.rs
@@ -51,6 +51,10 @@ impl SimWorld {
         self.inner.write().network.read(id, buf)
     }
 
+    pub(crate) fn has_readable_data(&self, id: ConnectionId) -> bool {
+        self.inner.read().network.has_readable_data(id)
+    }
+
     pub(crate) fn buffer_send(&self, id: ConnectionId, data: Vec<u8>) -> SimulationResult<()> {
         let mut inner = self.inner.write();
         let now = inner.now();

--- a/crates/moonpool-sim/src/network/sim/stream.rs
+++ b/crates/moonpool-sim/src/network/sim/stream.rs
@@ -137,22 +137,13 @@ impl SimTcpStream {
         true
     }
 
-    /// Run the chaos/closure checks that precede backpressure for a write.
+    /// Run the closure checks that precede backpressure for a write.
     ///
     /// Returns `Some(poll)` to short-circuit, `None` to proceed.
     fn write_guard_pre_backpressure(
         &self,
         sim: &crate::sim::SimWorld,
     ) -> Option<Poll<Result<usize, io::Error>>> {
-        // Random close chaos injection (FDB rollRandomClose pattern)
-        // Check at start of every write operation - sim2.actor.cpp:423
-        // Returns Some(true) for explicit error, Some(false) for silent (connection marked closed)
-        if let Some(true) = sim.roll_random_close(self.connection_id) {
-            // 30% explicit exception - throw connection_failed immediately
-            return Some(Poll::Ready(Err(random_connection_failure_error())));
-            // 70% silent case: connection already marked as closed, will fail below
-        }
-
         // Check if send side is closed (asymmetric closure)
         if sim.is_send_closed(self.connection_id) {
             return Some(Poll::Ready(Err(io::Error::new(
@@ -236,14 +227,6 @@ impl AsyncRead for SimTcpStream {
         }
 
         let sim = self.sim.upgrade().map_err(|_| sim_shutdown_error())?;
-        // Random close chaos injection (FDB rollRandomClose pattern)
-        // Check at start of every read operation - sim2.actor.cpp:408
-        // Returns Some(true) for explicit error, Some(false) for silent (connection marked closed)
-        if let Some(true) = sim.roll_random_close(self.connection_id) {
-            // 30% explicit exception - throw connection_failed immediately
-            return Poll::Ready(Err(random_connection_failure_error()));
-            // 70% silent case: connection already marked as closed, will return EOF below
-        }
 
         // `is_recv_closed` includes fully closed connections. Preserve the
         // stronger RST signal before treating an asymmetrically closed receive
@@ -272,6 +255,29 @@ impl AsyncRead for SimTcpStream {
             return Poll::Pending;
         }
 
+        // A parked read is not an I/O operation yet. In particular, do not
+        // consume simulation entropy merely because an executor polls h2 again
+        // while the socket still has no data. Poll counts are not semantic and
+        // may vary independently of the simulated execution.
+        if !sim.has_readable_data(self.connection_id) {
+            return Self::poll_read_no_data(&sim, self.connection_id, cx, buf);
+        }
+
+        // Random close chaos injection (FDB rollRandomClose pattern). Sample
+        // only once the read can make progress, so a no-data `Poll::Pending`
+        // cannot shift the global simulation RNG stream.
+        if let Some(true) = sim.roll_random_close(self.connection_id) {
+            return Poll::Ready(Err(random_connection_failure_error()));
+        }
+        if sim.is_connection_closed(self.connection_id)
+            && sim.close_reason(self.connection_id) == CloseReason::Aborted
+        {
+            return Poll::Ready(Err(connection_aborted_error()));
+        }
+        if sim.is_recv_closed(self.connection_id) {
+            return Poll::Ready(Ok(0));
+        }
+
         // Check if this read should be clogged
         if sim.should_clog_read(self.connection_id) {
             sim.clog_read(self.connection_id);
@@ -293,16 +299,14 @@ impl AsyncRead for SimTcpStream {
             bytes_read
         );
 
-        if bytes_read > 0 {
-            let data_preview = String::from_utf8_lossy(&buf[..bytes_read.min(20)]);
-            tracing::trace!(
-                "SimTcpStream::poll_read connection_id={} returning data: '{}'",
-                self.connection_id.0,
-                data_preview
-            );
-            return Poll::Ready(Ok(bytes_read));
-        }
-        Self::poll_read_no_data(&sim, self.connection_id, cx, buf)
+        debug_assert!(bytes_read > 0, "readable connection returned no bytes");
+        let data_preview = String::from_utf8_lossy(&buf[..bytes_read.min(20)]);
+        tracing::trace!(
+            "SimTcpStream::poll_read connection_id={} returning data: '{}'",
+            self.connection_id.0,
+            data_preview
+        );
+        Poll::Ready(Ok(bytes_read))
     }
 }
 
@@ -406,6 +410,16 @@ impl AsyncWrite for SimTcpStream {
             return Poll::Pending;
         }
 
+        // A full send buffer makes this a no-progress poll, not a fresh I/O
+        // operation. Roll random-close chaos only after capacity is available
+        // so backpressure repolls cannot perturb deterministic replay.
+        if let Some(true) = sim.roll_random_close(self.connection_id) {
+            return Poll::Ready(Err(random_connection_failure_error()));
+        }
+        if let Some(poll) = self.write_guard_pre_backpressure(&sim) {
+            return poll;
+        }
+
         if let Some(poll) = self.write_guard_clog(&sim, cx) {
             return poll;
         }
@@ -452,6 +466,13 @@ impl AsyncWrite for SimTcpStream {
                 return Poll::Ready(Err(sim_shutdown_error()));
             }
             return Poll::Pending;
+        }
+
+        if let Some(true) = sim.roll_random_close(self.connection_id) {
+            return Poll::Ready(Err(random_connection_failure_error()));
+        }
+        if let Some(poll) = self.write_guard_pre_backpressure(&sim) {
+            return poll;
         }
 
         if let Some(poll) = self.write_guard_clog(&sim, cx) {

--- a/crates/moonpool-sim/tests/raw_network_characterization.rs
+++ b/crates/moonpool-sim/tests/raw_network_characterization.rs
@@ -14,11 +14,12 @@ use std::{
 
 use futures::{
     future::join,
-    io::{AsyncReadExt, AsyncWrite, AsyncWriteExt},
+    io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
     task::noop_waker,
 };
 use moonpool_sim::{
     NetworkConfiguration, NetworkProvider, SimWorld, TcpListenerTrait, buggify_init, buggify_reset,
+    reset_rng_call_count, rng_call_count,
 };
 
 const MAX_DRIVER_STEPS: usize = 100_000;
@@ -48,6 +49,15 @@ fn poll_write_once(stream: &mut (impl AsyncWrite + Unpin), data: &[u8]) -> Poll<
     let waker = noop_waker();
     let mut context = Context::from_waker(&waker);
     Pin::new(stream).poll_write(&mut context, data)
+}
+
+fn poll_read_once(
+    stream: &mut (impl AsyncRead + Unpin),
+    data: &mut [u8],
+) -> Poll<io::Result<usize>> {
+    let waker = noop_waker();
+    let mut context = Context::from_waker(&waker);
+    Pin::new(stream).poll_read(&mut context, data)
 }
 
 fn poll_write_vectored_once(
@@ -144,6 +154,48 @@ fn scalar_and_vectored_writes_share_partial_backpressure_semantics() {
     sim.run_until_empty();
     assert!(sim.available_send_buffer(scalar.connection_id()) > 0);
     assert!(sim.available_send_buffer(vectored.connection_id()) > 0);
+}
+
+#[test]
+fn no_progress_io_polls_do_not_consume_simulation_rng() {
+    buggify_reset();
+    let mut sim = fast_world(12_345);
+    let provider = sim.network_provider("127.0.0.1".parse().expect("valid loopback IP"));
+    let listener = drive(&mut sim, provider.bind("poll-entropy-listener")).expect("listener binds");
+    let mut client =
+        drive(&mut sim, provider.connect("poll-entropy-listener")).expect("client connects");
+    let (mut server, _) = drive(&mut sim, listener.accept()).expect("server accepts");
+
+    let capacity = sim.available_send_buffer(client.connection_id());
+    let payload = vec![0x5a; capacity];
+    let accepted = poll_write_once(&mut client, &payload)
+        .map(|result| result.expect("initial write succeeds"));
+    assert_eq!(accepted, Poll::Ready(capacity));
+    assert_eq!(sim.available_send_buffer(client.connection_id()), 0);
+
+    let mut chaos = NetworkConfiguration::fast_local();
+    chaos.chaos.random_close_probability = 0.5;
+    chaos.chaos.random_close_cooldown = Duration::ZERO;
+    chaos.chaos.clog_probability = 0.5;
+    sim.set_network_config(chaos);
+    // Keep random-close call sites enabled but inactive. Their first encounter
+    // would still consume an activation draw, making this a sensitive check
+    // that neither pending path reaches a random decision.
+    buggify_init(0.0, 1.0);
+    reset_rng_call_count();
+
+    let mut byte = [0_u8; 1];
+    for _ in 0..3 {
+        assert!(poll_write_once(&mut client, b"x").is_pending());
+        assert!(poll_read_once(&mut server, &mut byte).is_pending());
+    }
+
+    assert_eq!(
+        rng_call_count(),
+        0,
+        "spurious backpressure and no-data polls must be entropy-neutral"
+    );
+    buggify_reset();
 }
 
 #[test]


### PR DESCRIPTION
Closes #171

## Summary

- keep no-progress simulated TCP polls entropy-neutral
- disable Hyper's automatic wall-clock Date response header in H2Server
- add a three-server, six-channel tonic replay regression with two shared lanes per channel
- inspect raw HTTP/2 responses so the regression deterministically rejects wall-clock Date injection

## Root cause

Hyper's automatic Date header differed between same-seed runs. The changed HPACK dynamic-table state later changed frame sizes, which changed data-bearing TCP read boundaries and shifted shared simulation RNG consumption. Pending I/O polls also consumed entropy before they could make progress, providing a second poll-order-dependent path.

## Validation

- Paros focused replay: 20/20 passed; all diagnostic traces byte-identical
- Paros full suite: 65/65 passed
- Moonpool nextest: 555/555 passed, 1 skipped
- cargo fmt --check
- cargo clippy -- -D warnings
- moonpool-sim clippy without default features
- moonpool-sim wasm32 check without default features
- mdbook build
- regression mutation check: removing auto_date_header(false) makes the new test fail immediately