### PR TITLE
feat: standalone moonpool-buggify crate + exploration-compatible scripted lifecycle faults (#165, #182)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,9 @@ crates/
 │                            (umbrella `tokio-providers`). wasm-clean with all off.
 ├── moonpool-assertions/   - Antithesis-style assertion accounting (pure std, ZERO deps, wasm-able).
 │                            Heap table by default; explorer overlays MAP_SHARED + a discovery hook.
+├── moonpool-buggify/      - Standalone buggify!/buggify_with_prob! macros + state (pure std, ZERO
+│                            deps, wasm-able). Inert by default; moonpool-sim installs its seeded
+│                            RNG per run and re-exports the macros. buggify_knob! stays in sim.
 ├── moonpool-sim/          - Simulation runtime, chaos testing, buggify, assertions wiring.
 │                            feature `exploration` (default ON) gates moonpool-explorer; without it
 │                            the sim compiles to wasm32-unknown-unknown.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,6 +229,7 @@ Strategic placement: error handling, timeouts, retries, resource limits
 - `.tags(&[("key", &["val1", "val2"])])` — round-robin tag distribution
 - `.enable_chaos([Chaos::Attrition { config, mode }])` — built-in chaos reboots (requires `.chaos_duration()`)
 - `.enable_chaos([Chaos::Network(mode) | Chaos::Storage(mode)])` — network/storage faults per seed (`ChaosMode::Random` all-on, `ChaosMode::Swarm` per-seed subset)
+- `.fault_factory(|| Box::new(injector))` — fresh custom `FaultInjector` per root/explored timeline (exploration-compatible; `FaultContext` has split `crash`/`restart` primitives + workload `state()`)
 - `.swarm_operations()` — per-seed swarm of each workload's operation alphabet
 
 **Reboot lifecycle**: Graceful (signal token → grace period → force kill → restart) vs Crash (immediate abort → restart)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@
 members = [
     "crates/moonpool",
     "crates/moonpool-assertions",
+    "crates/moonpool-buggify",
     "crates/moonpool-core",
     "crates/moonpool-explorer",
     "crates/moonpool-hyper",

--- a/book/src/appendix/03-configuration.md
+++ b/book/src/appendix/03-configuration.md
@@ -22,7 +22,8 @@ The builder pattern for configuring and running simulation experiments. Created 
 | `attrition(config)` | `Attrition` | Enable automatic process reboots during chaos phase |
 | `invariant(i)` | `impl Invariant` | Add an invariant checked after every simulation event |
 | `invariant_fn(name, f)` | `String`, closure | Add a closure-based invariant |
-| `fault(f)` | `impl FaultInjector` | Add a custom fault injector for the chaos phase |
+| `fault(f)` | `impl FaultInjector` | Add a custom fault injector instance for the chaos phase (reused across iterations; rejected by exploration) |
+| `fault_factory(f)` | `Fn() -> Box<dyn FaultInjector>` | Add a fault injector rebuilt fresh for every root and explored timeline (exploration-compatible) |
 | `chaos_duration(dur)` | `Duration` | Set the chaos phase duration (faults run concurrently with workloads) |
 | `set_iterations(n)` | `usize` | Run exactly N iterations (default: 1) |
 | `set_iteration_control(ctrl)` | `IterationControl` | Set the iteration control strategy |

--- a/book/src/part3-building/08-buggify.md
+++ b/book/src/part3-building/08-buggify.md
@@ -162,3 +162,16 @@ The default 25% firing probability works well for most injection points. Use `bu
 Buggify is gated behind simulation state. When the simulation is not running, `buggify!()` always returns `false`. There is no runtime cost in production: the check is a thread-local boolean read. You can leave buggify calls in your production code without worrying about them firing outside simulation.
 
 This is the same guarantee FoundationDB provides: BUGGIFY is gated behind `g_network->isSimulated()`, ensuring zero production impact regardless of how aggressively chaos is injected during testing.
+
+## The Standalone `moonpool-buggify` Crate
+
+The `buggify!()` and `buggify_with_prob!()` macros live in the zero-dependency `moonpool-buggify` crate. Sans-I/O and production code that wants buggify points can depend on it directly, without pulling the simulation runtime into its dependency graph:
+
+```toml
+[dependencies]
+moonpool-buggify = "0.8"
+```
+
+The crate owns only the disabled-by-default state and the macros. When a simulation run starts, `moonpool-sim` installs its deterministic seeded RNG into that shared state, so macros imported through either crate share activation decisions during simulation — and stay inert everywhere else. `moonpool-sim` re-exports both macros, so existing `moonpool_sim::buggify!` call sites are unchanged.
+
+`buggify_knob!` remains in `moonpool-sim`: knob randomization is simulation-specific configuration spiking, not application-level fault injection.

--- a/book/src/part3-building/09-attrition.md
+++ b/book/src/part3-building/09-attrition.md
@@ -186,3 +186,44 @@ impl FaultInjector for RollingRestart {
 ```
 
 The `FaultContext` provides access to process reboots, network partitions, and tag-based targeting. You can combine built-in attrition with custom fault injectors by registering both on the builder.
+
+## Scripted Lifecycle Faults
+
+`reboot()` combines the kill with a timer-based restart, which is right for random attrition but cannot express a scripted sequence like "crash node X, let the workload make progress, then bring X back". For that, `FaultContext` splits the primitives:
+
+- **`ctx.crash(ip)`** force-kills the process **without scheduling a restart**. The node stays down — no application work runs — until an explicit restart.
+- **`ctx.restart(ip)`** boots a fresh instance from the process factory, ending the hold-down.
+- **`ctx.state()`** exposes the same per-iteration `StateHandle` that workloads and processes see, so the injector can wait on a deterministic workload milestone (an operation counter, a published flag) instead of a wall of sleeps.
+
+```rust
+async fn inject(&mut self, ctx: &FaultContext) -> SimulationResult<()> {
+    let target = ctx.process_ips()[0].clone();
+    ctx.crash(&target)?;                       // crash now, hold down
+
+    // Wait until the workload has executed 100 operations.
+    while ctx.state().get::<u64>("ops").unwrap_or(0) < 100 {
+        ctx.time().sleep(Duration::from_millis(20)).await
+            .map_err(|e| SimulationError::InvalidState(e.to_string()))?;
+        if ctx.chaos_shutdown().is_cancelled() { return Ok(()); }
+    }
+
+    ctx.restart(&target)?;                     // explicit recovery
+    Ok(())
+}
+```
+
+Everything the script reads is per-iteration simulated state, so the crash target, milestone, and restart point replay exactly from the seed.
+
+### Fault Factories and Exploration
+
+`.fault(injector)` registers one injector *instance* that is reused across iterations — fine for stateless injectors, but exploration rejects it because a mutated instance cannot be rewound for every explored timeline. Register a **factory** instead:
+
+```rust
+SimulationBuilder::new()
+    .processes(3, || Box::new(MyProcess))
+    .workload_factory(|| Box::new(MyWorkload))
+    .fault_factory(|| Box::new(ScriptedCrashInjector::new()))
+    .chaos_duration(Duration::from_secs(30))
+```
+
+Like `workload_factory`, the factory builds a fresh injector for every root seed and every explored continuation timeline, so scripted fault sequences replay exactly from the root seed plus recipe — with in-process exploration (`workers: 0`) and forked workers alike.

--- a/crates/moonpool-buggify/Cargo.toml
+++ b/crates/moonpool-buggify/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "moonpool-buggify"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Standalone buggify fault-injection macros for the moonpool framework"
+documentation = "https://docs.rs/moonpool-buggify"
+
+# Pure std, zero dependencies — compiles on wasm32-unknown-unknown, macOS, and
+# Linux. Buggify is disabled by default and stays inert until a simulation
+# runtime (moonpool-sim) enables it and installs a deterministic random source,
+# so production and sans-I/O code can depend on this crate without pulling in
+# the simulation runtime.
+[dependencies]
+
+[lints]
+workspace = true

--- a/crates/moonpool-buggify/src/lib.rs
+++ b/crates/moonpool-buggify/src/lib.rs
@@ -1,0 +1,268 @@
+//! Standalone buggify fault injection following `FoundationDB`'s approach.
+//!
+//! Buggify marks code locations where a rare-but-legal behavior can be forced
+//! during simulation testing: an early timeout, a dropped buffer, a slow path.
+//! Each location is randomly **activated** once per simulation run; active
+//! locations then fire probabilistically on each call.
+//!
+//! This crate is dependency-free and owns only the disabled-by-default state
+//! and the [`buggify!`] / [`buggify_with_prob!`] macros, so production and
+//! sans-I/O code can depend on it without pulling in a simulation runtime:
+//!
+//! - Outside an active simulation, buggify is **inert**: every call site
+//!   evaluates to `false` with no side effects.
+//! - A simulation runtime (such as `moonpool-sim`) enables buggify at the
+//!   start of a run via [`buggify_init`] after installing its deterministic
+//!   seeded random source via [`set_random_source`], and disables it again
+//!   with [`buggify_reset`].
+//!
+//! State is thread-local, matching the single-threaded deterministic executors
+//! that drive moonpool simulations, and shared by every path into this crate —
+//! macros invoked through a re-export (e.g. `moonpool_sim::buggify!`) hit the
+//! same state as macros invoked through `moonpool_buggify::buggify!`.
+//!
+//! # Usage
+//!
+//! ```
+//! use moonpool_buggify::buggify;
+//!
+//! // Inert unless a simulation runtime has enabled buggify on this thread.
+//! if buggify!() {
+//!     // Simulate a rare failure path.
+//! }
+//! ```
+
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+
+thread_local! {
+    static STATE: RefCell<State> = RefCell::new(State::default());
+}
+
+/// Deterministic random source: returns an `f64` in `[0.0, 1.0)`.
+///
+/// A plain function pointer so the crate stays dependency-free; simulation
+/// runtimes install their seeded generator (e.g. `sim_random_f64`).
+pub type RandomSource = fn() -> f64;
+
+#[derive(Default)]
+struct State {
+    enabled: bool,
+    active_locations: BTreeMap<String, bool>,
+    activation_prob: f64,
+    random_source: Option<RandomSource>,
+}
+
+/// Install the deterministic random source used for activation and firing draws.
+///
+/// Called by the simulation runtime before [`buggify_init`]. Without an
+/// installed source, buggify stays inert even if enabled.
+pub fn set_random_source(source: RandomSource) {
+    STATE.with(|state| {
+        state.borrow_mut().random_source = Some(source);
+    });
+}
+
+/// Remove the installed random source, returning buggify to its inert state.
+pub fn clear_random_source() {
+    STATE.with(|state| {
+        state.borrow_mut().random_source = None;
+    });
+}
+
+/// Initialize buggify for a simulation run.
+///
+/// Clears per-location activation decisions from any previous run and enables
+/// firing with the given activation probability. The random source must have
+/// been installed via [`set_random_source`] for call sites to fire.
+pub fn buggify_init(activation_prob: f64, _firing_prob: f64) {
+    STATE.with(|state| {
+        let mut state = state.borrow_mut();
+        state.enabled = true;
+        state.active_locations.clear();
+        state.activation_prob = activation_prob;
+    });
+}
+
+/// Reset/disable buggify.
+///
+/// After this call every buggify site evaluates to `false` until the next
+/// [`buggify_init`]. The installed random source is left in place; use
+/// [`clear_random_source`] to remove it as well.
+pub fn buggify_reset() {
+    STATE.with(|state| {
+        let mut state = state.borrow_mut();
+        state.enabled = false;
+        state.active_locations.clear();
+        state.activation_prob = 0.0;
+    });
+}
+
+/// Internal buggify implementation backing the [`buggify!`] and
+/// [`buggify_with_prob!`] macros.
+///
+/// Decides activation for `location` on first encounter (one random draw),
+/// then fires probabilistically on each call while active (one draw per call).
+/// Draw order and count are stable for a given call sequence, so seeded replay
+/// through an installed [`RandomSource`] is exact.
+#[must_use]
+pub fn buggify_internal(prob: f64, location: &'static str) -> bool {
+    STATE.with(|state| {
+        let mut state = state.borrow_mut();
+
+        if !state.enabled || prob <= 0.0 {
+            return false;
+        }
+        let Some(random) = state.random_source else {
+            return false;
+        };
+
+        let location_str = location.to_string();
+        let activation_prob = state.activation_prob;
+
+        // Decide activation on first encounter
+        let is_active = *state
+            .active_locations
+            .entry(location_str)
+            .or_insert_with(|| random() < activation_prob);
+
+        // If active, fire probabilistically
+        is_active && random() < prob
+    })
+}
+
+/// Buggify with 25% probability
+#[macro_export]
+macro_rules! buggify {
+    () => {
+        $crate::buggify_internal(0.25, concat!(file!(), ":", line!()))
+    };
+}
+
+/// Buggify with custom probability
+#[macro_export]
+macro_rules! buggify_with_prob {
+    ($prob:expr) => {
+        $crate::buggify_internal($prob as f64, concat!(file!(), ":", line!()))
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+
+    thread_local! {
+        /// Deterministic test source: a simple counter-driven sequence.
+        static TEST_DRAWS: Cell<u64> = const { Cell::new(0) };
+    }
+
+    /// Test random source: cycles deterministically through [0.0, 1.0).
+    fn test_source() -> f64 {
+        let n = TEST_DRAWS.with(|c| {
+            let n = c.get();
+            c.set(n + 1);
+            n
+        });
+        // Multiplicative hash into [0, 1), deterministic per draw index. The
+        // shift leaves 32 bits, so the u32 conversion is lossless.
+        let bits = u32::try_from(n.wrapping_mul(0x9E37_79B9_7F4A_7C15) >> 32)
+            .expect("shifted value fits in u32");
+        f64::from(bits) / 4_294_967_296.0
+    }
+
+    fn reset_test_source() {
+        TEST_DRAWS.with(|c| c.set(0));
+    }
+
+    #[test]
+    fn disabled_by_default_is_inert() {
+        buggify_reset();
+        clear_random_source();
+        for _ in 0..10 {
+            assert!(!buggify_internal(1.0, "inert"));
+        }
+    }
+
+    #[test]
+    fn enabled_without_source_is_inert() {
+        clear_random_source();
+        buggify_init(1.0, 1.0);
+        assert!(!buggify_internal(1.0, "no_source"));
+        buggify_reset();
+    }
+
+    #[test]
+    fn activation_decision_is_consistent() {
+        reset_test_source();
+        set_random_source(test_source);
+        buggify_init(0.5, 1.0);
+
+        let location = "consistent_location";
+        let first = buggify_internal(1.0, location);
+        let second = buggify_internal(1.0, location);
+        // With prob=1.0 the outcome equals the activation decision, which is
+        // made once per location.
+        assert_eq!(first, second);
+        buggify_reset();
+        clear_random_source();
+    }
+
+    #[test]
+    fn sequences_replay_deterministically() {
+        let run = || {
+            reset_test_source();
+            set_random_source(test_source);
+            buggify_init(0.5, 0.5);
+            let out: Vec<bool> = (0..5)
+                .map(|i| {
+                    let location = Box::leak(format!("loc_{i}").into_boxed_str());
+                    buggify_internal(0.5, location)
+                })
+                .collect();
+            buggify_reset();
+            clear_random_source();
+            out
+        };
+        assert_eq!(run(), run());
+    }
+
+    #[test]
+    fn always_active_always_fires() {
+        reset_test_source();
+        set_random_source(test_source);
+        buggify_init(1.0, 1.0);
+        let fired = (0..20).any(|_| buggify_internal(1.0, "always"));
+        assert!(fired, "activation 1.0 + prob 1.0 must fire");
+        buggify_reset();
+        clear_random_source();
+    }
+
+    #[test]
+    fn reset_disables_firing() {
+        reset_test_source();
+        set_random_source(test_source);
+        buggify_init(1.0, 1.0);
+        assert!(buggify_internal(1.0, "reset_case"));
+        buggify_reset();
+        assert!(!buggify_internal(1.0, "reset_case"));
+        clear_random_source();
+    }
+
+    #[test]
+    fn macros_share_crate_state() {
+        reset_test_source();
+        set_random_source(test_source);
+        buggify_init(1.0, 1.0);
+        // buggify! fires at 25% per call; over many calls it must fire.
+        assert!(
+            (0..100).any(|_| crate::buggify!()),
+            "macro must observe enabled state"
+        );
+        assert!(crate::buggify_with_prob!(1.0));
+        buggify_reset();
+        assert!((0..100).all(|_| !crate::buggify!()));
+        assert!(!crate::buggify_with_prob!(1.0));
+        clear_random_source();
+    }
+}

--- a/crates/moonpool-sim/Cargo.toml
+++ b/crates/moonpool-sim/Cargo.toml
@@ -31,6 +31,9 @@ moonpool-core = { path = "../moonpool-core", version = "0.8.0", default-features
 # Assertion accounting (pure std, wasm-able) — always present. The fork-based
 # exploration backend below is optional and layers on top of it.
 moonpool-assertions = { path = "../moonpool-assertions", version = "0.8.0" }
+# Standalone buggify state + macros (pure std, wasm-able). The sim installs its
+# seeded RNG into it per run; production code can depend on it directly.
+moonpool-buggify = { path = "../moonpool-buggify", version = "0.8.0" }
 moonpool-explorer = { path = "../moonpool-explorer", version = "0.8.0", optional = true }
 
 # Runnable/Task split, waker wiring, join + cancellation for the deterministic

--- a/crates/moonpool-sim/src/chaos/buggify.rs
+++ b/crates/moonpool-sim/src/chaos/buggify.rs
@@ -1,66 +1,39 @@
-//! Deterministic fault injection following `FoundationDB`'s buggify approach.
+//! Simulation wiring for the standalone [`moonpool_buggify`] crate.
 //!
-//! Each buggify location is randomly activated once per simulation run.
-//! Active locations fire probabilistically on each call.
+//! The buggify state and the [`buggify!`](crate::buggify) /
+//! [`buggify_with_prob!`](crate::buggify_with_prob) macros live in
+//! `moonpool-buggify` (zero dependencies, usable from production and sans-I/O
+//! code). This module installs the simulation's deterministic seeded RNG into
+//! that crate for the duration of a run, and keeps the simulation-specific
+//! knob randomization ([`buggify_knob!`](crate::buggify_knob)).
+//!
+//! Because both crates share the one thread-local state in `moonpool-buggify`,
+//! macros imported through either crate observe the same activation decisions
+//! during a simulation.
 
-use crate::sim::rng::sim_random;
+use crate::sim::rng::sim_random_f64;
 use rand::distr::uniform::SampleUniform;
-use std::cell::RefCell;
-use std::collections::BTreeMap;
 
-thread_local! {
-    static STATE: RefCell<State> = RefCell::new(State::default());
+pub use moonpool_buggify::buggify_internal;
+
+/// Initialize buggify for a simulation run.
+///
+/// Installs the simulation's seeded RNG as the buggify random source, then
+/// enables buggify with the given activation probability. Each buggify
+/// location is randomly activated once per run; active locations fire
+/// probabilistically on each call.
+pub fn buggify_init(activation_prob: f64, firing_prob: f64) {
+    moonpool_buggify::set_random_source(sim_random_f64);
+    moonpool_buggify::buggify_init(activation_prob, firing_prob);
 }
 
-#[derive(Default)]
-struct State {
-    enabled: bool,
-    active_locations: BTreeMap<String, bool>,
-    activation_prob: f64,
-}
-
-/// Initialize buggify for simulation run
-pub fn buggify_init(activation_prob: f64, _firing_prob: f64) {
-    STATE.with(|state| {
-        let mut state = state.borrow_mut();
-        state.enabled = true;
-        state.active_locations.clear();
-        state.activation_prob = activation_prob;
-    });
-}
-
-/// Reset/disable buggify
+/// Reset/disable buggify and uninstall the simulation random source.
+///
+/// Buggify is inert again after this call, as it is outside an active
+/// simulation.
 pub fn buggify_reset() {
-    STATE.with(|state| {
-        let mut state = state.borrow_mut();
-        state.enabled = false;
-        state.active_locations.clear();
-        state.activation_prob = 0.0;
-    });
-}
-
-/// Internal buggify implementation
-#[must_use]
-pub fn buggify_internal(prob: f64, location: &'static str) -> bool {
-    STATE.with(|state| {
-        let mut state = state.borrow_mut();
-
-        if !state.enabled || prob <= 0.0 {
-            return false;
-        }
-
-        let location_str = location.to_string();
-        let activation_prob = state.activation_prob;
-
-        // Decide activation on first encounter
-        let is_active = *state
-            .active_locations
-            .entry(location_str)
-            .or_insert_with(|| sim_random::<f64>() < activation_prob);
-
-        // If active, fire probabilistically
-        is_active && sim_random::<f64>() < prob
-    })
+    moonpool_buggify::buggify_reset();
+    moonpool_buggify::clear_random_source();
 }
 
 /// Buggify a knob *value* within bounds.
@@ -83,29 +56,13 @@ where
     }
 }
 
-/// Buggify with 25% probability
-#[macro_export]
-macro_rules! buggify {
-    () => {
-        $crate::chaos::buggify::buggify_internal(0.25, concat!(file!(), ":", line!()))
-    };
-}
-
-/// Buggify with custom probability
-#[macro_export]
-macro_rules! buggify_with_prob {
-    ($prob:expr) => {
-        $crate::chaos::buggify::buggify_internal($prob as f64, concat!(file!(), ":", line!()))
-    };
-}
-
 /// Buggify a config knob *value* within bounds.
 ///
 /// `buggify_knob!(default, lo..hi)` evaluates to `default` on most seeds, but when
 /// buggify is enabled and this call site is activated + fires (same model as
-/// [`buggify!`]) it evaluates to a random value in `lo..hi`. Deterministic per
-/// `(location, seed)`, so replay is exact. Mirrors `FoundationDB`'s
-/// `if (randomize && BUGGIFY) KNOB = random(lo, hi)`.
+/// [`buggify!`](crate::buggify)) it evaluates to a random value in `lo..hi`.
+/// Deterministic per `(location, seed)`, so replay is exact. Mirrors
+/// `FoundationDB`'s `if (randomize && BUGGIFY) KNOB = random(lo, hi)`.
 #[macro_export]
 macro_rules! buggify_knob {
     ($default:expr, $range:expr) => {
@@ -170,6 +127,20 @@ mod tests {
         }
 
         assert_eq!(results1, results2);
+    }
+
+    #[test]
+    fn test_macro_paths_share_state() {
+        // The sim re-export and the standalone crate must hit the same state.
+        set_sim_seed(4242);
+        buggify_init(1.0, 1.0);
+        assert_eq!(
+            moonpool_buggify::buggify_internal(1.0, "shared_state"),
+            buggify_internal(1.0, "shared_state"),
+        );
+        assert!(moonpool_buggify::buggify_internal(1.0, "shared_state"));
+        buggify_reset();
+        assert!(!moonpool_buggify::buggify_internal(1.0, "shared_state"));
     }
 
     /// Collect a fixed sequence of `buggify_knob!` results for one seed.

--- a/crates/moonpool-sim/src/lib.rs
+++ b/crates/moonpool-sim/src/lib.rs
@@ -147,6 +147,11 @@ pub use runner::{
     WorkloadCount, WorkloadTopology,
 };
 
+// Buggify macros live in the standalone zero-dependency moonpool-buggify
+// crate; re-exported here so existing `moonpool_sim::buggify!` call sites keep
+// working and share the same state as direct moonpool-buggify users.
+pub use moonpool_buggify::{buggify, buggify_with_prob};
+
 // Chaos module re-exports
 pub use chaos::{
     AssertionStats, SIM_FAULT_EVENT_NAME, SimFaultEvent, StateHandle, assertion_results,

--- a/crates/moonpool-sim/src/runner/builder.rs
+++ b/crates/moonpool-sim/src/runner/builder.rs
@@ -105,6 +105,7 @@ impl RunState {
             metrics_collector: MetricsCollector::new(),
             progress_milestone,
             pending_return_map: Vec::new(),
+            pending_instance_injector_count: 0,
             #[cfg(feature = "exploration")]
             explorer: None,
             #[cfg(feature = "exploration")]
@@ -140,6 +141,11 @@ struct RunState {
     /// stashed between [`SimulationBuilder::run_orchestrator_for_iteration`]
     /// and [`SimulationBuilder::handle_orchestration_result`].
     pending_return_map: Vec<Option<usize>>,
+    /// How many of the injectors handed to the current orchestration were
+    /// user instances (`.fault()`), i.e. the prefix of the returned injector
+    /// list that goes back to the builder. Factory-created and attrition
+    /// injectors past that prefix are dropped and rebuilt per timeline.
+    pending_instance_injector_count: usize,
     // Exploration state (only populated/read with the `exploration` feature).
     /// The frontier controller; lives across iterations so cumulative novelty
     /// (discovery latches, sancov history) spans the whole run.
@@ -225,6 +231,9 @@ pub struct SimulationBuilder {
     swarm_operations: bool,
     invariants: Vec<Box<dyn Invariant + Send>>,
     fault_injectors: Vec<Box<dyn FaultInjector>>,
+    /// Factories that build a fresh fault injector for every root and explored
+    /// timeline, mirroring `workload_factory`. Compatible with exploration.
+    fault_factories: Vec<Box<dyn Fn() -> Box<dyn FaultInjector> + 'static>>,
     chaos_duration: Option<Duration>,
     exploration_config: Option<crate::chaos::exploration_glue::ExplorationConfig>,
     /// Replay breakpoints staged for the next orchestration run. Installed
@@ -266,6 +275,7 @@ impl SimulationBuilder {
             swarm_operations: false,
             invariants: Vec::new(),
             fault_injectors: Vec::new(),
+            fault_factories: Vec::new(),
             chaos_duration: None,
             exploration_config: None,
             pending_replay: None,
@@ -539,9 +549,27 @@ impl SimulationBuilder {
     }
 
     /// Add a fault injector to run during the chaos phase.
+    ///
+    /// The same instance is reused across iterations, so its internal state
+    /// carries over. For exploration — or whenever the injector must start
+    /// from pristine state on every timeline — use
+    /// [`fault_factory`](Self::fault_factory) instead.
     #[must_use]
     pub fn fault(mut self, f: impl FaultInjector) -> Self {
         self.fault_injectors.push(Box::new(f));
+        self
+    }
+
+    /// Add a fault injector reconstructed from a factory for every timeline.
+    ///
+    /// Unlike [`fault`](Self::fault), this never reuses a previously-run
+    /// injector value: a fresh instance is built for every iteration and for
+    /// every explored continuation timeline, so scripted fault sequences
+    /// (crash → hold-down → milestone → restart) replay exactly from the root
+    /// seed plus recipe. This is the form exploration accepts.
+    #[must_use]
+    pub fn fault_factory(mut self, factory: impl Fn() -> Box<dyn FaultInjector> + 'static) -> Self {
+        self.fault_factories.push(Box::new(factory));
         self
     }
 
@@ -707,10 +735,14 @@ impl SimulationBuilder {
     /// different deterministic seeds. Set `config.workers` to zero for
     /// sequential, fork-free exploration. Requires the `exploration` feature.
     ///
-    /// Exploration requires factory-created workloads and built-in [`Chaos`]
-    /// surfaces. Instance workloads, `before_iteration` hooks, and custom fault
-    /// injector instances are rejected because the runner cannot reconstruct
-    /// those values with fresh state for every continuation timeline.
+    /// Exploration requires factory-created workloads, and factory-created or
+    /// built-in fault injection. Instance workloads, `before_iteration` hooks,
+    /// and custom fault injector instances are rejected because the runner
+    /// cannot reconstruct those values with fresh state for every continuation
+    /// timeline. Custom fault injectors registered through
+    /// [`Self::fault_factory`] are supported: a fresh injector is built for
+    /// every root and explored timeline (both in-process `workers: 0` and
+    /// forked-worker exploration).
     ///
     /// # Panics
     ///
@@ -719,7 +751,8 @@ impl SimulationBuilder {
     /// with instance workloads, `before_iteration` hooks, or custom fault
     /// injector instances, because those values cannot be reconstructed for
     /// each continuation timeline. Use [`Self::workload_factory`] or
-    /// [`Self::workloads`] and built-in [`Chaos`] surfaces instead.
+    /// [`Self::workloads`], and [`Self::fault_factory`] or built-in [`Chaos`]
+    /// surfaces instead.
     #[cfg(feature = "exploration")]
     #[must_use]
     pub fn enable_exploration(
@@ -894,19 +927,40 @@ impl SimulationBuilder {
         sim
     }
 
-    /// Drain user-provided fault injectors and, when present, append the
-    /// built-in attrition injector.
+    /// Drain user-provided fault injector instances, then append one fresh
+    /// injector per registered factory and, when present, the built-in
+    /// attrition injector.
+    ///
+    /// Only the leading instance injectors are returned to the builder after
+    /// the run (see `keep_returned_instance_injectors`); factory-created and
+    /// attrition injectors are rebuilt fresh for every timeline.
     fn collect_fault_injectors(
         user_injectors: &mut Vec<Box<dyn FaultInjector>>,
+        fault_factories: &[Box<dyn Fn() -> Box<dyn FaultInjector> + 'static>],
         attrition: Option<&Attrition>,
     ) -> Vec<Box<dyn FaultInjector>> {
         let mut fault_injectors = std::mem::take(user_injectors);
+        for factory in fault_factories {
+            fault_injectors.push(factory());
+        }
         if let Some(attrition) = attrition {
             fault_injectors.push(Box::new(
                 crate::runner::fault_injector::AttritionInjector::new(attrition.clone()),
             ));
         }
         fault_injectors
+    }
+
+    /// Return only the leading instance injectors to the builder, dropping
+    /// factory-created and built-in attrition injectors so the next timeline
+    /// rebuilds them with fresh state (mirroring factory workloads).
+    fn keep_returned_instance_injectors(
+        &mut self,
+        mut returned_injectors: Vec<Box<dyn FaultInjector>>,
+        instance_count: usize,
+    ) {
+        returned_injectors.truncate(instance_count);
+        self.fault_injectors = returned_injectors;
     }
 
     /// Build an early-exit report on deadlock: snapshot the assertion
@@ -963,7 +1017,8 @@ impl SimulationBuilder {
         assert!(
             self.fault_injectors.is_empty(),
             "exploration does not support custom fault injector instances because they cannot be \
-             reconstructed for every timeline; use built-in Chaos surfaces"
+             reconstructed for every timeline; use SimulationBuilder::fault_factory or built-in \
+             Chaos surfaces"
         );
     }
 
@@ -1483,7 +1538,10 @@ impl SimulationBuilder {
                     // forked worker this mutates the copy-on-write copy only.
                     let return_map = std::mem::take(&mut state.pending_return_map);
                     self.return_entries(output.workloads, return_map);
-                    self.fault_injectors = output.fault_injectors;
+                    self.keep_returned_instance_injectors(
+                        output.fault_injectors,
+                        state.pending_instance_injector_count,
+                    );
                     failed
                 }
                 Err(_) => true,
@@ -1591,8 +1649,12 @@ impl SimulationBuilder {
             (Some(base), ChaosMode::Random) => Some(base.clone()),
             (None, _) => None,
         };
-        let fault_injectors =
-            Self::collect_fault_injectors(&mut self.fault_injectors, attrition.as_ref());
+        state.pending_instance_injector_count = self.fault_injectors.len();
+        let fault_injectors = Self::collect_fault_injectors(
+            &mut self.fault_injectors,
+            &self.fault_factories,
+            attrition.as_ref(),
+        );
         let outcome = Self::run_orchestrator_blocking(RunOrchestratorInputs {
             seed,
             iteration_count,
@@ -1633,7 +1695,10 @@ impl SimulationBuilder {
             }) => {
                 let return_map = std::mem::take(&mut state.pending_return_map);
                 self.return_entries(returned_workloads, return_map);
-                self.fault_injectors = returned_injectors;
+                self.keep_returned_instance_injectors(
+                    returned_injectors,
+                    state.pending_instance_injector_count,
+                );
                 let wall_time = start_time.elapsed();
                 state.metrics_collector.record_iteration(
                     seed,

--- a/crates/moonpool-sim/src/runner/fault_injector.rs
+++ b/crates/moonpool-sim/src/runner/fault_injector.rs
@@ -70,6 +70,7 @@ pub struct FaultContext {
     process_info: ProcessInfo,
     random: SimRandomProvider,
     time: SimTimeProvider,
+    state: crate::chaos::state_handle::StateHandle,
     chaos_shutdown: tokio_util::sync::CancellationToken,
 }
 
@@ -81,6 +82,7 @@ impl FaultContext {
         process_info: ProcessInfo,
         random: SimRandomProvider,
         time: SimTimeProvider,
+        state: crate::chaos::state_handle::StateHandle,
         chaos_shutdown: tokio_util::sync::CancellationToken,
     ) -> Self {
         Self {
@@ -88,8 +90,22 @@ impl FaultContext {
             process_info,
             random,
             time,
+            state,
             chaos_shutdown,
         }
+    }
+
+    /// The per-iteration shared state handle, also visible to workloads and
+    /// processes via `SimContext::state`.
+    ///
+    /// Lets a fault injector coordinate on deterministic workload milestones
+    /// (e.g. "crash node X, wait until the workload has executed N operations,
+    /// then restart X"). The values read here are per-iteration simulated
+    /// state, so scripted sequences replay exactly from the root seed plus
+    /// recipe.
+    #[must_use]
+    pub fn state(&self) -> &crate::chaos::state_handle::StateHandle {
+        &self.state
     }
 
     /// Get the number of currently dead (killed but not yet restarted) processes.
@@ -258,7 +274,7 @@ impl FaultContext {
                 self.sim.schedule_event(
                     crate::sim::Event::ProcessForceKill {
                         ip: ip_addr,
-                        recovery_delay_ms: delay_ms,
+                        recovery_delay_ms: Some(delay_ms),
                         cause,
                     },
                     Duration::from_nanos(1),
@@ -267,6 +283,67 @@ impl FaultContext {
             }
         }
 
+        Ok(())
+    }
+
+    /// Crash a process **without scheduling a restart** (hold-down).
+    ///
+    /// Unlike [`reboot`](Self::reboot) with [`RebootKind::Crash`] — which
+    /// combines the crash with a timer-based restart — this schedules only the
+    /// force-kill: the process task is aborted, its connections die, and its
+    /// unsynced storage state is lost, but no recovery timer is armed. The
+    /// process stays down until an explicit [`restart`](Self::restart), so a
+    /// scripted injector can hold a node down across a deterministic workload
+    /// milestone (observed via [`state`](Self::state)).
+    ///
+    /// The crashed process counts toward [`dead_count`](Self::dead_count)
+    /// until restarted.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if IP parsing fails.
+    pub fn crash(&self, ip: &str) -> SimulationResult<()> {
+        let ip_addr: std::net::IpAddr = ip
+            .parse()
+            .map_err(|e| crate::SimulationError::InvalidState(format!("invalid IP '{ip}': {e}")))?;
+        assert_reachable!("crash: hold-down path");
+        self.process_info
+            .dead_count
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        self.sim.schedule_event(
+            crate::sim::Event::ProcessForceKill {
+                ip: ip_addr,
+                recovery_delay_ms: None,
+                cause: ProcessKillKind::Crash,
+            },
+            Duration::from_nanos(1),
+        );
+        tracing::info!("Crashed process at IP {} (held down until restart)", ip);
+        Ok(())
+    }
+
+    /// Explicitly restart a process, typically one held down by
+    /// [`crash`](Self::crash).
+    ///
+    /// Schedules a `ProcessRestart` event: the orchestrator boots a fresh
+    /// instance from the process factory and the process leaves
+    /// [`dead_count`](Self::dead_count). Restarting a process that is still
+    /// running aborts it first and boots a fresh instance (a zero-downtime
+    /// reboot).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if IP parsing fails.
+    pub fn restart(&self, ip: &str) -> SimulationResult<()> {
+        let ip_addr: std::net::IpAddr = ip
+            .parse()
+            .map_err(|e| crate::SimulationError::InvalidState(format!("invalid IP '{ip}': {e}")))?;
+        assert_reachable!("restart: explicit restart path");
+        self.sim.schedule_event(
+            crate::sim::Event::ProcessRestart { ip: ip_addr },
+            Duration::from_nanos(1),
+        );
+        tracing::info!("Explicitly restarting process at IP {}", ip);
         Ok(())
     }
 

--- a/crates/moonpool-sim/src/runner/orchestrator.rs
+++ b/crates/moonpool-sim/src/runner/orchestrator.rs
@@ -489,6 +489,7 @@ impl WorkloadOrchestrator {
             sim,
             process_manager,
             seed,
+            state,
             &chaos_shutdown,
         )
         .map_err(|()| (vec![seed], 1usize))?;
@@ -825,6 +826,7 @@ impl WorkloadOrchestrator {
         sim: &crate::sim::SimWorld,
         process_manager: &ProcessManager<'_>,
         seed: u64,
+        state: &StateHandle,
         chaos_shutdown: &tokio_util::sync::CancellationToken,
     ) -> Result<(InjectorHandleSlots, Vec<Box<dyn FaultInjector>>), ()> {
         let mut injector_handles: InjectorHandleSlots = Vec::new();
@@ -837,6 +839,7 @@ impl WorkloadOrchestrator {
                     process_manager.process_info(),
                     crate::SimRandomProvider::new(seed),
                     sim.time_provider(),
+                    state.clone(),
                     chaos_shutdown.clone(),
                 );
                 let handle = crate::executor::spawn("fault-injector", async move {
@@ -1289,7 +1292,7 @@ impl WorkloadOrchestrator {
                 sim.schedule_event(
                     crate::sim::Event::ProcessForceKill {
                         ip,
-                        recovery_delay_ms,
+                        recovery_delay_ms: Some(recovery_delay_ms),
                         cause: ProcessKillKind::GracePeriodExpired,
                     },
                     Duration::from_millis(grace_period_ms),
@@ -1319,7 +1322,11 @@ impl WorkloadOrchestrator {
                         sim.wipe_storage_for_process(ip);
                     }
                 }
-                sim.schedule_process_restart(ip, Duration::from_millis(recovery_delay_ms));
+                // A held-down crash (None) schedules no restart: the process
+                // stays dead until a fault injector explicitly restarts it.
+                if let Some(recovery_delay_ms) = recovery_delay_ms {
+                    sim.schedule_process_restart(ip, Duration::from_millis(recovery_delay_ms));
+                }
             }
             Some(crate::sim::Event::ProcessRestart { ip }) => {
                 assert_reachable!("event: ProcessRestart");

--- a/crates/moonpool-sim/src/sim/events.rs
+++ b/crates/moonpool-sim/src/sim/events.rs
@@ -47,8 +47,11 @@ pub enum Event {
     ProcessForceKill {
         /// The IP address of the process to force-kill.
         ip: std::net::IpAddr,
-        /// Recovery delay in milliseconds before restart.
-        recovery_delay_ms: u64,
+        /// Recovery delay in milliseconds before restart. `None` holds the
+        /// process down indefinitely: no restart is scheduled until an
+        /// explicit [`Event::ProcessRestart`] arrives (scripted fault
+        /// injection via `FaultContext::restart`).
+        recovery_delay_ms: Option<u64>,
         /// Why the process is dying, and what that costs its storage.
         cause: ProcessKillKind,
     },

--- a/crates/moonpool-sim/tests/scripted_faults.rs
+++ b/crates/moonpool-sim/tests/scripted_faults.rs
@@ -1,0 +1,275 @@
+//! Scripted process lifecycle fault tests.
+//!
+//! A factory-created fault injector crashes a selected process, holds it down
+//! until the workload reaches a deterministic operation milestone (observed
+//! through the shared `StateHandle`), then explicitly restarts it — proving
+//! the crash / hold-down / restart split on `FaultContext`, `fault_factory`
+//! compatibility with in-process exploration, and exact replay.
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use moonpool_sim::{
+    FaultContext, FaultInjector, Process, SimContext, SimulationBuilder, SimulationError,
+    SimulationResult, TimeProvider, Workload, assert_always,
+};
+
+/// Milestone (in workload operations) the crashed process is held down until.
+const HOLD_MILESTONE: u64 = 100;
+/// Total operations the workload executes; well past the milestone so the
+/// injector finishes its script before the run ends.
+const TOTAL_OPS: u64 = 600;
+
+/// Timestamped fault-script events, shared across timelines of one run so two
+/// identical runs can be compared for exact replay.
+type EventLog = Arc<Mutex<Vec<(&'static str, u128)>>>;
+
+fn log_event(events: &EventLog, label: &'static str, now: Duration) {
+    events
+        .lock()
+        .expect("RwLock poisoned: prior task panicked")
+        .push((label, now.as_millis()));
+}
+
+/// Process that increments a per-IP tick counter in shared state every 10ms.
+/// A held-down process must stop ticking.
+struct TickerProcess;
+
+#[async_trait]
+impl Process for TickerProcess {
+    fn name(&self) -> &'static str {
+        "ticker"
+    }
+
+    async fn run(&mut self, ctx: &SimContext) -> SimulationResult<()> {
+        let key = format!("ticks:{}", ctx.my_ip());
+        loop {
+            let slept = moonpool_sim::select! {
+                biased;
+                () = ctx.shutdown().cancelled() => return Ok(()),
+                r = ctx.time().sleep(Duration::from_millis(10)) => r,
+            };
+            slept.map_err(|e| SimulationError::InvalidState(format!("sleep failed: {e}")))?;
+            let ticks: u64 = ctx.state().get(&key).unwrap_or(0);
+            ctx.state().publish(&key, ticks + 1);
+        }
+    }
+}
+
+/// Workload that executes operations at a fixed rate, publishing the running
+/// count so the fault injector can coordinate on a deterministic milestone.
+struct CountingWorkload;
+
+#[async_trait]
+impl Workload for CountingWorkload {
+    fn name(&self) -> &'static str {
+        "counter"
+    }
+
+    async fn run(&mut self, ctx: &SimContext) -> SimulationResult<()> {
+        for op in 1..=TOTAL_OPS {
+            ctx.time()
+                .sleep(Duration::from_millis(5))
+                .await
+                .map_err(|e| SimulationError::InvalidState(format!("sleep failed: {e}")))?;
+            ctx.state().publish("ops", op);
+        }
+        Ok(())
+    }
+}
+
+/// Scripted injector: crash process 0, hold it down until the workload passes
+/// [`HOLD_MILESTONE`] operations, verify no process work happened while held,
+/// then explicitly restart and verify recovery.
+struct ScriptedCrashInjector {
+    events: EventLog,
+}
+
+impl ScriptedCrashInjector {
+    /// Sleep briefly, bailing out early when the chaos phase ends.
+    async fn pause(ctx: &FaultContext, ms: u64) -> SimulationResult<bool> {
+        if ctx.chaos_shutdown().is_cancelled() {
+            return Ok(false);
+        }
+        ctx.time()
+            .sleep(Duration::from_millis(ms))
+            .await
+            .map_err(|e| SimulationError::InvalidState(format!("sleep failed: {e}")))?;
+        Ok(!ctx.chaos_shutdown().is_cancelled())
+    }
+}
+
+#[async_trait]
+impl FaultInjector for ScriptedCrashInjector {
+    fn name(&self) -> &'static str {
+        "scripted_crash"
+    }
+
+    async fn inject(&mut self, ctx: &FaultContext) -> SimulationResult<()> {
+        // Let processes boot and the workload start making progress.
+        if !Self::pause(ctx, 100).await? {
+            return Ok(());
+        }
+        let target = ctx.process_ips()[0].clone();
+        let ticks_key = format!("ticks:{target}");
+
+        ctx.crash(&target)?;
+        log_event(&self.events, "crash", ctx.time().now());
+
+        // Give the force-kill event time to land, then snapshot the tick
+        // counter: it must not move again until the explicit restart.
+        if !Self::pause(ctx, 30).await? {
+            return Ok(());
+        }
+        let ticks_held: u64 = ctx.state().get(&ticks_key).unwrap_or(0);
+
+        // Hold the process down until the workload milestone.
+        while ctx.state().get::<u64>("ops").unwrap_or(0) < HOLD_MILESTONE {
+            if !Self::pause(ctx, 20).await? {
+                return Ok(());
+            }
+        }
+        log_event(&self.events, "milestone", ctx.time().now());
+        assert_always!(
+            ctx.state().get::<u64>(&ticks_key).unwrap_or(0) == ticks_held,
+            "held-down process must not run application work"
+        );
+
+        ctx.restart(&target)?;
+        log_event(&self.events, "restart", ctx.time().now());
+
+        // Recovery: the fresh instance must resume ticking before the chaos
+        // cutoff, leaving the workload a quiet convergence tail.
+        let mut recovered = false;
+        for _ in 0..50 {
+            if !Self::pause(ctx, 20).await? {
+                break;
+            }
+            if ctx.state().get::<u64>(&ticks_key).unwrap_or(0) > ticks_held {
+                recovered = true;
+                break;
+            }
+        }
+        assert_always!(recovered, "restarted process must resume work");
+        log_event(&self.events, "recovered", ctx.time().now());
+        Ok(())
+    }
+}
+
+/// Build the scripted-fault simulation against a shared event log.
+fn scripted_builder(events: &EventLog) -> SimulationBuilder {
+    let events = events.clone();
+    SimulationBuilder::new()
+        .processes(2, || Box::new(TickerProcess))
+        .workload_factory(|| Box::new(CountingWorkload))
+        .fault_factory(move || {
+            Box::new(ScriptedCrashInjector {
+                events: events.clone(),
+            })
+        })
+        .chaos_duration(Duration::from_secs(30))
+}
+
+/// The crash → hold-down → milestone → restart script succeeds across seeds:
+/// no process work during the hold-down interval, recovery before the cutoff.
+#[test]
+fn test_scripted_crash_hold_restart() {
+    let events: EventLog = Arc::default();
+    let report = scripted_builder(&events)
+        .set_iterations(3)
+        .set_debug_seeds(vec![7, 11, 13])
+        .run();
+    assert_eq!(report.failed_runs, 0, "scripted lifecycle script must pass");
+    assert_eq!(report.successful_runs, 3);
+
+    let log = events
+        .lock()
+        .expect("RwLock poisoned: prior task panicked")
+        .clone();
+    let labels: Vec<&str> = log.iter().map(|(label, _)| *label).collect();
+    assert_eq!(
+        labels,
+        [
+            "crash",
+            "milestone",
+            "restart",
+            "recovered",
+            "crash",
+            "milestone",
+            "restart",
+            "recovered",
+            "crash",
+            "milestone",
+            "restart",
+            "recovered",
+        ],
+        "each seed must run the full script exactly once"
+    );
+}
+
+/// Two identical fresh-builder runs replay the exact same crash / restart
+/// timeline: same event order and identical simulated timestamps.
+#[test]
+fn test_scripted_faults_replay_exactly() {
+    let run = || {
+        let events: EventLog = Arc::default();
+        let report = scripted_builder(&events)
+            .set_iterations(1)
+            .set_debug_seeds(vec![4242])
+            .run();
+        assert_eq!(report.failed_runs, 0);
+        events
+            .lock()
+            .expect("RwLock poisoned: prior task panicked")
+            .clone()
+    };
+    let first = run();
+    let second = run();
+    assert_eq!(
+        first, second,
+        "fresh-builder replay must reproduce identical crash/restart events"
+    );
+    assert_eq!(first.len(), 4, "one full script per run");
+}
+
+/// `fault_factory` is accepted by in-process exploration (`workers: 0`): a
+/// fresh injector is built for every explored timeline, and two identical
+/// exploration runs stay fully deterministic.
+#[cfg(feature = "exploration")]
+#[test]
+fn test_fault_factory_with_in_process_exploration() {
+    let run = || {
+        let events: EventLog = Arc::default();
+        let report = scripted_builder(&events)
+            .set_iterations(1)
+            .set_debug_seeds(vec![99])
+            .enable_exploration(moonpool_sim::ExplorationConfig {
+                workers: 0,
+                max_runs_per_seed: 4,
+                branching_factor: 2,
+                max_frontier: 16,
+                max_recipe_len: 4,
+            })
+            .run();
+        assert_eq!(report.failed_runs, 0, "exploration run must pass");
+        let exploration = report.exploration.expect("exploration report missing");
+        let log = events
+            .lock()
+            .expect("RwLock poisoned: prior task panicked")
+            .clone();
+        (exploration.total_timelines, log)
+    };
+
+    let (timelines_a, log_a) = run();
+    let (timelines_b, log_b) = run();
+    assert_eq!(timelines_a, timelines_b);
+    assert_eq!(
+        log_a, log_b,
+        "explored timelines must replay identical fault scripts"
+    );
+    assert!(
+        log_a.len() >= 4,
+        "the root timeline must complete the script"
+    );
+}


### PR DESCRIPTION
Implements the two open issues in one PR.

## #165 — Extract buggify into a standalone crate

- New zero-dependency `moonpool-buggify` crate (pure std, wasm-able, modeled on `moonpool-assertions`) owning the disabled-by-default thread-local state and the `buggify!` / `buggify_with_prob!` macros.
- The crate takes an installable random source (a plain `fn() -> f64` pointer, keeping it dependency-free); `moonpool-sim` installs its seeded `sim_random_f64` in `buggify_init` and uninstalls it in `buggify_reset`, so buggify stays inert outside an active simulation.
- `moonpool-sim` re-exports the macros, so existing `moonpool_sim::buggify!` call sites are unchanged and both import paths share the same state during simulation (covered by a test).
- Simulation-specific knob randomization (`buggify_knob!`, `SampleUniform`-based) stays in `moonpool-sim`.

## #182 — Exploration-compatible scripted process lifecycle faults

Smallest surface, with lifecycle authority kept on `FaultContext`:

- **Split primitives**: `FaultContext::crash(ip)` force-kills without scheduling a restart — `Event::ProcessForceKill` now carries `recovery_delay_ms: Option<u64>`, and `None` holds the process down (no application work) until an explicit `FaultContext::restart(ip)`. Existing `reboot*` (timer-based restart) and graceful semantics are unchanged. Nothing is added to `SimContext`.
- **Milestone channel**: `FaultContext::state()` exposes the same per-iteration `StateHandle` workloads and processes see, so an injector can hold a node down until e.g. an operation counter passes a milestone.
- **`SimulationBuilder::fault_factory`**: registers a factory building a fresh injector for every root and explored timeline, mirroring `workload_factory`. Exploration accepts factories (both `workers: 0` and forked workers — the fork inherits the factory and every timeline constructs fresh state) while still rejecting mutable `.fault(...)` instances with a message pointing at `fault_factory`.
- **Fresh-state fix**: returned injectors are truncated to the leading user instances. Previously the built-in attrition injector was appended back into the user list after each iteration, accumulating one extra attrition injector per iteration/exploration job.

### Acceptance criteria coverage (`tests/scripted_faults.rs`)

- A workload increments a shared operation counter; a factory-created injector crashes a selected process, waits for the counter milestone, and explicitly restarts it.
- `assert_always!` proves no process work occurs during the hold-down interval (per-IP tick counter frozen) and that the process resumes before the chaos cutoff.
- Two fresh-builder runs of the same seed reproduce identical crash/restart events (labels + simulated timestamps).
- In-process exploration (`workers: 0`) with a `fault_factory` runs clean and is fully deterministic across two identical runs; parallel workers are supported via fork inheritance.
- Existing attrition/graceful reboot behavior: full suite stays green.

## Validation

- `cargo fmt`, `cargo clippy --workspace --all-targets` (pedantic, no allows) — clean
- `cargo nextest run` — 605 passed
- `cargo clippy -p moonpool-sim --no-default-features --all-targets -- -D warnings` — clean
- `cargo nextest run -p moonpool-sim --no-default-features` — 416 passed
- `cargo check --target wasm32-unknown-unknown -p moonpool-sim --no-default-features` and `-p moonpool-buggify` — clean
- Book updated: `08-buggify.md` (standalone crate section), `09-attrition.md` (scripted lifecycle faults + fault factories), configuration appendix, AGENTS.md crate map

Closes #165
Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FA3WMnyMJjhkBwZaNyKaVt

---
_Generated by [Claude Code](https://claude.ai/code/session_01FA3WMnyMJjhkBwZaNyKaVt)_