### PR TITLE
fix(moonpool-sim): bound chaos delays and swarm attrition

### DIFF
--- a/book/src/appendix/03-configuration.md
+++ b/book/src/appendix/03-configuration.md
@@ -104,6 +104,11 @@ Built-in configuration for automatic process reboots during the chaos phase. Req
 
 The `prob_*` fields are **weights**, not probabilities. They are normalized internally and do not need to sum to 1.0.
 
+In `ChaosMode::Swarm`, the recovery range is scaled per seed to 50%-200% of
+its configured values. Clustered campaigns also swarm among topology-backed
+scopes whose groups fit `max_dead`. Both decisions use `CONFIG_RNG`, leaving the
+counted runtime RNG stream unchanged.
+
 ### AttritionScope
 
 Which failure domain a reboot kills. `PerMachine`, `PerZone`, and `PerDatacenter` require a [`.cluster()`](../part3-building/09-attrition.md#failure-domains-correlated-reboots) topology; without locality they are a no-op.
@@ -276,6 +281,11 @@ Each ordered IP pair samples one fixed latency from this range at first contact 
 | `buggified_delay_enabled` | `bool` | `true` |
 | `buggified_delay_max` | `Duration` | 100ms |
 | `buggified_delay_probability` | `f64` | 0.25 (25%) |
+
+Builder campaigns apply this fault only to sleeps scheduled inside
+`.chaos_duration()`. Setup and the post-chaos quiet tail do not consume its RNG
+draws or receive extra delay. A directly constructed `SimWorld` has no campaign
+window and applies the configured fault for its whole lifetime.
 
 ### Connection Failures
 

--- a/book/src/part3-building/09-attrition.md
+++ b/book/src/part3-building/09-attrition.md
@@ -85,7 +85,21 @@ SimulationBuilder::new()
 
 The `.chaos_duration()` call is required because attrition runs only during the chaos phase. After the chaos duration elapses, fault injectors stop and the system continues until all workloads complete. A settle phase then drains remaining events before checks run, surfacing cleanup bugs rather than hiding them behind an arbitrary timer.
 
-`ChaosMode::Random` uses your configured weights as written every seed. Switch to `ChaosMode::Swarm` to swarm the reboot *regime* itself: each seed draws a random subset of the configuration, including the never-reboot case (which surfaces slow-leak and timer bugs that constant restarting hides) and single-mode cases like always-crash or graceful-only. Same reasoning as [swarming network faults](10-network-faults.md#swarm-testing-less-is-more).
+`ChaosMode::Random` uses your configured weights, recovery window, and scope as
+written every seed. Switch to `ChaosMode::Swarm` to swarm the reboot *regime*
+itself. Each seed can select the never-reboot case (which surfaces slow-leak and
+timer bugs that constant restarting hides), a single reboot kind such as
+always-crash or graceful-only, and a recovery-delay range scaled to between 50%
+and 200% of the configured range. With `.cluster()`, the seed also selects among
+`PerProcess` and correlated failure scopes whose groups fit the sampled
+`max_dead` budget. A flat `.processes()` campaign keeps its configured scope
+because it has no failure-domain topology to swarm.
+
+These regime choices come from the separate `CONFIG_RNG` stream. The injector
+still makes the same runtime draws for the actual recovery delay and victim, so
+changing the per-seed regime does not move `SIM_RNG` call counts or invalidate
+an exploration recipe. Same reasoning as [swarming network
+faults](10-network-faults.md#swarm-testing-less-is-more).
 
 ## The max_dead Constraint
 

--- a/book/src/part3-building/10-network-faults.md
+++ b/book/src/part3-building/10-network-faults.md
@@ -70,6 +70,23 @@ Packet data is corrupted with random bit flips at low probability (0.01% by defa
 
 Simulated clocks can drift by up to 100ms (configurable) between nodes. This tests anything that depends on time agreement: lease expiration, distributed consensus, TTL handling, and cache invalidation. Clock drift is subtle because the code often works correctly with small drift and fails catastrophically when drift exceeds a threshold.
 
+### Buggified Sleep Delay
+
+FoundationDB occasionally stretches a process timer with a power-law delay to
+exercise timeouts and timing-dependent races. Moonpool applies the same fault to
+`TimeProvider::sleep`. In a `SimulationBuilder` campaign it is active only during
+the configured `chaos_duration`: setup is clean, and sleeps scheduled at or
+after the chaos deadline receive exactly their requested duration. This makes
+the post-chaos quiet tail a real recovery period, so a claim such as "the
+cluster converges within five seconds after faults stop" is measuring the
+cluster rather than a fault that silently continued running.
+
+The gate is checked before either buggified-delay RNG draw. A configuration that
+disables the fault, a `NetworkFaultMask` without `BuggifiedDelay`, and sleeps
+outside the chaos window therefore leave the counted simulation RNG untouched.
+Direct low-level `SimWorld` construction has no campaign phases and retains the
+historical whole-run behavior.
+
 ### Network Partitions
 
 Moonpool supports seven partition strategies:
@@ -179,7 +196,7 @@ SimulationBuilder::new()
     // ...
 ```
 
-`ChaosMode::Swarm` builds on `random_for_seed()`, then masks each of the seven network fault families to off with 50% probability: clog, partition, bit-flip, random-close, connect-failure, clock-drift, and buggified-delay. The all-off subset is allowed on purpose, because a pure no-fault run is a useful, valid config. The same `enable_chaos` call swarms storage faults (`Chaos::Storage`) and the attrition reboot regime (`Chaos::Attrition`) the same way.
+`ChaosMode::Swarm` builds on `random_for_seed()`, then masks each of the eight network fault families to off with 50% probability: clog, partition, bit-flip, random-close, connect-failure, clock-drift, buggified-delay, and permanent pair latency. The all-off subset is allowed on purpose, because a pure no-fault run is a useful, valid config. The same `enable_chaos` call swarms storage faults (`Chaos::Storage`) and the attrition reboot regime (`Chaos::Attrition`) the same way.
 
 The interesting engineering detail is **where the randomness comes from**. Swarm decisions must not perturb the in-run randomness, or they would shift every fault's timing and break fork-explorer replay. So the subset is drawn from a separate `CONFIG_RNG` stream, seeded from the iteration seed but salted to decorrelate it from the main `SIM_RNG`. The config RNG never advances the in-run call counter. Same seed, same subset, every time, with zero effect on the simulation that follows.
 

--- a/crates/moonpool-sim/src/runner/builder.rs
+++ b/crates/moonpool-sim/src/runner/builder.rs
@@ -875,6 +875,10 @@ impl SimulationBuilder {
         // applied verbatim, whatever the chaos mode.
         network_config.link_latency = link_latency;
         let mut sim = crate::sim::SimWorld::new_with_network_config_and_seed(network_config, seed);
+        // Unlike raw `SimWorld` use, a builder campaign has explicit phases.
+        // Setup and the post-chaos quiet tail must not inherit the global sleep
+        // delay fault merely because the sampled network config enabled it.
+        sim.prepare_buggified_delay_campaign();
         sim.set_storage_config(storage_config);
         sim
     }
@@ -1563,7 +1567,13 @@ impl SimulationBuilder {
         // from `CONFIG_RNG` (after the network/storage masks, keeping the draw order
         // fixed); `Random` uses the configured weights as written.
         let attrition = match (self.attrition.as_ref(), self.attrition_mode) {
-            (Some(base), ChaosMode::Swarm) => Some(base.swarm_for_seed()),
+            (Some(base), ChaosMode::Swarm) => Some(
+                base.swarm_for_seed_with_topology(
+                    process_config
+                        .as_ref()
+                        .map(|config| &config.machine_registry),
+                ),
+            ),
             (Some(base), ChaosMode::Random) => Some(base.clone()),
             (None, _) => None,
         };

--- a/crates/moonpool-sim/src/runner/orchestrator.rs
+++ b/crates/moonpool-sim/src/runner/orchestrator.rs
@@ -480,6 +480,7 @@ impl WorkloadOrchestrator {
         } = inputs;
 
         let chaos_shutdown = tokio_util::sync::CancellationToken::new();
+        sim.start_buggified_delay_window(chaos_duration);
         let all_ips: Vec<String> = all_entities.iter().map(|(_, ip)| ip.clone()).collect();
         let (mut injector_handles, parked_injectors) = Self::start_fault_injectors(
             fault_injectors,

--- a/crates/moonpool-sim/src/runner/process.rs
+++ b/crates/moonpool-sim/src/runner/process.rs
@@ -199,18 +199,29 @@ impl Attrition {
     /// importantly the **never-reboot** case (needed to find slow leaks / timer
     /// overflows) and single-mode cases ("always crash", "graceful-only").
     ///
-    /// Draws exactly four `config_random_bool` values from the independent
+    /// Draws exactly six values from the independent
     /// `CONFIG_RNG` stream (fixed sequence ⇒ reproducible per seed, never
     /// perturbs in-run randomness). The first draw, with ~50% probability, sets
     /// `max_dead = 0` — the never-reboot regime, where the injector's
     /// `dead_count() >= max_dead` gate is always true so it never reboots. The
     /// remaining three each mask one reboot-kind weight to `0.0` with ~50%
-    /// probability.
+    /// probability. A fifth draw scales the configured recovery-delay range to
+    /// 50%-200% of its pinned values. The sixth is reserved for failure scope;
+    /// the runner uses it to select a topology-backed scope whose groups can fit
+    /// within `max_dead`.
     ///
     /// When all three kind weights are masked off, [`choose_kind`](Self::choose_kind)
     /// falls back to [`RebootKind::Crash`] — the "always crash" single-mode regime.
     #[must_use]
     pub fn swarm_for_seed(&self) -> Attrition {
+        self.swarm_for_seed_with_topology(None)
+    }
+
+    /// Derive a swarm regime with failure scopes constrained by `topology`.
+    pub(crate) fn swarm_for_seed_with_topology(
+        &self,
+        topology: Option<&super::locality::MachineRegistry>,
+    ) -> Attrition {
         let mut regime = self.clone();
         if !crate::sim::config_random_bool(0.5) {
             regime.max_dead = 0;
@@ -224,14 +235,78 @@ impl Attrition {
         if !crate::sim::config_random_bool(0.5) {
             regime.prob_wipe = 0.0;
         }
+
+        // Scale the whole window rather than sampling the eventual delay here:
+        // the injector still performs its usual single SIM_RNG draw, preserving
+        // counted-stream call positions and exploration recipes.
+        let recovery = self.recovery_delay_ms.clone().unwrap_or(1000..10000);
+        let scale_percent = crate::sim::rng::config_random_range(50..201);
+        regime.recovery_delay_ms = Some(Self::scaled_range(recovery, scale_percent));
+
+        // Twelve is divisible by every possible candidate count (1..=4), so
+        // reducing it modulo the viable set does not bias one scope.
+        let scope_draw = crate::sim::rng::config_random_range(0..12);
+        if let Some(topology) = topology.filter(|topology| !topology.is_empty()) {
+            let scopes = Self::viable_scopes(topology, regime.max_dead);
+            regime.scope = scopes[scope_draw % scopes.len()];
+        }
         regime
+    }
+
+    fn scaled_range(range: Range<usize>, percent: usize) -> Range<usize> {
+        let mut start = range.start.saturating_mul(percent) / 100;
+        let mut end = range.end.saturating_mul(percent) / 100;
+        if end <= start {
+            end = start.saturating_add(1);
+            if end == start {
+                start = start.saturating_sub(1);
+            }
+        }
+        start..end
+    }
+
+    fn viable_scopes(
+        topology: &super::locality::MachineRegistry,
+        max_dead: usize,
+    ) -> Vec<AttritionScope> {
+        let mut scopes = vec![AttritionScope::PerProcess];
+        let candidates = [
+            (
+                AttritionScope::PerMachine,
+                crate::locality::DomainLevel::Machine,
+                topology.all_machines(),
+            ),
+            (
+                AttritionScope::PerZone,
+                crate::locality::DomainLevel::Zone,
+                topology.all_zones(),
+            ),
+            (
+                AttritionScope::PerDatacenter,
+                crate::locality::DomainLevel::Datacenter,
+                topology.all_datacenters(),
+            ),
+        ];
+        for (scope, level, domains) in candidates {
+            let fits_budget = domains.iter().all(|domain| {
+                let group_size = topology.ips_in_domain(level, domain).len();
+                group_size > 0 && group_size <= max_dead
+            });
+            if fits_budget {
+                scopes.push(scope);
+            }
+        }
+        scopes
     }
 }
 
 #[cfg(test)]
 mod swarm_tests {
+    use std::net::IpAddr;
+
     use super::{Attrition, AttritionScope};
-    use crate::sim::rng::set_config_seed;
+    use crate::sim::rng::{rng_call_count, set_config_seed, set_sim_seed};
+    use crate::{LocalityInfo, runner::locality::MachineRegistry};
 
     /// A representative base regime: all three reboot kinds enabled.
     fn base() -> Attrition {
@@ -286,5 +361,75 @@ mod swarm_tests {
             saw_single_mode,
             "no seed in 0..1000 produced a single-mode regime (one kind enabled)"
         );
+    }
+
+    #[test]
+    fn swarm_varies_recovery_window_across_seeds() {
+        let windows = (0..100_u64)
+            .map(|seed| swarm_for(seed).recovery_delay_ms)
+            .collect::<Vec<_>>();
+        let first = windows[0].clone();
+        assert!(
+            windows.iter().any(|window| *window != first),
+            "swarm did not vary the recovery window across 100 seeds"
+        );
+    }
+
+    #[test]
+    fn attrition_swarm_never_advances_the_counted_rng() {
+        set_sim_seed(42);
+        set_config_seed(42);
+        let before = rng_call_count();
+
+        let _ = base().swarm_for_seed();
+
+        assert_eq!(rng_call_count(), before);
+    }
+
+    fn topology(processes_per_machine: usize) -> MachineRegistry {
+        let mut topology = MachineRegistry::new();
+        let mut process = 1_u8;
+        for machine in 1..=2 {
+            for _ in 0..processes_per_machine {
+                topology.register(
+                    IpAddr::from([10, 0, 1, process]),
+                    LocalityInfo::new(
+                        format!("dc{machine}"),
+                        format!("dc{machine}-z1"),
+                        format!("dc{machine}-z1-m1"),
+                    ),
+                );
+                process += 1;
+            }
+        }
+        topology
+    }
+
+    #[test]
+    fn clustered_swarm_varies_viable_attrition_scope() {
+        let topology = topology(1);
+        let scopes = (0..100_u64)
+            .map(|seed| {
+                set_config_seed(seed);
+                base().swarm_for_seed_with_topology(Some(&topology)).scope
+            })
+            .collect::<Vec<_>>();
+
+        assert!(
+            scopes
+                .iter()
+                .any(|scope| *scope != AttritionScope::PerProcess),
+            "clustered swarm did not select a correlated failure scope"
+        );
+    }
+
+    #[test]
+    fn clustered_swarm_rejects_scopes_that_exceed_max_dead() {
+        let topology = topology(3);
+        for seed in 0..100_u64 {
+            set_config_seed(seed);
+            let regime = base().swarm_for_seed_with_topology(Some(&topology));
+            assert_eq!(regime.scope, AttritionScope::PerProcess);
+        }
     }
 }

--- a/crates/moonpool-sim/src/sim/rng.rs
+++ b/crates/moonpool-sim/src/sim/rng.rs
@@ -355,6 +355,17 @@ pub fn config_random_bool(p: f64) -> bool {
     config_random_f64() < p
 }
 
+/// Generate a value within a range using the configuration RNG.
+///
+/// Like [`config_random_bool`], this never touches the counted [`SIM_RNG`]
+/// stream, so per-seed configuration choices cannot shift exploration recipes.
+pub(crate) fn config_random_range<T>(range: std::ops::Range<T>) -> T
+where
+    T: SampleUniform + PartialOrd,
+{
+    CONFIG_RNG.with(|rng| rng.borrow_mut().random_range(range))
+}
+
 /// Set the per-seed base for workload operation-alphabet swarm masks.
 ///
 /// Called once per iteration by the runner: `Some(seed)` when `.swarm_operations()`
@@ -674,6 +685,7 @@ mod tests {
         for _ in 0..5 {
             let _ = config_random_bool(0.5);
             let _ = config_random_f64();
+            let _ = config_random_range(10..20);
             experiment.push(sim_random::<f64>());
         }
 

--- a/crates/moonpool-sim/src/sim/world.rs
+++ b/crates/moonpool-sim/src/sim/world.rs
@@ -65,6 +65,18 @@ pub(crate) struct SimInner {
     pub(crate) events_processed: u64,
     pub(crate) last_processed_event: Option<Event>,
     pub(crate) pending_faults: Vec<SimFaultRecord>,
+    buggified_delay_window: BuggifiedDelayWindow,
+}
+
+/// Campaign lifetime for the global sleep-delay fault.
+#[derive(Debug, Clone, Copy)]
+enum BuggifiedDelayWindow {
+    /// Raw `SimWorld` users retain the historical whole-run behavior.
+    Unbounded,
+    /// Campaign setup, a campaign without a chaos duration, or the quiet tail.
+    Inactive,
+    /// The run phase is inside its configured chaos interval.
+    ActiveUntil(Duration),
 }
 
 impl SimInner {
@@ -83,6 +95,7 @@ impl SimInner {
             events_processed: 0,
             last_processed_event: None,
             pending_faults: Vec::new(),
+            buggified_delay_window: BuggifiedDelayWindow::Unbounded,
         }
     }
 
@@ -417,6 +430,14 @@ impl SimWorld {
         if !chaos.buggified_delay_enabled || chaos.buggified_delay_max == Duration::ZERO {
             return duration;
         }
+        let inside_chaos_window = match inner.buggified_delay_window {
+            BuggifiedDelayWindow::Unbounded => true,
+            BuggifiedDelayWindow::Inactive => false,
+            BuggifiedDelayWindow::ActiveUntil(deadline) => inner.now() < deadline,
+        };
+        if !inside_chaos_window {
+            return duration;
+        }
         if sim_random::<f64>() < chaos.buggified_delay_probability {
             duration.saturating_add(
                 chaos
@@ -426,6 +447,22 @@ impl SimWorld {
         } else {
             duration
         }
+    }
+
+    /// Keep campaign setup free of the global sleep-delay fault until the run
+    /// phase establishes its chaos window.
+    pub(crate) fn prepare_buggified_delay_campaign(&self) {
+        self.inner.write().buggified_delay_window = BuggifiedDelayWindow::Inactive;
+    }
+
+    /// Activate the global sleep-delay fault until the configured chaos
+    /// interval ends. `None` leaves it inactive because no chaos phase exists.
+    pub(crate) fn start_buggified_delay_window(&self, duration: Option<Duration>) {
+        let mut inner = self.inner.write();
+        inner.buggified_delay_window = duration
+            .map_or(BuggifiedDelayWindow::Inactive, |duration| {
+                BuggifiedDelayWindow::ActiveUntil(inner.now().saturating_add(duration))
+            });
     }
 
     pub(crate) fn poll_sleep(&self, task_id: u64, waker: &Waker) -> bool {
@@ -571,6 +608,52 @@ mod tests {
                 Poll::Ready(Ok(()))
             ));
         }
+    }
+
+    #[test]
+    fn buggified_delay_only_draws_inside_campaign_window() {
+        let mut config = NetworkConfiguration::fast_local();
+        config.chaos.buggified_delay_enabled = true;
+        config.chaos.buggified_delay_probability = 1.0;
+        config.chaos.buggified_delay_max = Duration::from_secs(1);
+        let mut sim = SimWorld::new_with_network_config(config);
+
+        sim.prepare_buggified_delay_campaign();
+        let setup_sleep = sim.sleep(Duration::from_millis(1));
+        assert_eq!(crate::sim::rng_call_count(), 0);
+        drop(setup_sleep);
+
+        sim.start_buggified_delay_window(Some(Duration::from_millis(5)));
+        let chaos_sleep = sim.sleep(Duration::from_millis(1));
+        assert_eq!(crate::sim::rng_call_count(), 2);
+        drop(chaos_sleep);
+
+        sim.schedule_event(Event::Timer { task_id: u64::MAX }, Duration::from_millis(5));
+        assert!(!sim.step());
+        let draws_at_cutoff = crate::sim::rng_call_count();
+        let quiet_start = sim.now();
+        let quiet_sleep = sim.sleep(Duration::from_millis(1));
+        assert_eq!(crate::sim::rng_call_count(), draws_at_cutoff);
+        sim.run_until_empty();
+        assert_eq!(
+            sim.now().saturating_sub(quiet_start),
+            Duration::from_millis(1)
+        );
+        drop(quiet_sleep);
+    }
+
+    #[test]
+    fn disabled_buggified_delay_preserves_rng_position_with_campaign_window() {
+        let mut config = NetworkConfiguration::fast_local();
+        config.chaos.buggified_delay_enabled = false;
+        let sim = SimWorld::new_with_network_config(config);
+
+        sim.prepare_buggified_delay_campaign();
+        sim.start_buggified_delay_window(Some(Duration::from_secs(1)));
+        let sleep = sim.sleep(Duration::from_millis(1));
+
+        assert_eq!(crate::sim::rng_call_count(), 0);
+        drop(sleep);
     }
 
     #[test]

--- a/crates/moonpool-sim/tests/chaos/buggified_delay.rs
+++ b/crates/moonpool-sim/tests/chaos/buggified_delay.rs
@@ -7,7 +7,11 @@
 //! - Add extra latency to sleep operations
 //! - Are deterministic across runs with the same seed
 
-use moonpool_sim::{NetworkConfiguration, SimWorld};
+use async_trait::async_trait;
+use moonpool_sim::{
+    Chaos, ChaosMode, NetworkConfiguration, NetworkFault, NetworkFaultMask, SimContext, SimWorld,
+    SimulationBuilder, SimulationError, TimeProvider, Workload,
+};
 use std::time::Duration;
 
 /// Test that buggified delay is disabled when explicitly turned off
@@ -242,4 +246,50 @@ async fn test_buggified_delay_default_probability() {
     );
 
     println!("✅ Default 25% probability executed successfully");
+}
+
+struct QuietTailSleep;
+
+#[async_trait]
+impl Workload for QuietTailSleep {
+    fn name(&self) -> &'static str {
+        "quiet-tail-sleep"
+    }
+
+    async fn run(&mut self, ctx: &SimContext) -> moonpool_sim::SimulationResult<()> {
+        // This sleep is scheduled inside a 1ms chaos window but necessarily
+        // wakes after it. The next sleep is therefore scheduled in the quiet
+        // tail and must not receive a buggified delay.
+        ctx.time()
+            .sleep(Duration::from_millis(2))
+            .await
+            .map_err(|error| SimulationError::InvalidState(error.to_string()))?;
+        let start = ctx.time().now();
+        let requested = Duration::from_millis(1);
+        ctx.time()
+            .sleep(requested)
+            .await
+            .map_err(|error| SimulationError::InvalidState(error.to_string()))?;
+        let elapsed = ctx.time().now().saturating_sub(start);
+        if elapsed != requested {
+            return Err(SimulationError::InvalidState(format!(
+                "quiet-tail sleep was inflated: requested {requested:?}, elapsed {elapsed:?}"
+            )));
+        }
+        Ok(())
+    }
+}
+
+#[test]
+fn builder_campaign_stops_buggified_delay_at_chaos_deadline() {
+    let report = SimulationBuilder::new()
+        .enable_chaos([Chaos::Network(ChaosMode::Random)])
+        .network_fault_mask(NetworkFaultMask::none().with(NetworkFault::BuggifiedDelay))
+        .chaos_duration(Duration::from_millis(1))
+        .set_iterations(1)
+        .set_debug_seeds(vec![42])
+        .workload(QuietTailSleep)
+        .run();
+
+    assert_eq!(report.failed_runs, 0, "quiet-tail campaign failed");
 }


### PR DESCRIPTION
## Summary

- gate buggified sleep delay to the configured builder chaos window, keeping setup and the quiet tail fault-free
- vary attrition recovery windows per seed in Swarm mode and choose only topology scopes that fit `max_dead`
- keep both decisions replay-safe by avoiding counted `SIM_RNG` draws outside their existing runtime positions
- document the campaign and swarm semantics

Closes #176.
Closes #177.

## Validation

- `nix develop --command cargo fmt`
- `nix develop --command cargo clippy`
- `nix develop --command cargo nextest run` (565 passed, 1 skipped)
- `nix develop --command mdbook build book/`