### PR TITLE
feat(moonpool-sim): add deterministic network fault mask

### DIFF
--- a/book/src/appendix/03-configuration.md
+++ b/book/src/appendix/03-configuration.md
@@ -17,6 +17,7 @@ The builder pattern for configuring and running simulation experiments. Created 
 | `processes(count, factory)` | `impl Into<ProcessCount>`, `Fn() -> Box<dyn Process>` | Add server processes (system under test) |
 | `cluster(config, factory)` | `LocalityConfig`, `Fn() -> Box<dyn Process>` | Add processes laid out across a datacenter/zone/machine topology (replaces `processes`) |
 | `link_latency(config)` | `LinkLatencyConfig` | Give links a distance-dependent latency, resolved through the `cluster` topology |
+| `network_fault_mask(mask)` | `NetworkFaultMask` | Suppress selected families after each Random/Swarm network profile is sampled; deterministic and exploration-safe |
 | `tags(dimensions)` | `&[(&str, &[&str])]` | Attach round-robin tag distribution to processes |
 | `attrition(config)` | `Attrition` | Enable automatic process reboots during chaos phase |
 | `invariant(i)` | `impl Invariant` | Add an invariant checked after every simulation event |
@@ -149,7 +150,32 @@ available send-buffer capacity.
 |-------------|-------------|
 | `NetworkConfiguration::default()` | Standard defaults with chaos enabled |
 | `NetworkConfiguration::random_for_seed()` | Randomized per seed for chaos testing |
+| `NetworkConfiguration::swarm_for_seed()` | Randomized per seed, then restricted to a per-seed subset of fault families |
 | `NetworkConfiguration::fast_local()` | Minimal latencies, all chaos disabled |
+
+### Network fault mask
+
+`SimulationBuilder::network_fault_mask()` applies a typed allow-mask after the
+per-seed Random or Swarm profile and buggify knob perturbations, but before the
+`SimWorld` is created. The mask consumes no simulation or configuration RNG
+draws, so it is compatible with frontier exploration and exact recipe replay.
+The default is `NetworkFaultMask::all()`, which leaves existing builders
+unchanged.
+
+```rust
+SimulationBuilder::new()
+    .enable_chaos([Chaos::Network(ChaosMode::Swarm)])
+    .network_fault_mask(
+        NetworkFaultMask::all().without(NetworkFault::BitFlip),
+    )
+    .enable_exploration(exploration_config)
+```
+
+The mask covers `Clog`, `Partition`, `BitFlip`, `RandomClose`,
+`ConnectFailure`, `ClockDrift`, `BuggifiedDelay`, and `PairLatency`. Removing a
+family can only suppress a fault; it cannot enable a family the sampled profile
+turned off. Partial reads and writes are TCP/buggify behavior rather than
+independently sampled fault families and remain active.
 
 ### Latency distribution
 

