### PR TITLE
fix(moonpool-sim): kill the process task when a crash reboot starts

### DIFF
--- a/book/src/appendix/04-fault-reference.md
+++ b/book/src/appendix/04-fault-reference.md
@@ -130,7 +130,7 @@ custom [`FaultInjector`](../part3-building/07-chaos.md) implementations.
 | Fault | Mechanism | Behavior |
 |-------|-----------|----------|
 | Graceful reboot | `RebootKind::Graceful` | Signal shutdown token, wait grace period (default 2-5s), force kill, restart after recovery delay (default 1-10s) |
-| Crash reboot | `RebootKind::Crash` | Immediate task abort, all connections reset, restart after recovery delay |
+| Crash reboot | `RebootKind::Crash` | Immediate task abort at the crash instant, all connections reset, restart after recovery delay |
 | Crash + wipe | `RebootKind::CrashAndWipe` | Crash behavior + immediate wipe of all persistent storage owned by the process (scoped by IP) |
 | Continuous attrition | `Attrition` config | Random reboots during chaos phase with weighted `prob_graceful`/`prob_crash`/`prob_wipe` and `max_dead` limit |
 | Correlated reboot | `AttritionScope::PerMachine` / `PerZone` / `PerDatacenter` | Reboot every process of one failure domain together; only fires when the whole group fits in `max_dead` |

--- a/book/src/part3-building/09-attrition.md
+++ b/book/src/part3-building/09-attrition.md
@@ -20,7 +20,7 @@ This models rolling deployments, planned maintenance, and well-behaved process m
 
 ### Crash
 
-The sudden death. The process task is immediately cancelled. All connections abort with no buffer drain. Peers see connection reset errors. Any in-memory state is lost. The process restarts after a recovery delay.
+The sudden death. The process task is cancelled at the crash instant -- before its connections abort, so nothing the crash disturbs can wake it again. All connections abort with no buffer drain. Peers see connection reset errors. Any in-memory state is lost. The process runs no further work until it restarts, after a recovery delay.
 
 This models kernel panics, OOM kills, and hardware failures. There is no warning and no cleanup. Code that assumes a graceful shutdown will always happen gets a rude surprise.
 

--- a/book/src/part3-building/17-events-and-invariants.md
+++ b/book/src/part3-building/17-events-and-invariants.md
@@ -188,7 +188,7 @@ fault beside its ordered scheduler effects, and `SimWorld` stamps it with the
 current monotonic scheduler time before the runner merges it into the trace
 timeline.
 
-- **Process lifecycle**: `process_graceful_shutdown` (with `grace_period_ms`), `process_force_kill`, `process_restart` (all with `ip`)
+- **Process lifecycle**: `process_graceful_shutdown` (with `grace_period_ms`), `process_force_kill` (with `cause`: `grace_period_expired`, `crash`, or `crash_and_wipe`), `process_restart` (all with `ip`)
 - **Network**: `partition_created`, `partition_healed` (with `from`/`to`), `random_close`, `bit_flip` (with `connection_id`), `send_partition_created`, `recv_partition_created` (with `ip`)
 - **Storage**: `storage_read_fault`, `storage_write_fault` (with `write_kind`), `storage_sync_fault`, `storage_crash`, `storage_wipe` (all with `ip`)
 

--- a/crates/moonpool-sim/src/chaos/fault_events.rs
+++ b/crates/moonpool-sim/src/chaos/fault_events.rs
@@ -32,6 +32,7 @@ use std::collections::BTreeMap;
 use serde::Serialize;
 
 use crate::observability::FieldValue;
+use crate::sim::ProcessKillKind;
 
 /// Well-known event name for simulator-emitted fault events.
 pub const SIM_FAULT_EVENT_NAME: &str = "sim_fault";
@@ -51,10 +52,12 @@ pub enum SimFaultEvent {
         /// Grace period before force-kill, in milliseconds.
         grace_period_ms: u64,
     },
