### PR TITLE
fix(moonpool-sim): stall partitioned sends instead of dropping them

### DIFF
--- a/book/src/part3-building/10-network-faults.md
+++ b/book/src/part3-building/10-network-faults.md
@@ -105,6 +105,17 @@ Partitions have configurable probability and duration. They can be programmatic 
 
 At the lower-level `SimWorld` API, `partition_pair(from, to, duration)` adds one directed pair entry. Call it for both directions to create a bidirectional pair cut. A single `restore_partition(from, to)` deliberately removes both directed entries, preventing a half-healed pair during recovery. Send-wide and receive-wide partitions remain separate and expire through their targeted restore events.
 
+A partition never punches a hole in an established connection. A queued send
+whose direction is cut **stalls**: the bytes stay at the front of the send
+buffer, the writer keeps seeing backpressure, and the stream resumes in order
+the moment the partition heals, whether that is at its deadline or through an
+early `restore_partition` / `FaultContext::heal_partition`. The peer therefore
+either reads the original bytes in order, or sees the connection fail. It never
+reads a later chunk in place of one that was silently dropped, which for a
+framed protocol (h2 on the same connection) would corrupt the frame that follows.
+This mirrors FoundationDB's `SimClogging`, where a clogged pair adds delay and
+only an explicit disconnect fails the connection.
+
 The first three strategies are IP-blind: they pick nodes out of a hat. `IsolateZone` and `IsolateDatacenter` read the [`.cluster()`](09-attrition.md#failure-domains-correlated-reboots) topology instead, so the cut lands exactly where a real one would, on the boundary that shares a switch or a region. Without a topology they fall back to `Random` selection, which keeps them safe to draw for any seed.
 
 The asymmetric pair is worth dwelling on. A node whose sends are blocked still hears every heartbeat from the cluster, so it happily believes it is healthy while everyone else marks it dead. Systems that infer liveness from "I can see you" rather than "you can see me" split brains here. Both arms record their own fault events (`SendPartitionCreated`, `RecvPartitionCreated`) on the timeline, so an invariant can correlate application behavior with the exact one-way cut that caused it.

--- a/crates/moonpool-sim/Cargo.toml
+++ b/crates/moonpool-sim/Cargo.toml
@@ -65,6 +65,9 @@ hyper = { version = "1", features = ["http1", "server", "client"] }
 # moonpool-hyper depends on moonpool-core, never on moonpool-sim.
 moonpool-hyper = { path = "../moonpool-hyper", version = "0.8.0" }
 tempfile = "3"
+# The h2 tests speak to moonpool-hyper's server/channel, which take and return
+# tower services.
+tower-service = "0.3"
 
 [lints]
 workspace = true

--- a/crates/moonpool-sim/src/network/sim/engine.rs
+++ b/crates/moonpool-sim/src/network/sim/engine.rs
@@ -477,16 +477,19 @@ impl NetworkSimulation {
                 self.state.ip_partitions.retain(|_, state| {
                     state.expires_at != expected_deadline || now < expected_deadline
                 });
+                self.resume_stalled_sends(now, &mut actions);
             }
             NetworkEvent::SendPartitionClear { expected_deadline } => {
                 self.state.send_partitions.retain(|_, deadline| {
                     *deadline != expected_deadline || now < expected_deadline
                 });
+                self.resume_stalled_sends(now, &mut actions);
             }
             NetworkEvent::RecvPartitionClear { expected_deadline } => {
                 self.state.recv_partitions.retain(|_, deadline| {
                     *deadline != expected_deadline || now < expected_deadline
                 });
+                self.resume_stalled_sends(now, &mut actions);
             }
             NetworkEvent::DataDelivery {
                 connection_id,
@@ -624,41 +627,72 @@ impl NetworkSimulation {
             if let Some(connection) = self.state.connections.get_mut(&id) {
                 connection.send_buffer.clear();
                 connection.flags.set_send_in_progress(false);
+                connection.flags.set_send_stalled(false);
             }
             Self::take_waiter(&mut self.waiters.send_buffers, id, wakes);
             return;
         }
-        if self.state.is_connection_partitioned(id, now) {
-            self.handle_partitioned_send(id, now, actions, wakes);
+        // Only queued bytes can stall: with nothing to send there is nothing a
+        // partition could reorder, and the normal path is what releases the
+        // send-in-progress flag and any pending FIN.
+        let has_queued_bytes = self
+            .state
+            .connections
+            .get(&id)
+            .is_some_and(|connection| !connection.send_buffer.is_empty());
+        if has_queued_bytes && self.state.connection_partition_clear_at(id, now).is_some() {
+            self.stall_partitioned_send(id);
         } else {
             self.handle_normal_send(id, now, actions, wakes);
         }
     }
 
-    fn handle_partitioned_send(
-        &mut self,
-        id: ConnectionId,
-        now: Duration,
-        actions: &mut NetworkActions,
-        wakes: &mut WakeBatch,
-    ) {
-        let Some(connection) = self.state.connections.get_mut(&id) else {
-            return;
-        };
-        connection.send_buffer.pop_front();
-        Self::take_waiter(&mut self.waiters.send_buffers, id, wakes);
-        if connection.send_buffer.is_empty() {
-            connection.flags.set_send_in_progress(false);
-            if connection.flags.graceful_close_pending() {
-                connection.flags.set_graceful_close_pending(false);
-                Self::schedule_fin(
-                    connection.paired_connection,
-                    connection.last_data_delivery_scheduled_at,
-                    now,
-                    actions,
-                );
+    /// Hold a queued send until every partition blocking it has healed.
+    ///
+    /// A partition must never punch a hole in an established byte stream. The
+    /// queued chunk stays at the front of the send buffer, so the peer either
+    /// sees the original bytes in order once the partition heals, or sees the
+    /// connection fail — never a later chunk silently filling the gap left by
+    /// an earlier one. `FoundationDB` models the same thing: `SimClogging` turns
+    /// a clogged pair into added delay (`getRecvDelay` clamps to
+    /// `clogPairUntil`), and only an explicit disconnect fails the connection.
+    ///
+    /// Send-buffer waiters are deliberately left registered: no buffer space is
+    /// released while the stream is stalled, so writers keep seeing
+    /// backpressure until the send actually drains.
+    ///
+    /// A stalled connection owns no scheduled work. It is re-driven by
+    /// [`resume_stalled_sends`](Self::resume_stalled_sends) when the partitions
+    /// blocking it heal, whether that happens at their deadline or earlier.
+    fn stall_partitioned_send(&mut self, id: ConnectionId) {
+        if let Some(connection) = self.state.connections.get_mut(&id) {
+            connection.flags.set_send_stalled(true);
+        }
+    }
+
+    /// Re-drive every connection whose blocking partitions have healed.
+    ///
+    /// Runs from each partition-clearing path, so a stream stalled by a
+    /// partition that is healed early releases its bytes early instead of
+    /// waiting out the deadline it stalled under.
+    fn resume_stalled_sends(&mut self, now: Duration, actions: &mut NetworkActions) {
+        let resumed = self
+            .state
+            .connections
+            .iter()
+            .filter(|(id, connection)| {
+                connection.flags.send_stalled()
+                    && self
+                        .state
+                        .connection_partition_clear_at(**id, now)
+                        .is_none()
+            })
+            .map(|(id, _)| *id)
+            .collect::<Vec<_>>();
+        for id in resumed {
+            if let Some(connection) = self.state.connections.get_mut(&id) {
+                connection.flags.set_send_stalled(false);
             }
-        } else {
             actions.schedule_at(now, NetworkEvent::ProcessSendBuffer { connection_id: id });
         }
     }
@@ -1283,7 +1317,12 @@ impl NetworkSimulation {
         actions
     }
 
-    pub(crate) fn restore_partition(&mut self, from: IpAddr, to: IpAddr) -> NetworkActions {
+    pub(crate) fn restore_partition(
+        &mut self,
+        from: IpAddr,
+        to: IpAddr,
+        now: Duration,
+    ) -> NetworkActions {
         self.state.ip_partitions.remove(&(from, to));
         self.state.ip_partitions.remove(&(to, from));
         let mut actions = NetworkActions::default();
@@ -1291,6 +1330,7 @@ impl NetworkSimulation {
             from: from.to_string(),
             to: to.to_string(),
         });
+        self.resume_stalled_sends(now, &mut actions);
         actions
     }
 
@@ -1396,6 +1436,7 @@ impl NetworkSimulation {
                 c.flags.set_send_closed(true);
                 c.flags.set_recv_closed(true);
                 c.flags.set_send_in_progress(false);
+                c.flags.set_send_stalled(false);
                 c.flags.set_graceful_close_pending(false);
                 c.send_buffer.clear();
                 c.close_reason = CloseReason::Aborted;

--- a/crates/moonpool-sim/src/network/sim/facade.rs
+++ b/crates/moonpool-sim/src/network/sim/facade.rs
@@ -384,7 +384,8 @@ impl SimWorld {
     /// Restores pair partitions in both directions between two IPs.
     pub fn restore_partition(&self, from: IpAddr, to: IpAddr) {
         let mut inner = self.inner.write();
-        let actions = inner.network.restore_partition(from, to);
+        let now = inner.now();
+        let actions = inner.network.restore_partition(from, to, now);
         inner.apply_network(actions);
     }
 

--- a/crates/moonpool-sim/src/network/sim/state.rs
+++ b/crates/moonpool-sim/src/network/sim/state.rs
@@ -46,6 +46,7 @@ impl ConnectionFlags {
     const GRACEFUL_CLOSE_PENDING: u16 = 1 << 6;
     const REMOTE_FIN_RECEIVED: u16 = 1 << 7;
     const SEND_IN_PROGRESS: u16 = 1 << 8;
+    const SEND_STALLED: u16 = 1 << 9;
 
     fn get(self, mask: u16) -> bool {
         (self.0 & mask) != 0
@@ -113,6 +114,18 @@ impl ConnectionFlags {
 
     pub(crate) fn set_send_in_progress(&mut self, value: bool) {
         self.set_bit(Self::SEND_IN_PROGRESS, value);
+    }
+
+    /// Whether a queued send is held back by a partition.
+    ///
+    /// A stalled connection owns no scheduled work: it is re-driven when the
+    /// partitions blocking it heal.
+    pub(crate) fn send_stalled(self) -> bool {
+        self.get(Self::SEND_STALLED)
+    }
+
+    pub(crate) fn set_send_stalled(&mut self, value: bool) {
+        self.set_bit(Self::SEND_STALLED, value);
     }
 }
 
@@ -183,28 +196,41 @@ impl NetworkState {
         }
     }
 
-    pub(crate) fn is_partitioned(&self, from_ip: IpAddr, to_ip: IpAddr, now: Duration) -> bool {
-        self.ip_partitions
-            .get(&(from_ip, to_ip))
-            .is_some_and(|partition| now < partition.expires_at)
-            || self
-                .send_partitions
-                .get(&from_ip)
-                .is_some_and(|expires_at| now < *expires_at)
-            || self
-                .recv_partitions
-                .get(&to_ip)
-                .is_some_and(|expires_at| now < *expires_at)
+    /// Deadline at which every partition blocking `from_ip -> to_ip` has healed.
+    ///
+    /// Returns `None` when the direction is not partitioned at `now`. Directed,
+    /// send-side, and receive-side partitions can overlap, so the caller has to
+    /// wait for the latest of the deadlines currently in force.
+    pub(crate) fn partition_clear_at(
+        &self,
+        from_ip: IpAddr,
+        to_ip: IpAddr,
+        now: Duration,
+    ) -> Option<Duration> {
+        [
+            self.ip_partitions
+                .get(&(from_ip, to_ip))
+                .map(|partition| partition.expires_at),
+            self.send_partitions.get(&from_ip).copied(),
+            self.recv_partitions.get(&to_ip).copied(),
+        ]
+        .into_iter()
+        .flatten()
+        .filter(|expires_at| now < *expires_at)
+        .max()
     }
 
-    pub(crate) fn is_connection_partitioned(
+    pub(crate) fn is_partitioned(&self, from_ip: IpAddr, to_ip: IpAddr, now: Duration) -> bool {
+        self.partition_clear_at(from_ip, to_ip, now).is_some()
+    }
+
+    /// Deadline at which `connection_id` may send again, if it is partitioned.
+    pub(crate) fn connection_partition_clear_at(
         &self,
         connection_id: ConnectionId,
         now: Duration,
-    ) -> bool {
-        self.connections
-            .get(&connection_id)
-            .and_then(|connection| Some((connection.local_ip?, connection.remote_ip?)))
-            .is_some_and(|(from, to)| self.is_partitioned(from, to, now))
+    ) -> Option<Duration> {
+        let connection = self.connections.get(&connection_id)?;
+        self.partition_clear_at(connection.local_ip?, connection.remote_ip?, now)
     }
 }

--- a/crates/moonpool-sim/tests/h2_partition_integrity.rs
+++ b/crates/moonpool-sim/tests/h2_partition_integrity.rs
@@ -1,0 +1,316 @@
+//! A partition must not alter the bytes of a multiplexed h2 connection.
+//!
+//! One reused h2 connection carries several concurrent requests. A scripted
+//! fault injector partitions the pair while those requests are in flight, then
+//! heals it. Every request body is self-describing (one repeated tag byte), so
+//! a byte stream that lost an interior range shows up as a body that is not
+//! uniform, or one carrying another request's tag.
+//!
+//! The transport may stall the stream or break the connection — a failed
+//! request is an accepted outcome here. Serving *different* bytes than the
+//! peer wrote is not.
+
+use std::error::Error;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::future::join_all;
+use http_body_util::{BodyExt, Full};
+use hyper::body::Incoming;
+use hyper::{Request, Response};
+use moonpool_hyper::{ChannelConfig, H2Server, ReconnectingChannel};
+use moonpool_sim::{
+    FaultContext, FaultInjector, NetworkProvider, Process, SimContext, SimProviders,
+    SimulationBuilder, SimulationError, SimulationResult, TaskProvider, TcpListenerTrait,
+    TimeProvider, Workload, assert_always, assert_sometimes,
+};
+
+/// The single workload's IP, assigned by the builder as `10.0.0.{n}`. The
+/// workload asserts this holds, so a change in the scheme fails loudly instead
+/// of silently partitioning nothing.
+const CLIENT_IP: &str = "10.0.0.1";
+
+/// Body length per request: several h2 DATA frames worth of one tag byte.
+const BODY_LEN: usize = 8 * 1024;
+
+/// Concurrent requests multiplexed onto the one connection per round.
+const CONCURRENCY: u8 = 4;
+
+/// Rounds of concurrent requests the workload drives.
+const ROUNDS: u8 = 12;
+
+/// How long the pair stays reachable between partitions.
+const HEALED: Duration = Duration::from_micros(700);
+
+/// How long each partition holds.
+const PARTITIONED: Duration = Duration::from_millis(3);
+
+/// The body for a request tag: uniform, so any missing interior range shows.
+fn body_for(tag: u8) -> Bytes {
+    Bytes::from(vec![tag; BODY_LEN])
+}
+
+/// Whether `body` is exactly the body this tag was sent with.
+fn is_body_for(tag: u8, body: &[u8]) -> bool {
+    body.len() == BODY_LEN && body.iter().all(|byte| *byte == tag)
+}
+
+// ============================================================================
+// Server: an echo service that validates what it receives
+// ============================================================================
+
+/// Echoes the request body back, after checking it arrived intact.
+#[derive(Clone)]
+struct EchoTag;
+
+impl tower_service::Service<Request<Incoming>> for EchoTag {
+    type Response = Response<Full<Bytes>>;
+    type Error = Box<dyn Error + Send + Sync>;
+    type Future =
+        Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, request: Request<Incoming>) -> Self::Future {
+        Box::pin(async move {
+            let body = request.into_body().collect().await?.to_bytes();
+            // The tag is the body's own content: a request that arrived intact
+            // is a run of one byte, of the length the client wrote.
+            let tag = body.first().copied().unwrap_or_default();
+            assert_always!(
+                is_body_for(tag, &body),
+                "h2_server_read_the_request_body_the_client_wrote"
+            );
+            Ok(Response::new(Full::new(body)))
+        })
+    }
+}
+
+struct EchoProcess;
+
+#[async_trait]
+impl Process for EchoProcess {
+    fn name(&self) -> &'static str {
+        "echo"
+    }
+
+    async fn run(&mut self, ctx: &SimContext) -> SimulationResult<()> {
+        let listener = ctx.network().bind(ctx.my_ip()).await?;
+        let server: H2Server<SimProviders> = H2Server::new(ctx.providers());
+
+        loop {
+            let (stream, _addr) = moonpool_sim::select! {
+                biased;
+                accepted = listener.accept() => accepted?,
+                () = ctx.shutdown().cancelled() => return Ok(()),
+            };
+            let connection = server.serve_connection_with_shutdown(
+                stream,
+                EchoTag,
+                ctx.shutdown().clone().cancelled_owned(),
+            );
+            ctx.task()
+                .spawn_task("h2-conn", async move {
+                    if let Err(error) = connection.await {
+                        tracing::debug!("h2 connection ended: {error}");
+                    }
+                })
+                .detach();
+        }
+    }
+}
+
+// ============================================================================
+// Workload: concurrent requests over one reused connection
+// ============================================================================
+
+struct MultiplexedClient;
+
+#[async_trait]
+impl Workload for MultiplexedClient {
+    fn name(&self) -> &'static str {
+        "client"
+    }
+
+    async fn run(&mut self, ctx: &SimContext) -> SimulationResult<()> {
+        assert_eq!(
+            ctx.my_ip(),
+            CLIENT_IP,
+            "the fault injector partitions this workload by IP"
+        );
+        let server_ip = ctx
+            .peer("echo")
+            .ok_or_else(|| SimulationError::InvalidState("echo process not found".into()))?;
+
+        let channel: ReconnectingChannel<SimProviders, Full<Bytes>> =
+            ReconnectingChannel::new(ctx.providers(), server_ip.clone(), ChannelConfig::default());
+
+        let mut completed = 0;
+        for round in 0..ROUNDS {
+            moonpool_sim::select! {
+                biased;
+                outcome = round_of_requests(&channel, &server_ip, round) => outcome?,
+                () = ctx.shutdown().cancelled() => break,
+            }
+            completed += 1;
+        }
+
+        // Every partition in this run heals, so every round must get through.
+        // A stream that a partition strands instead of stalling stops making
+        // progress and the run is cut short by its virtual-time budget.
+        assert_always!(
+            completed == ROUNDS,
+            "every_h2_round_completes_across_healing_partitions"
+        );
+        channel.close();
+        Ok(())
+    }
+}
+
+/// Send `CONCURRENCY` requests on the shared connection and validate every
+/// response body.
+async fn round_of_requests(
+    channel: &ReconnectingChannel<SimProviders, Full<Bytes>>,
+    server_ip: &str,
+    round: u8,
+) -> SimulationResult<()> {
+    let uri = format!("http://{server_ip}/echo");
+    let mut in_flight = Vec::new();
+
+    for slot in 0..CONCURRENCY {
+        // Tags start at 1: an empty body must not look like a valid one.
+        let tag = 1 + round * CONCURRENCY + slot;
+        let mut handle = channel.clone();
+        if futures::future::poll_fn(|cx| {
+            <ReconnectingChannel<_, _> as tower_service::Service<Request<Full<Bytes>>>>::poll_ready(
+                &mut handle,
+                cx,
+            )
+        })
+        .await
+        .is_err()
+        {
+            assert_sometimes!(true, "h2_channel_readiness_failed_under_partition");
+            return Ok(());
+        }
+
+        let request = Request::builder()
+            .method("POST")
+            .uri(&uri)
+            .body(Full::new(body_for(tag)))
+            .map_err(|e| SimulationError::InvalidState(format!("request build error: {e}")))?;
+        in_flight.push(async move {
+            (
+                tag,
+                tower_service::Service::call(&mut handle, request).await,
+            )
+        });
+    }
+
+    for (tag, outcome) in join_all(in_flight).await {
+        match outcome {
+            Ok(response) => {
+                let body = response
+                    .into_body()
+                    .collect()
+                    .await
+                    .map_err(|e| {
+                        SimulationError::InvalidState(format!("response body error: {e}"))
+                    })?
+                    .to_bytes();
+                // The heart of the regression: a partition may delay or kill
+                // this request, but the bytes that come back are either the
+                // ones this request sent, or nothing at all.
+                assert_always!(
+                    is_body_for(tag, &body),
+                    "h2_response_carries_this_requests_own_body"
+                );
+                assert_sometimes!(true, "h2_request_completed_with_partitions_flapping");
+            }
+            Err(_) => {
+                assert_sometimes!(true, "h2_request_failed_under_partition");
+            }
+        }
+    }
+    Ok(())
+}
+
+// ============================================================================
+// Fault: a partition that flaps across the in-flight requests
+// ============================================================================
+
+/// Sleep on the simulated clock, surfacing a shutdown as a simulation error.
+async fn sleep(ctx: &FaultContext, duration: Duration) -> SimulationResult<()> {
+    ctx.time()
+        .sleep(duration)
+        .await
+        .map_err(|e| SimulationError::InvalidState(format!("sleep failed: {e}")))
+}
+
+struct PartitionFlap;
+
+#[async_trait]
+impl FaultInjector for PartitionFlap {
+    fn name(&self) -> &'static str {
+        "partition_flap"
+    }
+
+    async fn inject(&mut self, ctx: &FaultContext) -> SimulationResult<()> {
+        let server_ip = ctx
+            .process_ips()
+            .first()
+            .cloned()
+            .ok_or_else(|| SimulationError::InvalidState("no process to partition".into()))?;
+
+        while !ctx.chaos_shutdown().is_cancelled() {
+            sleep(ctx, HEALED).await?;
+            ctx.partition(CLIENT_IP, &server_ip)?;
+            sleep(ctx, PARTITIONED).await?;
+            ctx.heal_partition(CLIENT_IP, &server_ip)?;
+        }
+        Ok(())
+    }
+}
+
+// ============================================================================
+// Test
+// ============================================================================
+
+#[test]
+fn a_partition_never_alters_a_multiplexed_request_body() {
+    let report = SimulationBuilder::new()
+        .processes(1, || Box::new(EchoProcess))
+        .workload(MultiplexedClient)
+        .fault(PartitionFlap)
+        .chaos_duration(Duration::from_secs(30))
+        // A healed partition must let the stalled stream continue. A stream
+        // stranded by one instead drags the run out by orders of magnitude
+        // (the whole workload otherwise finishes in tens of simulated ms).
+        .run_time_budget(Duration::from_secs(5))
+        .set_iterations(5)
+        .set_debug_seeds(vec![1, 2, 3, 4, 5])
+        .run();
+
+    println!("{report}");
+    assert!(
+        report.seeds_failing.is_empty(),
+        "failing seeds: {:?}",
+        report.seeds_failing
+    );
+    assert!(
+        report.assertion_violations.is_empty(),
+        "assertion violations:\n{}",
+        report
+            .assertion_violations
+            .iter()
+            .map(|violation| format!("  - {violation}"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
+}

--- a/crates/moonpool-sim/tests/network/partition.rs
+++ b/crates/moonpool-sim/tests/network/partition.rs
@@ -1,5 +1,63 @@
-use moonpool_sim::{SimFaultEvent, SimWorld, network::config::NetworkConfiguration};
-use std::{net::IpAddr, time::Duration};
+use futures::{
+    io::{AsyncRead, AsyncReadExt, AsyncWrite},
+    task::noop_waker,
+};
+use moonpool_sim::{
+    NetworkProvider, SimFaultEvent, SimWorld, TcpListenerTrait,
+    network::config::NetworkConfiguration,
+};
+use std::{
+    future::Future,
+    io,
+    net::IpAddr,
+    pin::{Pin, pin},
+    task::{Context, Poll},
+    time::Duration,
+};
+
+/// How many events a driven future may consume before it is declared stuck.
+const MAX_DRIVER_STEPS: usize = 10_000;
+
+fn ip(last_octet: u8) -> IpAddr {
+    format!("10.0.1.{last_octet}")
+        .parse()
+        .expect("valid test IP")
+}
+
+/// Poll a simulation-backed future, advancing virtual time whenever it parks.
+fn drive<F: Future>(sim: &mut SimWorld, future: F) -> F::Output {
+    let mut future = pin!(future);
+    let waker = noop_waker();
+    let mut context = Context::from_waker(&waker);
+
+    for _ in 0..MAX_DRIVER_STEPS {
+        if let Poll::Ready(output) = future.as_mut().poll(&mut context) {
+            return output;
+        }
+        assert!(
+            sim.has_pending_events(),
+            "simulation-backed future stalled without a pending event"
+        );
+        sim.step();
+    }
+
+    panic!("simulation-backed future exceeded {MAX_DRIVER_STEPS} events")
+}
+
+fn poll_write_once(stream: &mut (impl AsyncWrite + Unpin), data: &[u8]) -> Poll<io::Result<usize>> {
+    let waker = noop_waker();
+    let mut context = Context::from_waker(&waker);
+    Pin::new(stream).poll_write(&mut context, data)
+}
+
+fn poll_read_once(
+    stream: &mut (impl AsyncRead + Unpin),
+    data: &mut [u8],
+) -> Poll<io::Result<usize>> {
+    let waker = noop_waker();
+    let mut context = Context::from_waker(&waker);
+    Pin::new(stream).poll_read(&mut context, data)
+}
 
 /// Test basic partition functionality by directly testing the `SimWorld` API
 #[test]
@@ -180,4 +238,155 @@ fn test_partition_fault_timeline() {
 
     // A second drain returns nothing
     assert!(sim.take_faults().is_empty());
+}
+
+/// A partition must never punch a hole in an established byte stream.
+///
+/// Regression for the interior-hole bug: the engine used to drop the queued
+/// chunk of a partitioned connection while leaving later chunks flowing, so the
+/// peer silently read the suffix in place of the missing range. A framed
+/// protocol (h2 on top of this transport) then parsed later traffic as the
+/// remainder of an earlier frame.
+#[test]
+fn a_partition_between_chunks_never_leaves_a_hole_in_the_stream() {
+    const FIRST: &[u8] = b"first-chunk-of-the-frame";
+    const SECOND: &[u8] = b"second-chunk-of-the-frame";
+    const PARTITION: Duration = Duration::from_millis(200);
+
+    let mut sim =
+        SimWorld::new_with_network_config_and_seed(NetworkConfiguration::fast_local(), 20_240_183);
+    let client_ip = ip(1);
+    let server_ip = ip(2);
+
+    let server_provider = sim.network_provider(server_ip);
+    let listener = drive(&mut sim, server_provider.bind("10.0.1.2:8080")).expect("bind");
+    let client_provider = sim.network_provider(client_ip);
+    let mut client = drive(&mut sim, client_provider.connect("10.0.1.2:8080")).expect("connect");
+    let (mut server, _) = drive(&mut sim, listener.accept()).expect("accept");
+    sim.run_until_empty();
+    assert_eq!(sim.pending_event_count(), 0, "the handshake has settled");
+
+    let capacity = sim.available_send_buffer(client.connection_id());
+    assert_eq!(
+        poll_write_once(&mut client, FIRST).map(|result| result.expect("first chunk is accepted")),
+        Poll::Ready(FIRST.len())
+    );
+
+    // The partition strikes after the chunk is queued but before the engine
+    // drains it: exactly the window that used to swallow the bytes.
+    sim.partition_pair(client_ip, server_ip, PARTITION);
+    assert!(sim.step(), "the engine drains the queued send");
+
+    assert_eq!(
+        sim.available_send_buffer(client.connection_id()),
+        capacity - FIRST.len(),
+        "a partitioned send holds its bytes instead of dropping them"
+    );
+    let mut byte = [0_u8; 1];
+    assert!(
+        poll_read_once(&mut server, &mut byte).is_pending(),
+        "no byte crosses an active partition"
+    );
+
+    // Healing releases the stalled chunk, and the next chunk follows it.
+    sim.run_until_empty();
+    assert!(
+        !sim.is_partitioned(client_ip, server_ip),
+        "partition healed"
+    );
+    assert_eq!(
+        poll_write_once(&mut client, SECOND)
+            .map(|result| result.expect("second chunk is accepted")),
+        Poll::Ready(SECOND.len())
+    );
+    sim.run_until_empty();
+
+    let mut received = vec![0_u8; FIRST.len() + SECOND.len()];
+    drive(&mut sim, server.read_exact(&mut received)).expect("both chunks arrive");
+    assert_eq!(
+        received,
+        [FIRST, SECOND].concat(),
+        "the peer reads the original bytes in order, with no interior hole"
+    );
+}
+
+/// Healing a partition early releases the bytes it stalled, right away.
+///
+/// The stalled stream is re-driven by the heal itself, not by the deadline it
+/// stalled under: a `FaultContext::heal_partition` (which cuts for an hour and
+/// heals by hand) must not leave the connection waiting out that hour.
+#[test]
+fn healing_a_partition_releases_the_stalled_bytes_immediately() {
+    const PAYLOAD: &[u8] = b"payload-held-by-the-partition";
+    const CUT: Duration = Duration::from_hours(1);
+
+    let mut sim =
+        SimWorld::new_with_network_config_and_seed(NetworkConfiguration::fast_local(), 20_240_183);
+    let client_ip = ip(1);
+    let server_ip = ip(2);
+
+    let server_provider = sim.network_provider(server_ip);
+    let listener = drive(&mut sim, server_provider.bind("10.0.1.2:8080")).expect("bind");
+    let client_provider = sim.network_provider(client_ip);
+    let mut client = drive(&mut sim, client_provider.connect("10.0.1.2:8080")).expect("connect");
+    let (mut server, _) = drive(&mut sim, listener.accept()).expect("accept");
+    sim.run_until_empty();
+
+    sim.partition_pair(client_ip, server_ip, CUT);
+    assert_eq!(
+        poll_write_once(&mut client, PAYLOAD).map(|result| result.expect("payload is accepted")),
+        Poll::Ready(PAYLOAD.len())
+    );
+    assert!(sim.step(), "the engine drains the queued send");
+    let stalled_at = sim.current_time();
+    let mut byte = [0_u8; 1];
+    assert!(poll_read_once(&mut server, &mut byte).is_pending());
+
+    sim.restore_partition(client_ip, server_ip);
+    let mut received = vec![0_u8; PAYLOAD.len()];
+    drive(&mut sim, server.read_exact(&mut received)).expect("the payload arrives");
+
+    assert_eq!(received, PAYLOAD);
+    assert!(
+        sim.current_time().saturating_sub(stalled_at) < Duration::from_secs(1),
+        "healing re-drives the stream instead of waiting out the cut"
+    );
+}
+
+/// A send-wide partition stalls the stream too, and its own clear event
+/// resumes it.
+#[test]
+fn a_send_partition_stalls_the_stream_until_it_clears() {
+    const PAYLOAD: &[u8] = b"payload-held-by-the-send-cut";
+    const CUT: Duration = Duration::from_millis(200);
+
+    let mut sim =
+        SimWorld::new_with_network_config_and_seed(NetworkConfiguration::fast_local(), 20_240_183);
+    let client_ip = ip(1);
+    let server_ip = ip(2);
+
+    let server_provider = sim.network_provider(server_ip);
+    let listener = drive(&mut sim, server_provider.bind("10.0.1.2:8080")).expect("bind");
+    let client_provider = sim.network_provider(client_ip);
+    let mut client = drive(&mut sim, client_provider.connect("10.0.1.2:8080")).expect("connect");
+    let (mut server, _) = drive(&mut sim, listener.accept()).expect("accept");
+    sim.run_until_empty();
+
+    sim.partition_send_from(client_ip, CUT);
+    assert_eq!(
+        poll_write_once(&mut client, PAYLOAD).map(|result| result.expect("payload is accepted")),
+        Poll::Ready(PAYLOAD.len())
+    );
+    assert!(sim.step(), "the engine drains the queued send");
+    let mut byte = [0_u8; 1];
+    assert!(poll_read_once(&mut server, &mut byte).is_pending());
+
+    let mut received = vec![0_u8; PAYLOAD.len()];
+    drive(&mut sim, server.read_exact(&mut received)).expect("the payload arrives once it clears");
+
+    assert_eq!(received, PAYLOAD);
+    assert!(
+        sim.current_time() >= CUT,
+        "the bytes waited for the send partition to clear"
+    );
 }


### PR DESCRIPTION
Closes #183.

## The bug

`NetworkEngine::handle_partitioned_send` popped one queued chunk off a partitioned connection and threw it away, while leaving the connection established and later chunks flowing to `DataDelivery`. For a byte stream that is an interior hole: the peer reads the suffix in place of the range that was silently removed. A framed protocol on top (h2) then parses later traffic as the remainder of an earlier DATA frame — the value-integrity failure Paros hit on replay seed `11666517603030887004` with `NetworkFault::BitFlip` explicitly disabled.

## The fix

A partitioned send now **stalls** rather than dropping:

- the chunk stays at the front of the send buffer;
- send-buffer waiters stay registered, so no capacity is released and the writer keeps seeing backpressure;
- the stream resumes in order once the partitions blocking it heal.

This is what FoundationDB models. `SimClogging` turns a clogged pair into added delay (`getRecvDelay` clamps to `clogPairUntil`), and only an explicit `disconnect` fails the connection — a clogged pair never loses bytes from an established stream.

A stalled connection owns no scheduled work. It is re-driven by `resume_stalled_sends`, called from every partition-clearing path: `PartitionRestore`, `SendPartitionClear`, `RecvPartitionClear`, and `restore_partition`. Healing therefore releases the bytes immediately instead of stranding the stream until the deadline it stalled under, which matters for `FaultContext::partition` — its cut lasts an hour and is meant to be undone by hand.

Nothing here consumes RNG, and the resume is scheduled at a time derived purely from the event schedule, so replay stays deterministic. `NetworkFaultMask` is untouched: with `BitFlip` off, no path mutates application bytes.

## Coverage

Both new tests fail on `main` and pass with the fix:

- `network::partition::a_partition_between_chunks_never_leaves_a_hole_in_the_stream` — a chunk is queued, a partition strikes before the engine drains it, and the peer must read the original bytes in order once it heals. Also asserts the bytes stay queued and nothing crosses the cut while it holds.
- `network::partition::healing_a_partition_releases_the_stalled_bytes_immediately` — an hour-long cut healed by hand must not leave the stream waiting out the hour.
- `network::partition::a_send_partition_stalls_the_stream_until_it_clears` — the send-wide cut takes the same path and resumes on its own clear event.
- `h2_partition_integrity::a_partition_never_alters_a_multiplexed_request_body` — one reused h2 connection (`H2Server` + `ReconnectingChannel`) carries four concurrent requests per round under a flapping scripted partition. Every request body is one repeated tag byte, so a lost interior range shows up as a non-uniform body or another request's tag. Asserts the server reads intact request bodies, every response carries its own request's bytes, and every round completes.

## Validation

- `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt`
- portability: `cargo clippy -p moonpool-sim --no-default-features --all-targets -- -D warnings`, `cargo check --target wasm32-unknown-unknown -p moonpool-sim --no-default-features`
- simulation binaries: `cargo xtask sim run tonic-grpc` (50 seeds of h2 under chaos), `axum-web`, `topology`
- book: the Network Faults chapter documents the stall semantics

Two caveats on the local run, both pre-existing and unrelated to this change: this environment could not build the nix devshell (the flake's `flake-utils` tarball is blocked by the sandbox proxy), so the commands above ran on the rustup toolchain that `rust-toolchain.toml` pins (1.95.0) with `cargo test` instead of `cargo nextest`. Under plain `cargo test` — one process for the whole binary — `tests/determinism.rs` collides with itself through its process-wide `TRACE`, and `moonpool-explorer`'s `workers_are_bounded_and_recipes_replay` flakes under load; both pass individually and both behave identically on unmodified `main`.

The downstream Paros replay seed from the issue was not re-run here (different repository).

---
_Generated by [Claude Code](https://claude.ai/code/session_012knENXCj5CGLCV2SeWhG56)_