--- a/book/src/part3-building/10-network-faults.md
+++ b/book/src/part3-building/10-network-faults.md
@@ -143,6 +143,27 @@ config.chaos.partition_strategy = PartitionStrategy::IsolateSingle;
 // Everything else at defaults
 ```
 
+When a builder should keep its per-seed Random or Swarm profile but exclude one
+environmental fault family, use a `NetworkFaultMask`. For example, this campaign
+retains clogs, partitions, short reads and writes, closes, latency, and the other
+sampled faults while disabling wire-data corruption:
+
+```rust
+SimulationBuilder::new()
+    .enable_chaos([Chaos::Network(ChaosMode::Swarm)])
+    .network_fault_mask(
+        NetworkFaultMask::all().without(NetworkFault::BitFlip),
+    )
+    .enable_exploration(exploration_config)
+```
+
+The builder samples the complete profile first, applies buggify knob changes,
+then applies the mask immediately before creating `SimWorld`. Masking performs
+no RNG draws. The sampled values and Swarm subset therefore stay identical to
+an unmasked run, the in-run RNG call count does not move, and an exploration
+recipe replays deterministically. With the default all-family mask, this step is
+a no-op.
+
 ## Swarm Testing: Less Is More
 
 There is a subtle trap hiding inside `random_for_seed()`. It sets **every** fault family to a random non-zero probability. Clogging is a little bit on, partitions are a little bit on, bit flips are a little bit on, all at once, on every seed. That sounds thorough. It is actually the opposite.

--- a/crates/moonpool-sim/src/lib.rs
+++ b/crates/moonpool-sim/src/lib.rs
@@ -163,7 +163,8 @@ pub use observability::{
 // Network exports
 pub use network::{
     ChaosConfiguration, ConnectFailureMode, LatencyDistribution, LinkLatencyConfig,
-    NetworkConfiguration, PartitionStrategy, SimNetworkProvider, sample_duration, sample_latency,
+    NetworkConfiguration, NetworkFault, NetworkFaultMask, PartitionStrategy, SimNetworkProvider,
+    sample_duration, sample_latency,
 };
 
 // Storage exports

--- a/crates/moonpool-sim/src/network/config.rs
+++ b/crates/moonpool-sim/src/network/config.rs
@@ -166,6 +166,137 @@ pub enum ConnectFailureMode {
     Probabilistic,
 }
 
+/// A network fault family that can be retained or suppressed by a
+/// [`NetworkFaultMask`].
+///
+/// The mask only suppresses faults selected by a network chaos profile; it
+/// never enables a family whose sampled probability or mode is already off.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NetworkFault {
+    /// Write-delivery clogging.
+    Clog,
+    /// Directed network partitions.
+    Partition,
+    /// In-flight data bit-flip corruption.
+    BitFlip,
+    /// Spontaneous connection closes during I/O.
+    RandomClose,
+    /// Connection-establishment failures and hangs.
+    ConnectFailure,
+    /// Per-node simulated clock drift.
+    ClockDrift,
+    /// Buggify-driven extra timer delay.
+    BuggifiedDelay,
+    /// Permanent per-IP-pair latency degradation.
+    PairLatency,
+}
+
+impl NetworkFault {
+    const fn bit(self) -> u8 {
+        match self {
+            Self::Clog => 1 << 0,
+            Self::Partition => 1 << 1,
+            Self::BitFlip => 1 << 2,
+            Self::RandomClose => 1 << 3,
+            Self::ConnectFailure => 1 << 4,
+            Self::ClockDrift => 1 << 5,
+            Self::BuggifiedDelay => 1 << 6,
+            Self::PairLatency => 1 << 7,
+        }
+    }
+}
+
+/// A deterministic allow-mask for per-seed network fault profiles.
+///
+/// [`NetworkFaultMask::all`] is the default. Removing a family makes that
+/// family inert after the builder has sampled its Random or Swarm profile,
+/// without consuming either simulation or configuration randomness. This
+/// makes the mask safe for frontier exploration and exact recipe replay.
+///
+/// Partial reads and writes are TCP behavior exercised by buggify rather than
+/// independently sampled fault families, so this mask deliberately leaves
+/// them unchanged.
+///
+/// # Example
+///
+/// ```
+/// use moonpool_sim::{NetworkFault, NetworkFaultMask};
+///
+/// let mask = NetworkFaultMask::all().without(NetworkFault::BitFlip);
+/// assert!(!mask.contains(NetworkFault::BitFlip));
+/// assert!(mask.contains(NetworkFault::Partition));
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NetworkFaultMask(u8);
+
+impl Default for NetworkFaultMask {
+    fn default() -> Self {
+        Self::all()
+    }
+}
+
+impl NetworkFaultMask {
+    const ALL: u8 = u8::MAX;
+
+    /// Retain every selected network fault family.
+    #[must_use]
+    pub const fn all() -> Self {
+        Self(Self::ALL)
+    }
+
+    /// Suppress every network fault family.
+    #[must_use]
+    pub const fn none() -> Self {
+        Self(0)
+    }
+
+    /// Return a mask that also retains `fault`.
+    #[must_use]
+    pub const fn with(self, fault: NetworkFault) -> Self {
+        Self(self.0 | fault.bit())
+    }
+
+    /// Return a mask that suppresses `fault`.
+    #[must_use]
+    pub const fn without(self, fault: NetworkFault) -> Self {
+        Self(self.0 & !fault.bit())
+    }
+
+    /// Return whether `fault` is retained by this mask.
+    #[must_use]
+    pub const fn contains(self, fault: NetworkFault) -> bool {
+        self.0 & fault.bit() != 0
+    }
+
+    pub(crate) fn apply_to(self, chaos: &mut ChaosConfiguration) {
+        if !self.contains(NetworkFault::Clog) {
+            chaos.clog_probability = 0.0;
+        }
+        if !self.contains(NetworkFault::Partition) {
+            chaos.partition_probability = 0.0;
+        }
+        if !self.contains(NetworkFault::BitFlip) {
+            chaos.bit_flip_probability = 0.0;
+        }
+        if !self.contains(NetworkFault::RandomClose) {
+            chaos.random_close_probability = 0.0;
+        }
+        if !self.contains(NetworkFault::ConnectFailure) {
+            chaos.connect_failure_mode = ConnectFailureMode::Disabled;
+            chaos.connect_failure_probability = 0.0;
+        }
+        if !self.contains(NetworkFault::ClockDrift) {
+            chaos.clock_drift_enabled = false;
+        }
+        if !self.contains(NetworkFault::BuggifiedDelay) {
+            chaos.buggified_delay_enabled = false;
+        }
+        if !self.contains(NetworkFault::PairLatency) {
+            chaos.max_pair_latency = Duration::ZERO..Duration::ZERO;
+        }
+    }
+}
+
 impl ConnectFailureMode {
     /// Create a random failure mode for chaos testing
     #[must_use]
@@ -182,7 +313,7 @@ impl ConnectFailureMode {
 ///
 /// This struct contains all settings related to fault injection and chaos testing,
 /// following `FoundationDB`'s BUGGIFY patterns for deterministic testing.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ChaosConfiguration {
     /// Clogging probability for individual writes (0.0 - 1.0)
     pub clog_probability: f64,
@@ -500,7 +631,7 @@ impl LinkLatencyConfig {
 }
 
 /// Configuration for network simulation parameters
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct NetworkConfiguration {
     /// Latency distribution for bind operations
     pub bind_latency: LatencyDistribution,

--- a/crates/moonpool-sim/src/network/mod.rs
+++ b/crates/moonpool-sim/src/network/mod.rs
@@ -12,7 +12,8 @@ pub mod sim;
 // Re-export configuration
 pub use config::{
     ChaosConfiguration, ConnectFailureMode, LatencyDistribution, LinkLatencyConfig,
-    NetworkConfiguration, PartitionStrategy, sample_duration, sample_latency,
+    NetworkConfiguration, NetworkFault, NetworkFaultMask, PartitionStrategy, sample_duration,
+    sample_latency,
 };
 
 // Re-export simulation network provider

--- a/crates/moonpool-sim/src/runner/builder.rs
+++ b/crates/moonpool-sim/src/runner/builder.rs
@@ -214,6 +214,8 @@ pub struct SimulationBuilder {
     seeds: Vec<u64>,
     network_chaos: Option<ChaosMode>,
     storage_chaos: Option<ChaosMode>,
+    /// Deterministic allow-mask applied after each per-seed network profile.
+    network_fault_mask: crate::NetworkFaultMask,
     /// Distance-based link latency, applied to every iteration's network config.
     link_latency: Option<crate::network::LinkLatencyConfig>,
     /// Buggify-driven knob value-perturbation, enabled via [`Chaos::BuggifyKnobs`].
@@ -258,6 +260,7 @@ impl SimulationBuilder {
             seeds: Vec::new(),
             network_chaos: None,
             storage_chaos: None,
+            network_fault_mask: crate::NetworkFaultMask::all(),
             link_latency: None,
             buggify_knobs: false,
             swarm_operations: false,
@@ -410,6 +413,31 @@ impl SimulationBuilder {
     #[must_use]
     pub fn link_latency(mut self, config: crate::network::LinkLatencyConfig) -> Self {
         self.link_latency = Some(config);
+        self
+    }
+
+    /// Retain only the selected network fault families in every per-seed
+    /// Random or Swarm profile.
+    ///
+    /// The mask is applied after profile sampling and buggify knob
+    /// perturbation, immediately before the [`SimWorld`](crate::SimWorld) is
+    /// created. Applying it consumes no randomness, so configuration RNG draw
+    /// order, exploration recipes, and replay remain unchanged. The default
+    /// mask retains every family and is behaviorally inert.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// SimulationBuilder::new()
+    ///     .enable_chaos([Chaos::Network(ChaosMode::Swarm)])
+    ///     .network_fault_mask(
+    ///         NetworkFaultMask::all().without(NetworkFault::BitFlip),
+    ///     )
+    ///     .enable_exploration(exploration_config)
+    /// ```
+    #[must_use]
+    pub fn network_fault_mask(mut self, mask: crate::NetworkFaultMask) -> Self {
+        self.network_fault_mask = mask;
         self
     }
 
@@ -806,11 +834,14 @@ impl SimulationBuilder {
     /// from its [`ChaosMode`]: `None` ⇒ default (off), `Random` ⇒ `random_for_seed`,
     /// `Swarm` ⇒ `swarm_for_seed`.
     ///
-    /// The network mask (if any) draws from `CONFIG_RNG` before the storage mask,
-    /// keeping the per-seed draw order fixed and reproducible.
+    /// The Swarm network subset (if any) draws from `CONFIG_RNG` before the
+    /// storage subset, keeping the per-seed draw order fixed and reproducible.
+    /// The caller's [`NetworkFaultMask`](crate::NetworkFaultMask) is applied
+    /// afterward and consumes no draws.
     fn build_sim_for_iteration(
         network_chaos: Option<ChaosMode>,
         storage_chaos: Option<ChaosMode>,
+        network_fault_mask: crate::NetworkFaultMask,
         link_latency: Option<crate::network::LinkLatencyConfig>,
         buggify_knobs: bool,
         seed: u64,
@@ -837,6 +868,9 @@ impl SimulationBuilder {
                 storage_config.apply_buggify_knobs();
             }
         }
+        // A caller mask is the final fault-family decision. It consumes no RNG,
+        // so adding or omitting it cannot shift config sampling or replay.
+        network_fault_mask.apply_to(&mut network_config.chaos);
         // Distance latency is deployment shape, not a per-seed fault: it is
         // applied verbatim, whatever the chaos mode.
         network_config.link_latency = link_latency;
@@ -1507,6 +1541,7 @@ impl SimulationBuilder {
         let mut sim = Self::build_sim_for_iteration(
             self.network_chaos,
             self.storage_chaos,
+            self.network_fault_mask,
             self.link_latency.clone(),
             self.buggify_knobs,
             seed,
@@ -1895,6 +1930,61 @@ mod tests {
         assert_eq!(report.failed_runs, 0);
         assert!((report.success_rate() - 100.0).abs() < f64::EPSILON);
         assert_eq!(report.seeds_used, vec![1, 2, 3]);
+    }
+
+    fn sampled_network_config(
+        mode: ChaosMode,
+        mask: crate::NetworkFaultMask,
+        seed: u64,
+    ) -> (crate::NetworkConfiguration, u64) {
+        crate::sim::reset_sim_rng();
+        crate::sim::set_sim_seed(seed);
+        crate::sim::set_config_seed(seed);
+        let sim =
+            SimulationBuilder::build_sim_for_iteration(Some(mode), None, mask, None, false, seed);
+        let config = sim.with_network_config(Clone::clone);
+        let next_config_draw = crate::sim::config_random_f64().to_bits();
+        (config, next_config_draw)
+    }
+
+    #[test]
+    fn network_fault_mask_disables_only_bit_flips() {
+        let seed = 174;
+        let (baseline, _) =
+            sampled_network_config(ChaosMode::Random, crate::NetworkFaultMask::all(), seed);
+        let (masked, _) = sampled_network_config(
+            ChaosMode::Random,
+            crate::NetworkFaultMask::all().without(crate::NetworkFault::BitFlip),
+            seed,
+        );
+
+        assert!(baseline.chaos.bit_flip_probability > 0.0);
+        let mut expected = baseline;
+        expected.chaos.bit_flip_probability = 0.0;
+        assert_eq!(masked, expected, "the mask changed another fault family");
+        assert!(masked.chaos.partial_read_max_bytes > 0);
+        assert!(masked.chaos.partial_write_max_bytes > 0);
+    }
+
+    #[test]
+    fn network_fault_mask_preserves_swarm_config_rng_position() {
+        let (seed, baseline, baseline_next_draw) = (0..1000_u64)
+            .find_map(|seed| {
+                let (config, next_draw) =
+                    sampled_network_config(ChaosMode::Swarm, crate::NetworkFaultMask::all(), seed);
+                (config.chaos.bit_flip_probability > 0.0).then_some((seed, config, next_draw))
+            })
+            .expect("expected Swarm to select bit flips within 1000 seeds");
+        let (masked, masked_next_draw) = sampled_network_config(
+            ChaosMode::Swarm,
+            crate::NetworkFaultMask::all().without(crate::NetworkFault::BitFlip),
+            seed,
+        );
+
+        let mut expected = baseline;
+        expected.chaos.bit_flip_probability = 0.0;
+        assert_eq!(masked, expected);
+        assert_eq!(masked_next_draw, baseline_next_draw);
     }
 
     #[cfg(feature = "exploration")]

--- a/crates/moonpool-sim/tests/exploration/tests.rs
+++ b/crates/moonpool-sim/tests/exploration/tests.rs
@@ -10,8 +10,9 @@ use std::collections::BTreeMap;
 use async_trait::async_trait;
 use futures::io::{AsyncReadExt, AsyncWriteExt};
 use moonpool_sim::{
-    ExplorationConfig, Invariant, NetworkProvider, Process, SimContext, SimulationBuilder,
-    SimulationError, SimulationReport, SimulationResult, TcpListenerTrait, TraceQuery, Workload,
+    Chaos, ChaosMode, ExplorationConfig, Invariant, NetworkFault, NetworkFaultMask,
+    NetworkProvider, Process, SimContext, SimulationBuilder, SimulationError, SimulationReport,
+    SimulationResult, TcpListenerTrait, TraceQuery, Workload,
 };
 
 /// Helper to run a simulation and return the report.
@@ -333,6 +334,52 @@ fn test_exploration_basic() {
     assert!(
         exp.discoveries > 0,
         "expected the sometimes assertion to be discovered"
+    );
+}
+
+/// A typed network fault mask is reconstructed before every root and
+/// continuation timeline, so explored Swarm campaigns can exclude corruption
+/// without falling back to a forbidden `before_iteration` hook.
+#[test]
+fn test_network_fault_mask_with_exploration() {
+    let run = || {
+        run_simulation(
+            SimulationBuilder::new()
+                .set_iterations(1)
+                .set_debug_seeds(vec![174])
+                .enable_chaos([Chaos::Network(ChaosMode::Swarm)])
+                .network_fault_mask(NetworkFaultMask::all().without(NetworkFault::BitFlip))
+                .enable_exploration(test_config(0, 10))
+                .workload_factory(|| {
+                    Box::new(AssertOnceWorkload {
+                        message: "masked network exploration",
+                    })
+                }),
+        )
+    };
+    let first = run();
+    let second = run();
+
+    assert_eq!(first.successful_runs, 1);
+    assert_eq!(second.successful_runs, 1);
+    let first_exploration = first.exploration.expect("exploration report missing");
+    let second_exploration = second.exploration.expect("exploration report missing");
+    assert!(
+        first_exploration.total_timelines > 1,
+        "expected masked network exploration to run continuations"
+    );
+    assert_eq!(
+        first_exploration.total_timelines,
+        second_exploration.total_timelines
+    );
+    assert_eq!(first_exploration.expansions, second_exploration.expansions);
+    assert_eq!(
+        first_exploration.discoveries,
+        second_exploration.discoveries
+    );
+    assert_eq!(
+        first_exploration.per_seed_timelines,
+        second_exploration.per_seed_timelines
     );
 }
 


### PR DESCRIPTION
## Summary
- add a typed NetworkFaultMask builder API for suppressing individual sampled network fault families
- apply the mask after Random/Swarm sampling and buggify perturbation without consuming RNG draws
- cover bit-flip suppression, config RNG stability, deterministic exploration, and document the API

## Validation
- nix develop --command cargo fmt
- nix develop --command cargo clippy
- nix develop --command cargo nextest run (558 passed)
- no-default-features clippy
- wasm32-unknown-unknown check
- mdbook build book/

Fixes #174