-    /// Process force-killed.
+    /// Process task force-killed (grace period expired, or a crash reboot).
     ProcessForceKill {
         /// IP address of the process.
         ip: String,
+        /// Why the process was killed.
+        cause: ProcessKillKind,
     },
     /// Process restarted after recovery delay.
     ProcessRestart {

--- a/crates/moonpool-sim/src/lib.rs
+++ b/crates/moonpool-sim/src/lib.rs
@@ -130,10 +130,10 @@ pub mod simulations;
 // Sim module re-exports
 pub use network::sim::NetworkEvent;
 pub use sim::{
-    Event, ScheduleError, ScheduleId, Scheduled, Scheduler, SimFaultRecord, SimWorld, SleepFuture,
-    StorageOperation, WeakSimWorld, clear_rng_breakpoints, current_sim_seed, reset_rng_call_count,
-    reset_sim_rng, rng_call_count, set_rng_breakpoints, set_sim_seed, set_swarm_op_seed,
-    sim_random, sim_random_range, sim_random_range_or_default, swarm_op_enabled,
+    Event, ProcessKillKind, ScheduleError, ScheduleId, Scheduled, Scheduler, SimFaultRecord,
+    SimWorld, SleepFuture, StorageOperation, WeakSimWorld, clear_rng_breakpoints, current_sim_seed,
+    reset_rng_call_count, reset_sim_rng, rng_call_count, set_rng_breakpoints, set_sim_seed,
+    set_swarm_op_seed, sim_random, sim_random_range, sim_random_range_or_default, swarm_op_enabled,
 };
 
 // Locality vocabulary re-exports (shared by engine and runner)

--- a/crates/moonpool-sim/src/observability/mod.rs
+++ b/crates/moonpool-sim/src/observability/mod.rs
@@ -291,6 +291,7 @@ mod tests {
             43,
             &SimFaultEvent::ProcessForceKill {
                 ip: "10.0.1.1".to_owned(),
+                cause: crate::sim::ProcessKillKind::Crash,
             },
         );
 
@@ -303,6 +304,7 @@ mod tests {
         assert_eq!(entries[0].str("to"), Some("10.0.1.2"));
         assert_eq!(entries[1].str("kind"), Some("process_force_kill"));
         assert_eq!(entries[1].str("ip"), Some("10.0.1.1"));
+        assert_eq!(entries[1].str("cause"), Some("crash"));
     }
 
     // ------------------------------------------------------------------

--- a/crates/moonpool-sim/src/runner/fault_injector.rs
+++ b/crates/moonpool-sim/src/runner/fault_injector.rs
@@ -45,7 +45,7 @@ use crate::providers::{SimRandomProvider, SimTimeProvider};
 use crate::runner::locality::MachineRegistry;
 use crate::runner::process::{AttritionScope, RebootKind};
 use crate::runner::tags::TagRegistry;
-use crate::sim::SimWorld;
+use crate::sim::{ProcessKillKind, SimWorld};
 use crate::{assert_reachable, assert_sometimes_each};
 
 /// Process-related state for fault injection targeting.
@@ -185,8 +185,11 @@ impl FaultContext {
     /// a grace period to drain buffers and clean up. After the grace period,
     /// a force-kill aborts the task and connections, then schedules restart.
     ///
-    /// For [`RebootKind::Crash`] and [`RebootKind::CrashAndWipe`]: immediately
-    /// aborts all connections and schedules a `ProcessRestart` event.
+    /// For [`RebootKind::Crash`] and [`RebootKind::CrashAndWipe`]: schedules a
+    /// `ProcessForceKill` event at the crash instant. The orchestrator aborts
+    /// the process task before aborting its connections and crashing (or
+    /// wiping) its storage, then schedules the restart. The process runs no
+    /// further application work during the recovery delay.
     ///
     /// # Errors
     ///
@@ -240,24 +243,27 @@ impl FaultContext {
             }
             RebootKind::Crash | RebootKind::CrashAndWipe => {
                 assert_reachable!("reboot: crash path");
-                self.sim.abort_all_connections_for_ip(ip_addr);
-                // Crash storage for this process
-                self.sim.simulate_crash_for_process(ip_addr, true);
-                // Wipe storage if CrashAndWipe
-                if kind == RebootKind::CrashAndWipe {
-                    self.sim.wipe_storage_for_process(ip_addr);
-                }
                 self.process_info
                     .dead_count
                     .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                 let delay_ms = crate::sim::sim_random_range(recovery_delay_range_ms.clone()) as u64;
-                let recovery_delay = Duration::from_millis(delay_ms);
-                self.sim.schedule_process_restart(ip_addr, recovery_delay);
-                tracing::info!(
-                    "Crashed process at IP {} (recovery in {:?})",
-                    ip,
-                    recovery_delay
+                let cause = if kind == RebootKind::CrashAndWipe {
+                    ProcessKillKind::CrashAndWipe
+                } else {
+                    ProcessKillKind::Crash
+                };
+                // A crash is a force-kill, not just a restart: the orchestrator
+                // owns the process handles, so route through ProcessForceKill so
+                // the task dies now instead of surviving the recovery delay.
+                self.sim.schedule_event(
+                    crate::sim::Event::ProcessForceKill {
+                        ip: ip_addr,
+                        recovery_delay_ms: delay_ms,
+                        cause,
+                    },
+                    Duration::from_nanos(1),
                 );
+                tracing::info!("Crashed process at IP {} (recovery in {}ms)", ip, delay_ms);
             }
         }
 

--- a/crates/moonpool-sim/src/runner/orchestrator.rs
+++ b/crates/moonpool-sim/src/runner/orchestrator.rs
@@ -17,6 +17,7 @@ use crate::runner::locality::MachineRegistry;
 use crate::runner::tags::{ProcessTags, TagRegistry};
 use crate::runner::topology::{TopologyFactory, TopologyInputs};
 use crate::runner::workload::Workload;
+use crate::sim::ProcessKillKind;
 use crate::{SimulationResult, assert_reachable};
 
 use super::process_manager::{ProcessConfig, ProcessManager};
@@ -1289,6 +1290,7 @@ impl WorkloadOrchestrator {
                     crate::sim::Event::ProcessForceKill {
                         ip,
                         recovery_delay_ms,
+                        cause: ProcessKillKind::GracePeriodExpired,
                     },
                     Duration::from_millis(grace_period_ms),
                 );
@@ -1296,11 +1298,27 @@ impl WorkloadOrchestrator {
             Some(crate::sim::Event::ProcessForceKill {
                 ip,
                 recovery_delay_ms,
+                cause,
             }) => {
-                let event = SimFaultEvent::ProcessForceKill { ip: ip.to_string() };
+                assert_reachable!("event: ProcessForceKill");
+                let event = SimFaultEvent::ProcessForceKill {
+                    ip: ip.to_string(),
+                    cause,
+                };
                 obs.record_sim_fault(Self::sim_now_ms(sim), &event);
+                // Abort the task *first*: aborting connections and crashing
+                // storage wake the process, and a dead process must not run
+                // application work during its recovery delay.
                 process_manager.abort_process(ip);
                 sim.abort_all_connections_for_ip(ip);
+                match cause {
+                    ProcessKillKind::GracePeriodExpired => {}
+                    ProcessKillKind::Crash => sim.simulate_crash_for_process(ip, true),
+                    ProcessKillKind::CrashAndWipe => {
+                        sim.simulate_crash_for_process(ip, true);
+                        sim.wipe_storage_for_process(ip);
+                    }
+                }
                 sim.schedule_process_restart(ip, Duration::from_millis(recovery_delay_ms));
             }
             Some(crate::sim::Event::ProcessRestart { ip }) => {

--- a/crates/moonpool-sim/src/runner/process.rs
+++ b/crates/moonpool-sim/src/runner/process.rs
@@ -65,10 +65,12 @@ pub enum RebootKind {
     /// Send buffers drain during the grace period (FIN delivery).
     Graceful,
 
-    /// Instant kill: task cancelled, all connections abort immediately.
+    /// Instant kill: the task is cancelled and all connections abort at the
+    /// crash instant, not after the recovery delay.
     ///
     /// No buffer drain. Peers see connection reset errors. Unsynced storage
-    /// data may be lost (when per-IP storage scoping is implemented).
+    /// data may be lost. The process performs no further work until it is
+    /// restarted.
     Crash,
 
     /// Instant kill + wipe all storage for this process.

--- a/crates/moonpool-sim/src/sim/events.rs
+++ b/crates/moonpool-sim/src/sim/events.rs
@@ -8,6 +8,8 @@ use std::{
     time::Duration,
 };
 
+use serde::Serialize;
+
 use crate::network::sim::NetworkEvent;
 pub use crate::storage::StorageOperation;
 use crate::storage::sim::StorageEvent;
@@ -40,13 +42,30 @@ pub enum Event {
         /// Recovery delay in milliseconds after force-kill before restart.
         recovery_delay_ms: u64,
     },
-    /// Force-kill a process after a graceful shutdown grace period.
+    /// Force-kill a process: the task is aborted before any other side effect
+    /// of the kill can wake it again.
     ProcessForceKill {
         /// The IP address of the process to force-kill.
         ip: std::net::IpAddr,
         /// Recovery delay in milliseconds before restart.
         recovery_delay_ms: u64,
+        /// Why the process is dying, and what that costs its storage.
+        cause: ProcessKillKind,
     },
+}
+
+/// Why a process task is force-killed, and what the kill does to its storage.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProcessKillKind {
+    /// A graceful reboot's grace period expired: persistent storage survives.
+    GracePeriodExpired,
+    /// A [`RebootKind::Crash`](crate::RebootKind::Crash) reboot: unsynced
+    /// storage state is lost.
+    Crash,
+    /// A [`RebootKind::CrashAndWipe`](crate::RebootKind::CrashAndWipe) reboot:
+    /// every persistent file owned by the process is deleted as well.
+    CrashAndWipe,
 }
 
 impl Event {

--- a/crates/moonpool-sim/src/sim/mod.rs
+++ b/crates/moonpool-sim/src/sim/mod.rs
@@ -19,7 +19,9 @@ pub mod wakers;
 pub mod world;
 
 // Re-export main types at module level
-pub use events::{Event, ScheduleError, ScheduleId, Scheduled, Scheduler, StorageOperation};
+pub use events::{
+    Event, ProcessKillKind, ScheduleError, ScheduleId, Scheduled, Scheduler, StorageOperation,
+};
 pub use rng::{
     clear_rng_breakpoints, config_random_bool, config_random_f64, current_sim_seed,
     reset_config_rng, reset_rng_call_count, reset_select_rng, reset_sim_rng, rng_call_count,

--- a/crates/moonpool-sim/tests/reboot.rs
+++ b/crates/moonpool-sim/tests/reboot.rs
@@ -483,9 +483,12 @@ impl Invariant for RebootTimingInvariant {
 
         let entries = q.snapshot(SIM_FAULT_EVENT_NAME);
 
-        // Check grace period timing: graceful shutdown → force kill for same IP
+        // Check grace period timing: graceful shutdown → force kill for same IP.
+        // Crash force-kills carry a different cause and have no grace period.
         for (i, entry) in entries.iter().enumerate() {
-            if entry.str("kind") == Some("process_force_kill") {
+            if entry.str("kind") == Some("process_force_kill")
+                && entry.str("cause") == Some("grace_period_expired")
+            {
                 let ip = entry.str("ip").expect("force kill carries an ip");
                 // Look backwards for matching graceful shutdown
                 for j in (0..i).rev() {
@@ -610,5 +613,277 @@ fn test_max_dead_limits_concurrent_kills_via_attrition() {
     assert_eq!(
         report.failed_runs, 0,
         "attrition with max_dead=1 should not cause failures"
+    );
+}
+
+// ============================================================================
+// Test: a crash reboot silences the process at the crash instant
+// ============================================================================
+//
+// Regression guard for the crash path scheduling only `ProcessRestart`: the
+// old task was aborted inside `ProcessManager::restart`, i.e. *after* the
+// recovery delay, so a crashed process kept running application work
+// throughout the interval it was reported dead.
+
+/// Event name emitted by [`HeartbeatProcess`] on every tick.
+const HEARTBEAT: &str = "process_heartbeat";
+
+/// Sim-time between two heartbeats.
+const HEARTBEAT_PERIOD: Duration = Duration::from_millis(200);
+
+/// Fixed recovery delay for [`CrashOnceInjector`], in milliseconds. Spans many
+/// heartbeat periods so a task that survives the crash cannot stay silent by
+/// accident.
+const CRASH_RECOVERY_MS: usize = 3000;
+
+/// Process that ticks forever. A crashed instance must go silent immediately
+/// instead of ticking on until its restart.
+struct HeartbeatProcess;
+
+#[async_trait]
+impl Process for HeartbeatProcess {
+    fn name(&self) -> &'static str {
+        "heartbeat"
+    }
+
+    async fn run(&mut self, ctx: &SimContext) -> SimulationResult<()> {
+        let mut beat = 0u64;
+        while !ctx.shutdown().is_cancelled() {
+            ctx.time().sleep(HEARTBEAT_PERIOD).await.map_err(|e| {
+                moonpool_sim::SimulationError::InvalidState(format!("sleep failed: {e}"))
+            })?;
+            beat += 1;
+            tracing::info!(beat, "process_heartbeat");
+        }
+        Ok(())
+    }
+}
+
+/// Crashes the first process once, with a fixed recovery delay so kill and
+/// restart times are comparable across replays of the same seed.
+///
+/// It records the IP and the sim time of the crash itself, so the invariant
+/// knows when the dead interval starts without relying on the very fault event
+/// this test is about.
+struct CrashOnceInjector {
+    observations: SharedObservations,
+}
+
+#[async_trait]
+impl FaultInjector for CrashOnceInjector {
+    fn name(&self) -> &'static str {
+        "crash_once"
+    }
+
+    async fn inject(&mut self, ctx: &FaultContext) -> SimulationResult<()> {
+        let _ = ctx.time().sleep(Duration::from_secs(1)).await;
+
+        if let Some(ip) = ctx.process_ips().first().cloned() {
+            let crashed_at_ms = u64::try_from(ctx.time().now().as_millis())
+                .expect("sim time fits in u64 milliseconds");
+            ctx.reboot_with_delays(
+                &ip,
+                RebootKind::Crash,
+                &(CRASH_RECOVERY_MS..CRASH_RECOVERY_MS + 1),
+                &(0..1),
+            )?;
+            lock(&self.observations).crashed = Some((ip, crashed_at_ms));
+        }
+
+        ctx.chaos_shutdown().cancelled().await;
+        Ok(())
+    }
+}
+
+/// Shared observations for one run of the crash scenario.
+#[derive(Default)]
+struct CrashObservations {
+    /// `(ip, sim time in ms)` of the crash, recorded by the fault injector.
+    crashed: Option<(String, u64)>,
+    /// `kind@ip@time_ms` for every process-lifecycle fault, in order. Two runs
+    /// of the same seed must produce identical vectors.
+    lifecycle: Vec<String>,
+    /// Number of crash → restart windows proven silent end to end.
+    verified_windows: usize,
+}
+
+type SharedObservations = std::sync::Arc<std::sync::Mutex<CrashObservations>>;
+
+fn lock(observations: &SharedObservations) -> std::sync::MutexGuard<'_, CrashObservations> {
+    observations
+        .lock()
+        .expect("CrashObservations poisoned: prior task panicked")
+}
+
+/// Invariant: from the instant a process is crashed until it restarts, that
+/// process emits nothing.
+///
+/// The window start comes from the injector's own record of the crash, not
+/// from a simulator fault event, so the invariant still fires if the crash
+/// path stops reporting the kill.
+///
+/// Cursor-based — it runs after every simulation step, so it only inspects
+/// events it has not seen before.
+struct DeadProcessIsSilentInvariant {
+    fault_cursor: Cell<usize>,
+    beat_cursor: Cell<usize>,
+    /// Set once the crashed process is seen restarting.
+    restarted: Cell<bool>,
+    observations: SharedObservations,
+}
+
+impl DeadProcessIsSilentInvariant {
+    fn new(observations: SharedObservations) -> Self {
+        Self {
+            fault_cursor: Cell::new(0),
+            beat_cursor: Cell::new(0),
+            restarted: Cell::new(false),
+            observations,
+        }
+    }
+}
+
+impl Invariant for DeadProcessIsSilentInvariant {
+    fn name(&self) -> &'static str {
+        "dead_process_is_silent"
+    }
+
+    fn observe(&self, q: &dyn TraceQuery, _sim_time_ms: u64) {
+        // Merge the two streams by global sequence number: a heartbeat and the
+        // kill that silences it can land in the same batch.
+        let mut fresh = q.since(SIM_FAULT_EVENT_NAME, &self.fault_cursor);
+        fresh.extend(q.since(HEARTBEAT, &self.beat_cursor));
+        if fresh.is_empty() {
+            return;
+        }
+        fresh.sort_by_key(|event| event.seq);
+
+        let mut observations = lock(&self.observations);
+
+        for event in fresh {
+            let Some((crashed_ip, crashed_at_ms)) = observations.crashed.clone() else {
+                continue;
+            };
+
+            if event.name == HEARTBEAT {
+                assert_always!(
+                    self.restarted.get()
+                        || event.source != crashed_ip
+                        || event.time_ms <= crashed_at_ms,
+                    format!(
+                        "{} emitted a heartbeat at {}ms, after crashing at {crashed_at_ms}ms",
+                        event.source, event.time_ms
+                    )
+                );
+                continue;
+            }
+
+            let Some(kind @ ("process_force_kill" | "process_restart")) = event.str("kind") else {
+                continue;
+            };
+            let ip = event.str("ip").expect("lifecycle fault carries an ip");
+            observations
+                .lifecycle
+                .push(format!("{kind}@{ip}@{}", event.time_ms));
+            if kind == "process_restart" && ip == crashed_ip && !self.restarted.replace(true) {
+                observations.verified_windows += 1;
+            }
+        }
+    }
+
+    fn reset(&mut self) {
+        self.fault_cursor.set(0);
+        self.beat_cursor.set(0);
+        self.restarted.set(false);
+    }
+}
+
+/// Run one seed of the crash scenario, returning the report and what the
+/// invariant observed.
+fn run_crash_scenario(seed: u64) -> (moonpool_sim::SimulationReport, CrashObservations) {
+    let observations: SharedObservations = std::sync::Arc::default();
+    let report = SimulationBuilder::new()
+        .processes(2, || Box::new(HeartbeatProcess))
+        .workload(TimedWorkload(Duration::from_secs(8)))
+        .fault(CrashOnceInjector {
+            observations: observations.clone(),
+        })
+        .invariant(DeadProcessIsSilentInvariant::new(observations.clone()))
+        .invariant(RebootTimingInvariant::new())
+        .chaos_duration(Duration::from_secs(6))
+        .set_iterations(1)
+        .set_debug_seeds(vec![seed])
+        .run();
+
+    let observed = std::mem::take(&mut *lock(&observations));
+    (report, observed)
+}
+
+#[test]
+fn test_crash_reboot_silences_process_until_restart() {
+    for seed in [42, 123, 999] {
+        let (report, observed) = run_crash_scenario(seed);
+
+        assert_eq!(
+            report.failed_runs, 0,
+            "seed {seed}: a crashed process must emit nothing until it restarts"
+        );
+        assert_eq!(
+            observed.verified_windows, 1,
+            "seed {seed}: expected exactly one crash → restart window, saw {:?}",
+            observed.lifecycle
+        );
+
+        // The crash records a force-kill at crash time and a restart one
+        // recovery delay later.
+        let times: Vec<u64> = observed
+            .lifecycle
+            .iter()
+            .map(|entry| {
+                entry
+                    .rsplit('@')
+                    .next()
+                    .and_then(|ms| ms.parse().ok())
+                    .expect("lifecycle entry ends with a timestamp")
+            })
+            .collect();
+        assert_eq!(
+            observed.lifecycle.len(),
+            2,
+            "seed {seed}: expected force-kill then restart, saw {:?}",
+            observed.lifecycle
+        );
+        assert!(
+            observed.lifecycle[0].starts_with("process_force_kill@"),
+            "seed {seed}: first lifecycle fault should be the force-kill, saw {:?}",
+            observed.lifecycle
+        );
+        assert!(
+            observed.lifecycle[1].starts_with("process_restart@"),
+            "seed {seed}: second lifecycle fault should be the restart, saw {:?}",
+            observed.lifecycle
+        );
+        assert_eq!(
+            times[1] - times[0],
+            CRASH_RECOVERY_MS as u64,
+            "seed {seed}: restart should land one recovery delay after the kill"
+        );
+    }
+}
+
+#[test]
+fn test_crash_reboot_replays_identically_for_a_seed() {
+    let (first_report, first) = run_crash_scenario(7);
+    let (second_report, second) = run_crash_scenario(7);
+
+    assert_eq!(first_report.failed_runs, 0);
+    assert_eq!(second_report.failed_runs, 0);
+    assert_eq!(
+        first.lifecycle, second.lifecycle,
+        "the same seed must replay the same kill and restart times"
+    );
+    assert!(
+        !first.lifecycle.is_empty(),
+        "the scenario must actually crash a process"
     );
 }


### PR DESCRIPTION
Closes #181.

## Problem

`RebootKind::Crash` is documented as an instant kill, but the crash arm of `FaultContext::reboot_with_delays` scheduled only `ProcessRestart`. `ProcessManager` owns the process `JoinHandle`s and is only reachable from the orchestrator's event handlers, so the old task was aborted inside `ProcessManager::restart` — *after* the recovery delay. A crashed process therefore kept executing application work throughout the interval it was reported dead.

Aborting connections and crashing storage inline made it worse: both wake the process that is supposed to be gone, so the crash itself scheduled the dead process back onto the executor.

## Fix

The crash path now schedules `Event::ProcessForceKill` — the event that actually owns the process handles — carrying the recovery delay plus a new `ProcessKillKind` (`GracePeriodExpired` / `Crash` / `CrashAndWipe`) telling the orchestrator what the kill costs the process's storage.

The handler aborts the task **first**, then aborts connections, then applies the storage crash (and wipe), then schedules the restart. Graceful reboots pass `GracePeriodExpired` and leave storage untouched, so their semantics are unchanged.

`process_force_kill` fault events gained a `cause` field so invariants can tell a crash kill from a grace-period kill; the existing `RebootTimingInvariant` needed that to stop matching a crash kill against an earlier graceful shutdown for the same IP.

## Acceptance criteria

| Criterion | Where |
|---|---|
| Deterministic process emits a heartbeat while alive | `HeartbeatProcess` in `tests/reboot.rs` |
| No process events throughout the recovery delay after a crash | `DeadProcessIsSilentInvariant` |
| Force-kill fault at crash time, restart fault at recovery time | `test_crash_reboot_silences_process_until_restart` |
| Connections abort and storage crash/wipe stay at the crash boundary | `ProcessForceKill` handler in `orchestrator.rs` |
| Same seed replays the same kill and restart times | `test_crash_reboot_replays_identically_for_a_seed` |
| Existing graceful / crash / crash-and-wipe reboot tests stay green | all 13 `reboot.rs` tests pass |

The regression invariant anchors the dead window on the **injector's own** record of the crash instant, not on the fault event under test — so it still fires if the crash path ever stops reporting the kill.

Verified by reverting the fix: the crashed process kept beating from 1400ms to 4000ms after crashing at 1200ms, and both new tests failed.

## Validation

Nix could not fetch `flake-utils` through this sandbox's proxy, so I used the system toolchain — the same pinned `1.95.0` from `rust-toolchain.toml`.

- `cargo fmt` clean
- `cargo clippy --workspace --all-targets` clean (pedantic; no new `#[allow]`)
- `cargo nextest run --workspace` — 590 passed, 0 failed
- `cargo xtask sim run-all` — 6/6 passed
- `cargo clippy -p moonpool-sim --no-default-features --all-targets -- -D warnings` clean
- `cargo check --target wasm32-unknown-unknown -p moonpool-sim --no-default-features` clean
- `mdbook build book/` clean

Note: `cargo test --workspace` shows a failure in `determinism::same_seed_produces_identical_execution_traces` that is unrelated to this change — it shares process-global state and only fails under `cargo test`'s threaded runner. It fails identically on unmodified `main` and passes under `cargo nextest`.

## Book

Updated the crash-reboot description in `part3-building/09-attrition.md`, the `process_force_kill` field list in `part3-building/17-events-and-invariants.md`, and the fault reference table in `appendix/04-fault-reference.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F1xaTmWr6qnXe8sosEREtg

---
_Generated by [Claude Code](https://claude.ai/code/session_01F1xaTmWr6qnXe8sosEREtg)_