### PR TITLE
feat(sim): report application metrics from a custom registry

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -67,9 +67,11 @@ jobs:
           # rustflags must be able to build every published crate.
           RUSTFLAGS="" nix develop --command cargo check \
             -p moonpool-assertions \
+            -p moonpool-buggify \
             -p moonpool-core \
             -p moonpool-explorer \
             -p moonpool-hyper \
+            -p moonpool-prometheus \
             -p moonpool-sim \
             -p moonpool
       - name: Lean production dependency tree excludes sim/explorer
@@ -82,6 +84,10 @@ jobs:
           fi
           if echo "$tree" | grep -qE "moonpool-hyper|hyper v|h2 v"; then
             echo "::error::lean production build pulled in hyper"
+            exit 1
+          fi
+          if echo "$tree" | grep -qE "moonpool-prometheus|prometheus v"; then
+            echo "::error::lean production build pulled in prometheus"
             exit 1
           fi
 
@@ -112,6 +118,7 @@ jobs:
           - dungeon-explore
           - frontier-explore
           - axum-web
+          - metrics-service
           - topology
           - tonic-grpc
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/moonpool-core",
     "crates/moonpool-explorer",
     "crates/moonpool-hyper",
+    "crates/moonpool-prometheus",
     "crates/moonpool-sim",
     "crates/moonpool-sim-examples",
     "crates/moonpool-wasm-demo",

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -55,6 +55,7 @@
   - [Numeric Assertions](./part3-building/15-numeric-assertions.md)
   - [Compound Assertions](./part3-building/16-compound-assertions.md)
 - [Events and Invariants](./part3-building/17-events-and-invariants.md)
+- [Application Metrics](./part3-building/25-metrics.md)
 - [Designing Workloads That Find Bugs](./part3-building/19-designing-workloads.md)
 - [Debugging a Failing Seed](./part3-building/20-debugging.md)
   - [Reproducing with FixedCount](./part3-building/21-reproducing.md)

--- a/book/src/appendix/02-crate-map.md
+++ b/book/src/appendix/02-crate-map.md
@@ -14,7 +14,7 @@ usually need.
                            (facade crate)
                          /       |       \
                         v        v        v
-             moonpool-core  moonpool-sim  moonpool-hyper
+             moonpool-core  moonpool-sim  moonpool-hyper  moonpool-prometheus
                     ^          /     \          |
                     |         v       v         |
                     |  moonpool-   moonpool-     |
@@ -98,6 +98,24 @@ moonpool-explorer. Disable it for `wasm32-unknown-unknown`.
 
 Client and server features are individually selectable. The featureless crate
 contains only the runtime adapters.
+
+### moonpool-prometheus
+
+**Role**: Report the metrics your application already keeps as simulation
+output.
+
+**Key types**:
+
+- `PrometheusSource` wraps a `prometheus::Registry` and implements
+  `MetricsSource`
+- `SimCounter`, `SimGauge`, `SimHistogram` are instrumented handles that record
+  every mutation on the simulated clock
+- `SimTimer` times a histogram observation from `TimeProvider`, not the wall
+  clock
+
+It depends only on moonpool-core, never on moonpool-sim, so the adapter is
+equally usable in production and moonpool-sim stays wasm-clean. See
+[Application Metrics](../part3-building/25-metrics.md).
 
 ### moonpool-explorer
 

--- a/book/src/part3-building/25-metrics.md
+++ b/book/src/part3-building/25-metrics.md
@@ -1,0 +1,153 @@
+# Application Metrics
+
+Your service is probably already instrumented. There is a `prometheus::Registry`
+somewhere, a `requests_total` counter, a latency histogram, a gauge for the
+queue depth. That instrumentation exists because it is how you understand the
+system in production.
+
+Moonpool can report on it. Register a metrics source per simulated node and the
+counters, gauges and histograms your code already keeps show up in the
+simulation report — aggregated across seeds, attributed per node, with an exact
+time series of every mutation.
+
+```rust,ignore
+use std::sync::Arc;
+use moonpool_prometheus::PrometheusSource;
+
+let report = SimulationBuilder::new()
+    .metrics_factory(|_ip| Arc::new(PrometheusSource::default()))
+    .processes(3, || Box::new(MyNode::new()))
+    .workload(MyWorkload::default())
+    .set_iterations(10)
+    .run();
+
+report.eprint();
+```
+
+```text
+━━━ Metrics (15 series) ━━━━━━━━━━━━━━━━━━━━━━━━━━
+  kv_keys_stored{instance="10.0.1.1"}                  15.81 avg        1 min       16 max
+  kv_request_latency_seconds{instance="10.0.1.1"}     130.83 total  6,667 obs     0.02 avg
+  kv_requests_in_flight{instance="10.0.1.1"}            2.22 avg         0 min        3 max
+  kv_requests_rejected_total{instance="10.0.1.1"}      8,620 total     862 per seed
+  kv_requests_served_total{instance="10.0.1.1"}        6,667 total  666.70 per seed
+```
+
+## Reading your metrics from process code
+
+The source is reachable from any process or workload through its context:
+
+```rust,ignore
+let metrics = ctx.metrics::<PrometheusSource>()
+    .ok_or_else(|| SimulationError::InvalidState("no metrics factory".into()))?;
+
+let served = metrics.counter("requests_served_total", "Requests served")?;
+let in_flight = metrics.gauge("requests_in_flight", "Requests running")?;
+let latency = metrics.histogram_with_buckets(
+    "request_latency_seconds",
+    "Time to serve one request",
+    vec![0.001, 0.005, 0.010, 0.050, 0.100],
+)?;
+
+served.inc();
+```
+
+These are get-or-register, which matters because a source outlives process
+reboots (see below). A rebooted process looks its metrics up instead of failing
+with `AlreadyReg`.
+
+To wrap a registry your application already built, use
+`PrometheusSource::new(my_registry)`.
+
+## Why per node, and why per iteration
+
+Every simulated node shares one OS process. A single shared registry would
+merge three nodes' counters into one number, so the factory is keyed by IP and
+each node gets its own registry. Each sample is stamped with an `instance`
+label naming the node — Prometheus' own label for a scrape target.
+
+The factory also runs afresh every iteration. Most registries have no reset, so
+a reused instance would make seed 50 report the sum of fifty runs. This is the
+same reasoning behind [`fault_factory`](./07-chaos.md) versus `fault`.
+
+A **reboot** is the exception: a source is keyed by IP, so a crashed and
+restarted process keeps its counters, exactly as a real node's `/metrics` does
+across a restart on the same host.
+
+## Time series, not samples
+
+Metrics created through the source hand back instrumented handles. Every
+`inc()`, `set()` and `observe()` records a point, stamped with the **simulated**
+clock. There is no scrape interval and no sampling: the series is exact, and it
+replays bit-for-bit for a given seed.
+
+```rust,ignore
+let metrics = report.individual_metrics[0].as_ref().expect("seed passed");
+
+for (series, points) in &metrics.app_series {
+    for point in points {
+        println!("{series} {} at {}ms", point.value, point.time_ms);
+    }
+}
+```
+
+That is what makes a latency spike line up with the partition that caused it.
+The aggregated view on `report.app_metrics` uses this series for `min`, `max`
+and `mean`, which is why a gauge reports the range it actually moved over
+rather than whatever value it happened to rest at when the run ended.
+
+Series are capped (10,000 points each by default; see
+`PrometheusSource::set_series_capacity`) so a hot loop cannot grow a test's
+memory without bound. `SimulationMetrics::dropped_metric_points` is non-zero
+when a series was truncated.
+
+## Timing on the simulated clock
+
+Use `start_timer` from this crate, not `prometheus`' own:
+
+```rust,ignore
+let timer = latency.start_timer(ctx.time());
+let response = client.request(req).await?;   // observed even on an early return
+timer.stop_and_record();
+```
+
+`prometheus::Histogram::start_timer()` reads the wall clock. Inside a
+simulation that records how fast your laptop happened to be, not the latency
+the simulation modeled, and it gives a different answer on every replay of the
+same seed. `SimHistogram::start_timer` reads the provider clock instead.
+
+Pick bucket bounds that bracket what your simulation produces.
+Prometheus' defaults are tuned for real HTTP latency; simulated latencies often
+live on a different scale, and a distribution that lands entirely in the last
+bucket tells you nothing.
+
+## What metrics are not
+
+Metric values are **reported, never used to steer the simulation**. Not
+everything in a registry is deterministic — a metric fed from the wall clock,
+or from a library's own internal timing, is not — so the runner treats a scrape
+as an observation. If you want a property enforced, assert on it: metrics tell
+you the shape of a run, [assertions](./12-assertions.md) tell you whether it was
+correct.
+
+Under [fork-based exploration](../part5-building-on-top/01-exploration.md), only
+root timelines are scraped. Explored timelines report back through the shared
+assertion table, which carries no metric values.
+
+## Beyond Prometheus
+
+`PrometheusSource` is one implementation of `MetricsSource`, a registry-agnostic
+trait in `moonpool-core`:
+
+```rust,ignore
+pub trait MetricsSource: Send + Sync + 'static {
+    fn collect(&self) -> Vec<MetricSample>;
+    fn set_clock(&self, clock: Arc<dyn MetricClock>) {}
+    fn series(&self) -> BTreeMap<String, Vec<MetricPoint>> { BTreeMap::new() }
+}
+```
+
+`collect` alone is enough for a scrape-only adapter over any registry. The other
+two are what an adapter implements to deliver an exact time series. An
+OpenTelemetry adapter slots in the same way, with no change to the simulation
+runner.

--- a/crates/moonpool-core/src/lib.rs
+++ b/crates/moonpool-core/src/lib.rs
@@ -51,6 +51,7 @@ pub mod block;
 #[cfg(all(feature = "tokio-fs", unix))]
 mod block_tokio;
 mod error;
+pub mod metrics;
 mod network;
 mod providers;
 mod random;
@@ -85,6 +86,9 @@ pub use block_tokio::{TokioBlockDevice, TokioBlockDeviceProvider};
 
 // Error exports
 pub use error::{SimulationError, SimulationResult};
+
+// Application metrics seam (registry-agnostic; adapters live in their own crates).
+pub use metrics::{HistogramValue, MetricSample, MetricValue, MetricsSource};
 
 // Provider trait exports
 pub use network::{NetworkProvider, TcpListenerTrait};

--- a/crates/moonpool-core/src/metrics.rs
+++ b/crates/moonpool-core/src/metrics.rs
@@ -1,0 +1,539 @@
+//! Registry-agnostic application metrics.
+//!
+//! Production code is usually already instrumented with a metrics library —
+//! a `prometheus::Registry`, an OpenTelemetry `MeterProvider`, and so on.
+//! [`MetricsSource`] is the seam that lets the simulation *scrape* that
+//! instrumentation without knowing which library produced it: an adapter
+//! flattens whatever the library holds into [`MetricSample`]s, and
+//! `moonpool-sim` folds those into its per-seed report.
+//!
+//! The vocabulary here is deliberately the smallest common denominator of
+//! Prometheus and OpenTelemetry: a name, a set of labels, and a value that is
+//! a counter, a gauge, or a histogram. Anything richer (exemplars, native
+//! histograms, summaries with quantiles) degrades into that shape rather than
+//! leaking a specific backend into the simulation runner.
+//!
+//! # Determinism
+//!
+//! Metric *values* are reported, never used to steer the simulation, because
+//! not all of them are deterministic. In particular, timers that read the wall
+//! clock (`prometheus::Histogram::start_timer`, `Instant::now()`) record host
+//! noise and vary run to run. Record durations from the simulated clock
+//! (`ctx.time()`) if you want a metric that is stable across replays of a seed.
+//!
+//! Adapters must emit samples in a deterministic order — sort by
+//! [`MetricSample::sort_key`] if the backing registry does not already
+//! guarantee one — so that two replays of the same seed produce byte-identical
+//! reports.
+
+/// The value carried by a single metric sample.
+///
+/// Counters and gauges are both `f64` (a Prometheus counter is a float even
+/// when it is only ever incremented by one); the distinction is kept because
+/// the two aggregate differently across simulation seeds — counters sum,
+/// gauges average.
+#[derive(Debug, Clone, PartialEq)]
+pub enum MetricValue {
+    /// A monotonically increasing total, e.g. `requests_total`.
+    Counter(f64),
+    /// A value that goes up and down, e.g. `queue_depth`.
+    Gauge(f64),
+    /// A bucketed distribution.
+    Histogram(HistogramValue),
+}
+
+impl MetricValue {
+    /// The scalar this sample contributes to a summary line: the counter or
+    /// gauge value, or a histogram's sum.
+    #[must_use]
+    pub fn scalar(&self) -> f64 {
+        match self {
+            Self::Counter(v) | Self::Gauge(v) => *v,
+            Self::Histogram(h) => h.sum,
+        }
+    }
+
+    /// Short name of this value's kind, for display.
+    #[must_use]
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::Counter(_) => "counter",
+            Self::Gauge(_) => "gauge",
+            Self::Histogram(_) => "histogram",
+        }
+    }
+}
+
+/// A bucketed distribution, in Prometheus' cumulative-bucket form.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct HistogramValue {
+    /// Total number of observations.
+    pub count: u64,
+    /// Sum of all observed values.
+    pub sum: f64,
+    /// `(upper_bound, cumulative_count)` pairs, ascending by bound.
+    ///
+    /// Cumulative, as Prometheus reports them: the count for a bucket includes
+    /// every observation in the buckets below it. The implicit `+Inf` bucket
+    /// (whose count equals [`count`](Self::count)) is not repeated here.
+    pub buckets: Vec<(f64, u64)>,
+}
+
+impl HistogramValue {
+    /// Mean of the observations, or `0.0` when nothing was observed.
+    #[must_use]
+    pub fn mean(&self) -> f64 {
+        if self.count == 0 {
+            0.0
+        } else {
+            // Precision loss acceptable: observation counts fit within 2^52.
+            self.sum / u32::try_from(self.count).map_or(f64::INFINITY, f64::from)
+        }
+    }
+
+    /// Merge another histogram over the same buckets into this one.
+    ///
+    /// Bucket bounds are expected to match; a bound present in `other` but not
+    /// in `self` is appended, and the result is re-sorted by bound so the
+    /// merged histogram stays ascending.
+    pub fn merge(&mut self, other: &Self) {
+        self.count += other.count;
+        self.sum += other.sum;
+        for (bound, count) in &other.buckets {
+            if let Some(slot) = self
+                .buckets
+                .iter_mut()
+                .find(|(b, _)| b.to_bits() == bound.to_bits())
+            {
+                slot.1 += count;
+            } else {
+                self.buckets.push((*bound, *count));
+            }
+        }
+        self.buckets
+            .sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+    }
+}
+
+/// One metric, at one label combination, at one point in time.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MetricSample {
+    /// Metric name, e.g. `http_requests_total`.
+    pub name: String,
+    /// Label pairs, sorted by key so that two samples of the same series
+    /// always compare and format identically.
+    pub labels: Vec<(String, String)>,
+    /// The observed value.
+    pub value: MetricValue,
+}
+
+impl MetricSample {
+    /// Build a sample, sorting `labels` into canonical order.
+    #[must_use]
+    pub fn new(
+        name: impl Into<String>,
+        mut labels: Vec<(String, String)>,
+        value: MetricValue,
+    ) -> Self {
+        labels.sort();
+        Self {
+            name: name.into(),
+            labels,
+            value,
+        }
+    }
+
+    /// Add a label unless one with that key is already present.
+    ///
+    /// Used by the simulation runner to stamp each sample with the node it was
+    /// scraped from, without clobbering a label the application already set.
+    pub fn label_if_absent(&mut self, key: &str, value: &str) {
+        if self.labels.iter().any(|(k, _)| k == key) {
+            return;
+        }
+        self.labels.push((key.to_owned(), value.to_owned()));
+        self.labels.sort();
+    }
+
+    /// Fully-qualified series identity: `name{key="value",...}`.
+    ///
+    /// Two samples with the same key are the same series and aggregate
+    /// together across simulation seeds.
+    #[must_use]
+    pub fn sort_key(&self) -> String {
+        if self.labels.is_empty() {
+            return self.name.clone();
+        }
+        let mut key = String::with_capacity(self.name.len() + self.labels.len() * 16);
+        key.push_str(&self.name);
+        key.push('{');
+        for (i, (k, v)) in self.labels.iter().enumerate() {
+            if i > 0 {
+                key.push(',');
+            }
+            key.push_str(k);
+            key.push_str("=\"");
+            key.push_str(v);
+            key.push('"');
+        }
+        key.push('}');
+        key
+    }
+}
+
+/// One recorded value of a series, at one point in simulated time.
+///
+/// Points are pushed by instrumented metric handles as the application
+/// mutates them — not sampled on a timer — so the series is exact: every
+/// `inc()` and every `observe()` appears, at the simulated instant it
+/// happened.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct MetricPoint {
+    /// Simulated time of the mutation, in milliseconds.
+    pub time_ms: u64,
+    /// The series' value after the mutation. For a histogram, the value that
+    /// was observed rather than a running total.
+    pub value: f64,
+}
+
+/// Supplies the timestamp stamped onto each [`MetricPoint`].
+///
+/// The simulation installs one backed by its logical clock, which is what
+/// makes a recorded series deterministic: two replays of a seed produce
+/// identical timestamps. Outside a simulation no clock is installed and
+/// recording is inert.
+pub trait MetricClock: Send + Sync + 'static {
+    /// Current simulated time, in milliseconds.
+    fn now_ms(&self) -> u64;
+}
+
+/// Default cap on points held per series before recording stops.
+///
+/// A hot loop can mutate a counter millions of times; keeping every point
+/// would let a test's memory grow without bound. Once a series hits the cap it
+/// stops growing and the overflow is counted, so a truncated series is visible
+/// rather than silently misleading.
+pub const DEFAULT_SERIES_CAPACITY: usize = 10_000;
+
+/// Shared sink that instrumented metric handles push their mutations into.
+///
+/// Cheap to clone; every handle a source hands out shares one recorder, so a
+/// single [`series`](Self::series) call returns the whole node's history.
+/// Recording is inert until a [`MetricClock`] is installed — outside a
+/// simulation the handles behave like their plain counterparts.
+#[derive(Clone, Default)]
+pub struct SeriesRecorder {
+    inner: std::sync::Arc<SeriesRecorderInner>,
+}
+
+#[derive(Default)]
+struct SeriesRecorderInner {
+    clock: std::sync::RwLock<Option<std::sync::Arc<dyn MetricClock>>>,
+    series: std::sync::Mutex<SeriesState>,
+}
+
+#[derive(Default)]
+struct SeriesState {
+    points: std::collections::BTreeMap<String, Vec<MetricPoint>>,
+    capacity: Option<usize>,
+    dropped: u64,
+}
+
+impl SeriesRecorder {
+    /// Create an inert recorder — no clock, so nothing is recorded yet.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Install the clock that timestamps recorded points, arming recording.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the recorder's lock is poisoned by a prior task panic.
+    pub fn set_clock(&self, clock: std::sync::Arc<dyn MetricClock>) {
+        *self
+            .inner
+            .clock
+            .write()
+            .expect("RwLock poisoned: prior task panicked") = Some(clock);
+    }
+
+    /// Set the per-series point cap. `None` restores
+    /// [`DEFAULT_SERIES_CAPACITY`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if the recorder's lock is poisoned by a prior task panic.
+    pub fn set_capacity(&self, capacity: Option<usize>) {
+        self.state().capacity = capacity;
+    }
+
+    /// Whether a clock is installed. `false` means every `record` is a no-op,
+    /// which is the case in production.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the recorder's lock is poisoned by a prior task panic.
+    #[must_use]
+    pub fn is_armed(&self) -> bool {
+        self.inner
+            .clock
+            .read()
+            .expect("RwLock poisoned: prior task panicked")
+            .is_some()
+    }
+
+    /// Record `value` for the series named `key`, at the clock's current time.
+    ///
+    /// A no-op when no clock is installed, so instrumented handles cost one
+    /// atomic read outside a simulation.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the recorder's lock is poisoned by a prior task panic.
+    pub fn record(&self, key: &str, value: f64) {
+        let Some(time_ms) = self
+            .inner
+            .clock
+            .read()
+            .expect("RwLock poisoned: prior task panicked")
+            .as_ref()
+            .map(|c| c.now_ms())
+        else {
+            return;
+        };
+
+        let mut state = self.state();
+        let capacity = state.capacity.unwrap_or(DEFAULT_SERIES_CAPACITY);
+        let entry = state.points.entry(key.to_owned()).or_default();
+        if entry.len() >= capacity {
+            state.dropped += 1;
+            return;
+        }
+        entry.push(MetricPoint { time_ms, value });
+    }
+
+    /// Every recorded series, keyed by series identity, each ascending in time.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the recorder's lock is poisoned by a prior task panic.
+    #[must_use]
+    pub fn series(&self) -> std::collections::BTreeMap<String, Vec<MetricPoint>> {
+        self.state().points.clone()
+    }
+
+    /// Points dropped because their series was at capacity.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the recorder's lock is poisoned by a prior task panic.
+    #[must_use]
+    pub fn dropped(&self) -> u64 {
+        self.state().dropped
+    }
+
+    fn state(&self) -> std::sync::MutexGuard<'_, SeriesState> {
+        self.inner
+            .series
+            .lock()
+            .expect("Mutex poisoned: prior task panicked")
+    }
+}
+
+impl std::fmt::Debug for SeriesRecorder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let state = self.state();
+        f.debug_struct("SeriesRecorder")
+            .field("series", &state.points.len())
+            .field("dropped", &state.dropped)
+            .finish()
+    }
+}
+
+/// A metrics backend the simulation can scrape.
+///
+/// Implemented by adapters over concrete registries — `moonpool-prometheus`
+/// wraps a `prometheus::Registry` — and registered on the simulation builder
+/// with `SimulationBuilder::metrics_factory`. The runner scrapes every source
+/// once per iteration, after the check phase, and folds the samples into the
+/// simulation report.
+///
+/// `Send + Sync` is a type-system constraint only: moonpool runs
+/// single-threaded, but contexts must be `Send` to cross the executor.
+pub trait MetricsSource: Send + Sync + 'static {
+    /// Flatten the backing registry's current state into samples.
+    ///
+    /// Called once per simulation iteration. Implementations must produce a
+    /// deterministic order (see the module docs) and must not mutate the
+    /// registry — a scrape is an observation, and the same iteration may be
+    /// replayed.
+    fn collect(&self) -> Vec<MetricSample>;
+
+    /// Arm event-driven recording against the simulated clock.
+    ///
+    /// Called once per node at the start of each iteration. A source that
+    /// hands out instrumented handles installs the clock on its
+    /// [`SeriesRecorder`]; one that only wraps a foreign registry leaves the
+    /// default no-op and is captured by the end-of-iteration scrape instead.
+    fn set_clock(&self, _clock: std::sync::Arc<dyn MetricClock>) {}
+
+    /// The series recorded since the clock was installed, keyed by series
+    /// identity (see [`MetricSample::sort_key`]).
+    ///
+    /// Default: no series, meaning this source is scrape-only.
+    fn series(&self) -> std::collections::BTreeMap<String, Vec<MetricPoint>> {
+        std::collections::BTreeMap::new()
+    }
+
+    /// Points this source dropped because a series hit its capacity.
+    fn dropped_points(&self) -> u64 {
+        0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_sorts_labels() {
+        let s = MetricSample::new(
+            "requests_total",
+            vec![
+                ("method".to_owned(), "GET".to_owned()),
+                ("code".to_owned(), "200".to_owned()),
+            ],
+            MetricValue::Counter(3.0),
+        );
+        assert_eq!(s.labels[0].0, "code");
+        assert_eq!(s.sort_key(), r#"requests_total{code="200",method="GET"}"#);
+    }
+
+    #[test]
+    fn sort_key_without_labels_is_the_name() {
+        let s = MetricSample::new("uptime", Vec::new(), MetricValue::Gauge(1.0));
+        assert_eq!(s.sort_key(), "uptime");
+    }
+
+    #[test]
+    fn label_if_absent_does_not_clobber() {
+        let mut s = MetricSample::new(
+            "requests_total",
+            vec![("instance".to_owned(), "mine".to_owned())],
+            MetricValue::Counter(1.0),
+        );
+        s.label_if_absent("instance", "10.0.1.1");
+        assert_eq!(s.labels, vec![("instance".to_owned(), "mine".to_owned())]);
+
+        s.label_if_absent("zone", "eu");
+        assert_eq!(s.labels.len(), 2);
+        assert_eq!(s.labels[0].0, "instance", "labels stay sorted");
+    }
+
+    #[test]
+    fn histogram_merge_adds_counts_and_unions_bounds() {
+        let mut a = HistogramValue {
+            count: 2,
+            sum: 3.0,
+            buckets: vec![(1.0, 1), (5.0, 2)],
+        };
+        a.merge(&HistogramValue {
+            count: 1,
+            sum: 4.0,
+            buckets: vec![(5.0, 1), (0.5, 0)],
+        });
+        assert_eq!(a.count, 3);
+        assert!((a.sum - 7.0).abs() < f64::EPSILON);
+        assert_eq!(a.buckets, vec![(0.5, 0), (1.0, 1), (5.0, 3)]);
+    }
+
+    #[test]
+    fn histogram_mean_handles_empty() {
+        assert!((HistogramValue::default().mean() - 0.0).abs() < f64::EPSILON);
+        let h = HistogramValue {
+            count: 4,
+            sum: 10.0,
+            buckets: Vec::new(),
+        };
+        assert!((h.mean() - 2.5).abs() < f64::EPSILON);
+    }
+
+    struct FixedClock(std::sync::atomic::AtomicU64);
+
+    impl MetricClock for FixedClock {
+        fn now_ms(&self) -> u64 {
+            self.0.load(std::sync::atomic::Ordering::Relaxed)
+        }
+    }
+
+    #[test]
+    fn recorder_is_inert_without_a_clock() {
+        let recorder = SeriesRecorder::new();
+        assert!(!recorder.is_armed());
+        recorder.record("hits", 1.0);
+        assert!(recorder.series().is_empty(), "no clock, nothing recorded");
+    }
+
+    #[test]
+    fn recorder_stamps_points_with_the_clock() {
+        let clock = std::sync::Arc::new(FixedClock(std::sync::atomic::AtomicU64::new(10)));
+        let recorder = SeriesRecorder::new();
+        recorder.set_clock(clock.clone());
+        assert!(recorder.is_armed());
+
+        recorder.record("hits", 1.0);
+        clock.0.store(25, std::sync::atomic::Ordering::Relaxed);
+        recorder.record("hits", 2.0);
+        recorder.record("other", 7.0);
+
+        let series = recorder.series();
+        assert_eq!(series["hits"].len(), 2);
+        assert_eq!(
+            series["hits"][0],
+            MetricPoint {
+                time_ms: 10,
+                value: 1.0
+            }
+        );
+        assert_eq!(
+            series["hits"][1],
+            MetricPoint {
+                time_ms: 25,
+                value: 2.0
+            }
+        );
+        assert_eq!(series["other"].len(), 1);
+        assert_eq!(recorder.dropped(), 0);
+    }
+
+    #[test]
+    fn recorder_caps_a_series_and_counts_the_overflow() {
+        let recorder = SeriesRecorder::new();
+        recorder.set_clock(std::sync::Arc::new(FixedClock(
+            std::sync::atomic::AtomicU64::new(0),
+        )));
+        recorder.set_capacity(Some(2));
+
+        for i in 0..5 {
+            recorder.record("hits", f64::from(i));
+        }
+
+        assert_eq!(recorder.series()["hits"].len(), 2, "capped");
+        assert_eq!(recorder.dropped(), 3, "overflow is visible, not silent");
+    }
+
+    #[test]
+    fn scalar_reads_each_variant() {
+        assert!((MetricValue::Counter(2.0).scalar() - 2.0).abs() < f64::EPSILON);
+        assert!((MetricValue::Gauge(-1.0).scalar() + 1.0).abs() < f64::EPSILON);
+        let h = MetricValue::Histogram(HistogramValue {
+            count: 1,
+            sum: 9.0,
+            buckets: Vec::new(),
+        });
+        assert!((h.scalar() - 9.0).abs() < f64::EPSILON);
+        assert_eq!(h.kind(), "histogram");
+    }
+}

--- a/crates/moonpool-prometheus/Cargo.toml
+++ b/crates/moonpool-prometheus/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "moonpool-prometheus"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Prometheus registry adapter for moonpool simulation metrics"
+documentation = "https://docs.rs/moonpool-prometheus"
+readme = "README.md"
+
+[dependencies]
+# Only the metrics vocabulary (MetricsSource / MetricSample) and TimeProvider.
+# No dependency on moonpool-sim: this adapter is equally usable in production,
+# and keeping it out preserves moonpool-sim's wasm-clean build.
+moonpool-core = { path = "../moonpool-core", version = "0.8.0", default-features = false }
+# default-features = false drops the protobuf text/encoding stack; `gather()`
+# still returns the same `proto::MetricFamily` values, which is all we read.
+prometheus = { version = "0.14", default-features = false }
+
+[dev-dependencies]
+moonpool-sim = { path = "../moonpool-sim", version = "0.8.0" }
+async-trait = "0.1"
+
+[lints]
+workspace = true

--- a/crates/moonpool-prometheus/README.md
+++ b/crates/moonpool-prometheus/README.md
@@ -1,0 +1,17 @@
+# moonpool-prometheus
+
+Scrape a `prometheus::Registry` into a moonpool simulation report.
+
+Register a source per simulated node and the counters, gauges and histograms
+your application already keeps show up as workload metrics, aggregated across
+seeds:
+
+```rust,ignore
+SimulationBuilder::new()
+    .metrics_factory(|_ip| Arc::new(PrometheusSource::default()))
+    .processes(3, || Box::new(MyNode::new()))
+    .workload(MyWorkload::default())
+    .run();
+```
+
+See the [moonpool book](https://pierrez.github.io/moonpool/) for the full guide.

--- a/crates/moonpool-prometheus/src/handles.rs
+++ b/crates/moonpool-prometheus/src/handles.rs
@@ -1,0 +1,482 @@
+//! Instrumented metric handles that record every mutation.
+//!
+//! Each handle wraps the plain `prometheus` metric and, on every mutation,
+//! pushes a point into the [`SeriesRecorder`] it shares with its
+//! [`PrometheusSource`](crate::PrometheusSource). That is what makes a
+//! simulation's metrics a *time series* rather than a final total: no polling
+//! interval, no sampling, just the exact value at the exact simulated instant
+//! it changed.
+//!
+//! Outside a simulation no clock is installed, so recording short-circuits on
+//! one lock-free read and the handles behave like the metrics they wrap.
+
+use std::time::Duration;
+
+use moonpool_core::TimeProvider;
+use moonpool_core::metrics::SeriesRecorder;
+use prometheus::{Gauge, GaugeVec, Histogram, HistogramVec, IntCounter, IntCounterVec};
+
+/// Widen a counter to `f64` for the recorded series.
+///
+/// Split into 32-bit halves rather than cast: `f64` holds every integer below
+/// `2^53` exactly, and going through two `f64::from(u32)` conversions gets
+/// there without a lossy primitive cast. Above `2^53` the result rounds, which
+/// no simulation counter reaches.
+pub(crate) fn counter_as_f64(value: u64) -> f64 {
+    let high = f64::from(u32::try_from(value >> 32).unwrap_or(u32::MAX));
+    let low = f64::from(u32::try_from(value & 0xFFFF_FFFF).unwrap_or(u32::MAX));
+    high * 4_294_967_296.0 + low
+}
+
+/// A monotonically increasing counter that records each increment.
+#[derive(Clone)]
+pub struct SimCounter {
+    inner: IntCounter,
+    key: String,
+    recorder: SeriesRecorder,
+}
+
+impl SimCounter {
+    pub(crate) fn new(inner: IntCounter, key: String, recorder: SeriesRecorder) -> Self {
+        Self {
+            inner,
+            key,
+            recorder,
+        }
+    }
+
+    /// Increment by one.
+    pub fn inc(&self) {
+        self.inner.inc();
+        self.record();
+    }
+
+    /// Increment by `value`.
+    pub fn inc_by(&self, value: u64) {
+        self.inner.inc_by(value);
+        self.record();
+    }
+
+    /// Current value.
+    #[must_use]
+    pub fn get(&self) -> u64 {
+        self.inner.get()
+    }
+
+    /// The wrapped `prometheus` counter, for code that needs the real type.
+    ///
+    /// Mutating through it bypasses series recording; the value still shows up
+    /// in the end-of-iteration scrape.
+    #[must_use]
+    pub fn inner(&self) -> &IntCounter {
+        &self.inner
+    }
+
+    fn record(&self) {
+        self.recorder
+            .record(&self.key, counter_as_f64(self.inner.get()));
+    }
+}
+
+impl std::fmt::Debug for SimCounter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SimCounter")
+            .field("key", &self.key)
+            .field("value", &self.inner.get())
+            .finish_non_exhaustive()
+    }
+}
+
+/// A gauge that records each new value.
+#[derive(Clone)]
+pub struct SimGauge {
+    inner: Gauge,
+    key: String,
+    recorder: SeriesRecorder,
+}
+
+impl SimGauge {
+    pub(crate) fn new(inner: Gauge, key: String, recorder: SeriesRecorder) -> Self {
+        Self {
+            inner,
+            key,
+            recorder,
+        }
+    }
+
+    /// Set the gauge to `value`.
+    pub fn set(&self, value: f64) {
+        self.inner.set(value);
+        self.record();
+    }
+
+    /// Increment by one.
+    pub fn inc(&self) {
+        self.inner.inc();
+        self.record();
+    }
+
+    /// Decrement by one.
+    pub fn dec(&self) {
+        self.inner.dec();
+        self.record();
+    }
+
+    /// Add `value` (negative subtracts).
+    pub fn add(&self, value: f64) {
+        self.inner.add(value);
+        self.record();
+    }
+
+    /// Subtract `value`.
+    pub fn sub(&self, value: f64) {
+        self.inner.sub(value);
+        self.record();
+    }
+
+    /// Current value.
+    #[must_use]
+    pub fn get(&self) -> f64 {
+        self.inner.get()
+    }
+
+    /// The wrapped `prometheus` gauge. See [`SimCounter::inner`].
+    #[must_use]
+    pub fn inner(&self) -> &Gauge {
+        &self.inner
+    }
+
+    fn record(&self) {
+        self.recorder.record(&self.key, self.inner.get());
+    }
+}
+
+impl std::fmt::Debug for SimGauge {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SimGauge")
+            .field("key", &self.key)
+            .field("value", &self.inner.get())
+            .finish_non_exhaustive()
+    }
+}
+
+/// A histogram that records each observation.
+///
+/// The scrape reports the bucket distribution; the recorded series reports the
+/// individual observations in simulated-time order, which is what a latency
+/// plot needs. Custom buckets come from
+/// [`PrometheusSource::histogram_with_buckets`](crate::PrometheusSource::histogram_with_buckets).
+#[derive(Clone)]
+pub struct SimHistogram {
+    inner: Histogram,
+    key: String,
+    recorder: SeriesRecorder,
+}
+
+impl SimHistogram {
+    pub(crate) fn new(inner: Histogram, key: String, recorder: SeriesRecorder) -> Self {
+        Self {
+            inner,
+            key,
+            recorder,
+        }
+    }
+
+    /// Observe `value`.
+    pub fn observe(&self, value: f64) {
+        self.inner.observe(value);
+        // The observation itself, not a running total: a histogram's series is
+        // the distribution over time, and summing it would hide the shape.
+        self.recorder.record(&self.key, value);
+    }
+
+    /// Observe a duration, in seconds — Prometheus' convention for latency.
+    pub fn observe_duration(&self, duration: Duration) {
+        self.observe(duration.as_secs_f64());
+    }
+
+    /// Start a timer driven by the **simulated** clock.
+    ///
+    /// `prometheus`' own `start_timer()` reads the wall clock, which in a
+    /// simulation records host noise instead of simulated latency and differs
+    /// between replays of the same seed. This one reads `ctx.time()`, so the
+    /// observation is exactly the latency the simulation modeled and replays
+    /// identically.
+    ///
+    /// The timer observes on drop, so an early `?` return still records:
+    ///
+    /// ```ignore
+    /// let _timer = latency.start_timer(ctx.time());
+    /// let response = client.request(req).await?;
+    /// ```
+    #[must_use]
+    pub fn start_timer<T: TimeProvider>(&self, time: &T) -> SimTimer<T> {
+        SimTimer {
+            histogram: self.clone(),
+            start: time.now(),
+            time: time.clone(),
+            recorded: false,
+        }
+    }
+
+    /// Number of observations so far.
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.inner.get_sample_count()
+    }
+
+    /// Sum of all observations.
+    #[must_use]
+    pub fn sum(&self) -> f64 {
+        self.inner.get_sample_sum()
+    }
+
+    /// The wrapped `prometheus` histogram. See [`SimCounter::inner`].
+    #[must_use]
+    pub fn inner(&self) -> &Histogram {
+        &self.inner
+    }
+}
+
+impl std::fmt::Debug for SimHistogram {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SimHistogram")
+            .field("key", &self.key)
+            .field("count", &self.count())
+            .field("sum", &self.sum())
+            .finish_non_exhaustive()
+    }
+}
+
+/// A running timer that observes simulated elapsed time into a histogram.
+///
+/// Created by [`SimHistogram::start_timer`]. Observes on drop unless stopped
+/// explicitly, mirroring `prometheus::HistogramTimer`.
+pub struct SimTimer<T: TimeProvider> {
+    histogram: SimHistogram,
+    time: T,
+    start: Duration,
+    recorded: bool,
+}
+
+impl<T: TimeProvider> SimTimer<T> {
+    /// Observe the elapsed simulated time and return it, in seconds.
+    pub fn stop_and_record(mut self) -> f64 {
+        self.record()
+    }
+
+    /// Drop the timer without observing.
+    pub fn stop_and_discard(mut self) {
+        self.recorded = true;
+    }
+
+    /// Simulated time elapsed so far.
+    #[must_use]
+    pub fn elapsed(&self) -> Duration {
+        self.time.now().saturating_sub(self.start)
+    }
+
+    fn record(&mut self) -> f64 {
+        self.recorded = true;
+        let elapsed = self.elapsed().as_secs_f64();
+        self.histogram.observe(elapsed);
+        elapsed
+    }
+}
+
+impl<T: TimeProvider> Drop for SimTimer<T> {
+    fn drop(&mut self) {
+        if !self.recorded {
+            self.record();
+        }
+    }
+}
+
+impl<T: TimeProvider> std::fmt::Debug for SimTimer<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SimTimer")
+            .field("histogram", &self.histogram)
+            .field("start", &self.start)
+            .field("elapsed", &self.elapsed())
+            .field("recorded", &self.recorded)
+            .finish_non_exhaustive()
+    }
+}
+
+/// A labelled counter family. Resolve a label combination with
+/// [`with_label_values`](Self::with_label_values).
+#[derive(Clone)]
+pub struct SimCounterVec {
+    inner: IntCounterVec,
+    name: String,
+    labels: Vec<String>,
+    recorder: SeriesRecorder,
+}
+
+impl SimCounterVec {
+    pub(crate) fn new(
+        inner: IntCounterVec,
+        name: String,
+        labels: Vec<String>,
+        recorder: SeriesRecorder,
+    ) -> Self {
+        Self {
+            inner,
+            name,
+            labels,
+            recorder,
+        }
+    }
+
+    /// Get the counter for one label combination.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `values` does not match the family's label count.
+    pub fn with_label_values(&self, values: &[&str]) -> prometheus::Result<SimCounter> {
+        let child = self.inner.get_metric_with_label_values(values)?;
+        Ok(SimCounter::new(
+            child,
+            series_key(&self.name, &self.labels, values),
+            self.recorder.clone(),
+        ))
+    }
+
+    /// The wrapped `prometheus` family.
+    #[must_use]
+    pub fn inner(&self) -> &IntCounterVec {
+        &self.inner
+    }
+}
+
+/// A labelled gauge family.
+#[derive(Clone)]
+pub struct SimGaugeVec {
+    inner: GaugeVec,
+    name: String,
+    labels: Vec<String>,
+    recorder: SeriesRecorder,
+}
+
+impl SimGaugeVec {
+    pub(crate) fn new(
+        inner: GaugeVec,
+        name: String,
+        labels: Vec<String>,
+        recorder: SeriesRecorder,
+    ) -> Self {
+        Self {
+            inner,
+            name,
+            labels,
+            recorder,
+        }
+    }
+
+    /// Get the gauge for one label combination.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `values` does not match the family's label count.
+    pub fn with_label_values(&self, values: &[&str]) -> prometheus::Result<SimGauge> {
+        let child = self.inner.get_metric_with_label_values(values)?;
+        Ok(SimGauge::new(
+            child,
+            series_key(&self.name, &self.labels, values),
+            self.recorder.clone(),
+        ))
+    }
+
+    /// The wrapped `prometheus` family.
+    #[must_use]
+    pub fn inner(&self) -> &GaugeVec {
+        &self.inner
+    }
+}
+
+/// A labelled histogram family.
+#[derive(Clone)]
+pub struct SimHistogramVec {
+    inner: HistogramVec,
+    name: String,
+    labels: Vec<String>,
+    recorder: SeriesRecorder,
+}
+
+impl SimHistogramVec {
+    pub(crate) fn new(
+        inner: HistogramVec,
+        name: String,
+        labels: Vec<String>,
+        recorder: SeriesRecorder,
+    ) -> Self {
+        Self {
+            inner,
+            name,
+            labels,
+            recorder,
+        }
+    }
+
+    /// Get the histogram for one label combination.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `values` does not match the family's label count.
+    pub fn with_label_values(&self, values: &[&str]) -> prometheus::Result<SimHistogram> {
+        let child = self.inner.get_metric_with_label_values(values)?;
+        Ok(SimHistogram::new(
+            child,
+            series_key(&self.name, &self.labels, values),
+            self.recorder.clone(),
+        ))
+    }
+
+    /// The wrapped `prometheus` family.
+    #[must_use]
+    pub fn inner(&self) -> &HistogramVec {
+        &self.inner
+    }
+}
+
+/// Build the series identity for a labelled child: `name{key="value",...}`.
+///
+/// Label pairs are sorted so the key matches the one a scraped
+/// `MetricSample` produces for the same series, letting the recorded series
+/// and the final scrape line up.
+fn series_key(name: &str, label_names: &[String], values: &[&str]) -> String {
+    let mut pairs: Vec<String> = label_names
+        .iter()
+        .zip(values.iter())
+        .map(|(k, v)| format!("{k}=\"{v}\""))
+        .collect();
+    if pairs.is_empty() {
+        return name.to_owned();
+    }
+    pairs.sort();
+    format!("{name}{{{}}}", pairs.join(","))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn counter_as_f64_is_exact_across_the_32_bit_boundary() {
+        assert!((counter_as_f64(0) - 0.0).abs() < f64::EPSILON);
+        assert!((counter_as_f64(1) - 1.0).abs() < f64::EPSILON);
+        assert!((counter_as_f64(4_294_967_295) - 4_294_967_295.0).abs() < f64::EPSILON);
+        assert!((counter_as_f64(4_294_967_296) - 4_294_967_296.0).abs() < f64::EPSILON);
+        assert!((counter_as_f64(1_000_000_000_000) - 1_000_000_000_000.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn series_key_sorts_labels() {
+        let names = vec!["method".to_owned(), "code".to_owned()];
+        assert_eq!(
+            series_key("requests_total", &names, &["GET", "200"]),
+            r#"requests_total{code="200",method="GET"}"#
+        );
+        assert_eq!(series_key("uptime", &[], &[]), "uptime");
+    }
+}

--- a/crates/moonpool-prometheus/src/lib.rs
+++ b/crates/moonpool-prometheus/src/lib.rs
@@ -1,0 +1,430 @@
+//! # moonpool-prometheus
+//!
+//! Turn the `prometheus` metrics your code already keeps into moonpool
+//! simulation output.
+//!
+//! Register a [`PrometheusSource`] per simulated node and every counter, gauge
+//! and histogram it holds is reported at the end of the run — aggregated
+//! across seeds, per node, with no changes to how your application records
+//! them.
+//!
+//! ```ignore
+//! use moonpool_prometheus::PrometheusSource;
+//!
+//! SimulationBuilder::new()
+//!     .metrics_factory(|_ip| Arc::new(PrometheusSource::default()))
+//!     .processes(3, || Box::new(MyNode::new()))
+//!     .workload(MyWorkload::default())
+//!     .run();
+//! ```
+//!
+//! ## Two ways metrics reach the report
+//!
+//! **Instrumented handles push.** Metrics you create through this source —
+//! [`counter`](PrometheusSource::counter), [`gauge`](PrometheusSource::gauge),
+//! [`histogram`](PrometheusSource::histogram) — hand back wrappers that record
+//! every mutation into a time series, stamped with the *simulated* clock. No
+//! polling interval, no sampling: one point per `inc()`, `set()` and
+//! `observe()`, at the simulated instant it happened. The series lands in
+//! `SimulationMetrics::app_series`, ready to plot or assert on.
+//!
+//! **A final scrape catches the rest.** Anything else in the registry —
+//! metrics a library registered itself, `lazy_static!` globals, a collector
+//! from another crate — has no mutation hook to subscribe to, so it is read
+//! once at the end of the iteration into `SimulationMetrics::app_metrics`. You
+//! get totals for those, just not their history.
+//!
+//! ## Determinism
+//!
+//! Use [`SimHistogram::start_timer`] rather than `prometheus`' own
+//! `start_timer()`: the latter reads the wall clock, so it records host noise
+//! instead of simulated latency and gives a different answer on every replay
+//! of the same seed. This one reads the provider clock and replays exactly.
+//!
+//! Metric values are reported, never used to steer the simulation.
+//!
+//! ## Reboots
+//!
+//! A source is keyed by node IP, so it outlives process reboots — exactly as a
+//! real node's `/metrics` does across a restart on the same host. The
+//! `counter` / `gauge` / `histogram` methods are therefore get-or-register: a
+//! process that boots a second time looks its metrics up instead of failing
+//! with `AlreadyReg`.
+
+#![deny(missing_docs)]
+#![deny(clippy::unwrap_used)]
+
+mod handles;
+
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
+
+use moonpool_core::metrics::{
+    HistogramValue, MetricClock, MetricPoint, MetricSample, MetricValue, MetricsSource,
+    SeriesRecorder,
+};
+use prometheus::{
+    Gauge, GaugeVec, Histogram, HistogramOpts, HistogramVec, IntCounter, IntCounterVec, Opts,
+    Registry,
+};
+
+pub use handles::{
+    SimCounter, SimCounterVec, SimGauge, SimGaugeVec, SimHistogram, SimHistogramVec, SimTimer,
+};
+
+/// A metric already registered, kept so a rebooted process can look it up.
+#[derive(Clone)]
+enum Cached {
+    Counter(IntCounter),
+    Gauge(Gauge),
+    Histogram(Histogram),
+    CounterVec(IntCounterVec, Vec<String>),
+    GaugeVec(GaugeVec, Vec<String>),
+    HistogramVec(HistogramVec, Vec<String>),
+}
+
+/// A `prometheus::Registry` the simulation can report on.
+///
+/// One per simulated node — see
+/// `SimulationBuilder::metrics_factory`. Cheap to share behind an `Arc`, which
+/// is how the simulation hands it to your code via `ctx.metrics()`.
+pub struct PrometheusSource {
+    registry: Registry,
+    recorder: SeriesRecorder,
+    cache: Mutex<BTreeMap<String, Cached>>,
+}
+
+impl Default for PrometheusSource {
+    fn default() -> Self {
+        Self::new(Registry::new())
+    }
+}
+
+impl PrometheusSource {
+    /// Wrap an existing registry.
+    ///
+    /// Use this when your application already builds its own `Registry` and
+    /// passes it around. To scrape the crate-global default registry, pass
+    /// `prometheus::default_registry().clone()` — but note it is process-wide,
+    /// so its counters accumulate across seeds and nodes rather than starting
+    /// fresh per iteration.
+    #[must_use]
+    pub fn new(registry: Registry) -> Self {
+        Self {
+            registry,
+            recorder: SeriesRecorder::new(),
+            cache: Mutex::new(BTreeMap::new()),
+        }
+    }
+
+    /// The wrapped registry, for handing to code that expects the real type
+    /// (an HTTP `/metrics` handler, a library that registers its own
+    /// collectors).
+    #[must_use]
+    pub fn registry(&self) -> &Registry {
+        &self.registry
+    }
+
+    /// The shared series recorder backing this source's instrumented handles.
+    #[must_use]
+    pub fn recorder(&self) -> &SeriesRecorder {
+        &self.recorder
+    }
+
+    /// Cap the points held per recorded series. `None` restores the default.
+    pub fn set_series_capacity(&self, capacity: Option<usize>) {
+        self.recorder.set_capacity(capacity);
+    }
+
+    /// Get or register a counter.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `name` is not a valid metric name, or if it is
+    /// already registered as a different metric kind.
+    pub fn counter(&self, name: &str, help: &str) -> prometheus::Result<SimCounter> {
+        let metric = self.get_or_register(name, || {
+            let counter = IntCounter::with_opts(Opts::new(name, help))?;
+            self.registry.register(Box::new(counter.clone()))?;
+            Ok(Cached::Counter(counter))
+        })?;
+        match metric {
+            Cached::Counter(counter) => Ok(SimCounter::new(
+                counter,
+                name.to_owned(),
+                self.recorder.clone(),
+            )),
+            _ => Err(kind_clash(name, "counter")),
+        }
+    }
+
+    /// Get or register a gauge.
+    ///
+    /// # Errors
+    ///
+    /// As [`counter`](Self::counter).
+    pub fn gauge(&self, name: &str, help: &str) -> prometheus::Result<SimGauge> {
+        let metric = self.get_or_register(name, || {
+            let gauge = Gauge::with_opts(Opts::new(name, help))?;
+            self.registry.register(Box::new(gauge.clone()))?;
+            Ok(Cached::Gauge(gauge))
+        })?;
+        match metric {
+            Cached::Gauge(gauge) => {
+                Ok(SimGauge::new(gauge, name.to_owned(), self.recorder.clone()))
+            }
+            _ => Err(kind_clash(name, "gauge")),
+        }
+    }
+
+    /// Get or register a histogram with Prometheus' default buckets.
+    ///
+    /// # Errors
+    ///
+    /// As [`counter`](Self::counter).
+    pub fn histogram(&self, name: &str, help: &str) -> prometheus::Result<SimHistogram> {
+        self.histogram_with_opts(HistogramOpts::new(name, help))
+    }
+
+    /// Get or register a histogram with explicit bucket bounds.
+    ///
+    /// Default buckets are tuned for HTTP latency in seconds. Simulated
+    /// latencies often live on a different scale, so pick bounds that bracket
+    /// what the simulation actually produces — a distribution that lands
+    /// entirely in the last bucket tells you nothing.
+    ///
+    /// # Errors
+    ///
+    /// As [`counter`](Self::counter), plus an error if `buckets` is not
+    /// strictly ascending.
+    pub fn histogram_with_buckets(
+        &self,
+        name: &str,
+        help: &str,
+        buckets: Vec<f64>,
+    ) -> prometheus::Result<SimHistogram> {
+        self.histogram_with_opts(HistogramOpts::new(name, help).buckets(buckets))
+    }
+
+    /// Get or register a histogram from full `prometheus` options.
+    ///
+    /// # Errors
+    ///
+    /// As [`histogram_with_buckets`](Self::histogram_with_buckets).
+    pub fn histogram_with_opts(&self, opts: HistogramOpts) -> prometheus::Result<SimHistogram> {
+        let name = opts.common_opts.name.clone();
+        let metric = self.get_or_register(&name, || {
+            let histogram = Histogram::with_opts(opts)?;
+            self.registry.register(Box::new(histogram.clone()))?;
+            Ok(Cached::Histogram(histogram))
+        })?;
+        match metric {
+            Cached::Histogram(histogram) => Ok(SimHistogram::new(
+                histogram,
+                name.clone(),
+                self.recorder.clone(),
+            )),
+            _ => Err(kind_clash(&name, "histogram")),
+        }
+    }
+
+    /// Get or register a labelled counter family.
+    ///
+    /// # Errors
+    ///
+    /// As [`counter`](Self::counter).
+    pub fn counter_vec(
+        &self,
+        name: &str,
+        help: &str,
+        labels: &[&str],
+    ) -> prometheus::Result<SimCounterVec> {
+        let owned: Vec<String> = labels.iter().map(|l| (*l).to_owned()).collect();
+        let metric = self.get_or_register(name, || {
+            let family = IntCounterVec::new(Opts::new(name, help), labels)?;
+            self.registry.register(Box::new(family.clone()))?;
+            Ok(Cached::CounterVec(family, owned))
+        })?;
+        match metric {
+            Cached::CounterVec(family, labels) => Ok(SimCounterVec::new(
+                family,
+                name.to_owned(),
+                labels,
+                self.recorder.clone(),
+            )),
+            _ => Err(kind_clash(name, "counter vec")),
+        }
+    }
+
+    /// Get or register a labelled gauge family.
+    ///
+    /// # Errors
+    ///
+    /// As [`counter`](Self::counter).
+    pub fn gauge_vec(
+        &self,
+        name: &str,
+        help: &str,
+        labels: &[&str],
+    ) -> prometheus::Result<SimGaugeVec> {
+        let owned: Vec<String> = labels.iter().map(|l| (*l).to_owned()).collect();
+        let metric = self.get_or_register(name, || {
+            let family = GaugeVec::new(Opts::new(name, help), labels)?;
+            self.registry.register(Box::new(family.clone()))?;
+            Ok(Cached::GaugeVec(family, owned))
+        })?;
+        match metric {
+            Cached::GaugeVec(family, labels) => Ok(SimGaugeVec::new(
+                family,
+                name.to_owned(),
+                labels,
+                self.recorder.clone(),
+            )),
+            _ => Err(kind_clash(name, "gauge vec")),
+        }
+    }
+
+    /// Get or register a labelled histogram family.
+    ///
+    /// # Errors
+    ///
+    /// As [`histogram_with_buckets`](Self::histogram_with_buckets).
+    pub fn histogram_vec(
+        &self,
+        opts: HistogramOpts,
+        labels: &[&str],
+    ) -> prometheus::Result<SimHistogramVec> {
+        let name = opts.common_opts.name.clone();
+        let owned: Vec<String> = labels.iter().map(|l| (*l).to_owned()).collect();
+        let metric = self.get_or_register(&name, || {
+            let family = HistogramVec::new(opts, labels)?;
+            self.registry.register(Box::new(family.clone()))?;
+            Ok(Cached::HistogramVec(family, owned))
+        })?;
+        match metric {
+            Cached::HistogramVec(family, labels) => Ok(SimHistogramVec::new(
+                family,
+                name.clone(),
+                labels,
+                self.recorder.clone(),
+            )),
+            _ => Err(kind_clash(&name, "histogram vec")),
+        }
+    }
+
+    /// Look a metric up by name, registering it on first use.
+    ///
+    /// The cache is what makes reboots work: a process that boots again finds
+    /// its metrics already registered rather than hitting `AlreadyReg`.
+    fn get_or_register(
+        &self,
+        name: &str,
+        create: impl FnOnce() -> prometheus::Result<Cached>,
+    ) -> prometheus::Result<Cached> {
+        let mut cache = self
+            .cache
+            .lock()
+            .expect("Mutex poisoned: prior task panicked");
+        if let Some(existing) = cache.get(name) {
+            return Ok(existing.clone());
+        }
+        let created = create()?;
+        cache.insert(name.to_owned(), created.clone());
+        Ok(created)
+    }
+}
+
+impl std::fmt::Debug for PrometheusSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PrometheusSource")
+            .field(
+                "metrics",
+                &self.cache.lock().map(|c| c.len()).unwrap_or_default(),
+            )
+            .field("recorder", &self.recorder)
+            .finish_non_exhaustive()
+    }
+}
+
+impl MetricsSource for PrometheusSource {
+    fn collect(&self) -> Vec<MetricSample> {
+        let mut samples = Vec::new();
+        // `gather()` returns families sorted by name, and we sort the final
+        // set again downstream, so a scrape is order-stable across replays.
+        for family in self.registry.gather() {
+            let name = family.name().to_owned();
+            for metric in family.get_metric() {
+                let labels: Vec<(String, String)> = metric
+                    .get_label()
+                    .iter()
+                    .map(|pair| (pair.name().to_owned(), pair.value().to_owned()))
+                    .collect();
+                let Some(value) = read_value(family.get_field_type(), metric) else {
+                    continue;
+                };
+                samples.push(MetricSample::new(name.clone(), labels, value));
+            }
+        }
+        samples
+    }
+
+    fn set_clock(&self, clock: Arc<dyn MetricClock>) {
+        self.recorder.set_clock(clock);
+    }
+
+    fn series(&self) -> BTreeMap<String, Vec<MetricPoint>> {
+        self.recorder.series()
+    }
+
+    fn dropped_points(&self) -> u64 {
+        self.recorder.dropped()
+    }
+}
+
+/// Map one `prometheus` metric onto the registry-agnostic value model.
+///
+/// A summary degrades to a histogram carrying only count and sum: its
+/// quantiles are computed client-side and have no bucket representation.
+fn read_value(
+    kind: prometheus::proto::MetricType,
+    metric: &prometheus::proto::Metric,
+) -> Option<MetricValue> {
+    match kind {
+        prometheus::proto::MetricType::COUNTER => {
+            Some(MetricValue::Counter(metric.get_counter().get_value()))
+        }
+        prometheus::proto::MetricType::GAUGE => {
+            Some(MetricValue::Gauge(metric.get_gauge().get_value()))
+        }
+        // `Untyped` is deprecated in the prometheus crate with no replacement
+        // and no public API that produces one, so there is nothing to read.
+        prometheus::proto::MetricType::UNTYPED => None,
+        prometheus::proto::MetricType::HISTOGRAM => {
+            let histogram = metric.get_histogram();
+            Some(MetricValue::Histogram(HistogramValue {
+                count: histogram.get_sample_count(),
+                sum: histogram.get_sample_sum(),
+                buckets: histogram
+                    .get_bucket()
+                    .iter()
+                    .map(|b| (b.upper_bound(), b.cumulative_count()))
+                    .collect(),
+            }))
+        }
+        prometheus::proto::MetricType::SUMMARY => {
+            let summary = metric.get_summary();
+            Some(MetricValue::Histogram(HistogramValue {
+                count: summary.sample_count(),
+                sum: summary.sample_sum(),
+                buckets: Vec::new(),
+            }))
+        }
+    }
+}
+
+/// Error for a name already registered under a different metric kind.
+fn kind_clash(name: &str, wanted: &str) -> prometheus::Error {
+    prometheus::Error::Msg(format!(
+        "metric {name:?} is already registered as a different kind (wanted a {wanted})"
+    ))
+}

--- a/crates/moonpool-prometheus/tests/simulation.rs
+++ b/crates/moonpool-prometheus/tests/simulation.rs
@@ -1,0 +1,169 @@
+//! End-to-end: a workload's own prometheus metrics land in the simulation report.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use moonpool_prometheus::PrometheusSource;
+use moonpool_sim::{SimContext, SimulationBuilder, SimulationResult, TimeProvider, Workload};
+
+/// Drives a fixed number of "requests", recording each one the way production
+/// code would: a counter, a gauge, and a latency histogram.
+struct MeteredWorkload {
+    requests: u64,
+}
+
+#[async_trait]
+impl Workload for MeteredWorkload {
+    fn name(&self) -> &'static str {
+        "metered"
+    }
+
+    async fn run(&mut self, ctx: &SimContext) -> SimulationResult<()> {
+        let metrics = ctx
+            .metrics::<PrometheusSource>()
+            .expect("metrics factory registered");
+        let processed = metrics
+            .counter("requests_total", "Requests processed")
+            .expect("counter registers");
+        let in_flight = metrics
+            .gauge("requests_in_flight", "Requests currently running")
+            .expect("gauge registers");
+        let latency = metrics
+            .histogram_with_buckets(
+                "request_latency_seconds",
+                "Request latency",
+                vec![0.005, 0.01, 0.05, 0.1],
+            )
+            .expect("histogram registers");
+
+        for _ in 0..self.requests {
+            in_flight.inc();
+            // Timed on the simulated clock, so the observation is the latency
+            // the simulation modeled and replays identically.
+            let timer = latency.start_timer(ctx.time());
+            ctx.time().sleep(Duration::from_millis(10)).await.ok();
+            timer.stop_and_record();
+            in_flight.dec();
+            processed.inc();
+        }
+        Ok(())
+    }
+}
+
+fn run_metered(requests: u64, seed: u64) -> moonpool_sim::SimulationReport {
+    SimulationBuilder::new()
+        .set_debug_seeds(vec![seed])
+        .set_iterations(1)
+        .metrics_factory(|_ip| Arc::new(PrometheusSource::default()))
+        .workload(MeteredWorkload { requests })
+        .run()
+}
+
+#[test]
+fn counters_gauges_and_histograms_reach_the_report() {
+    let report = run_metered(5, 42);
+    assert_eq!(report.failed_runs, 0, "workload should succeed");
+
+    let by_name = |name: &str| {
+        report
+            .app_metrics
+            .iter()
+            .find(|m| m.name == name)
+            .unwrap_or_else(|| panic!("{name} missing from report: {:?}", report.app_metrics))
+    };
+
+    let requests = by_name("requests_total");
+    assert_eq!(requests.kind, "counter");
+    assert!(
+        (requests.total - 5.0).abs() < f64::EPSILON,
+        "one per request"
+    );
+    assert!(
+        requests.key.contains("instance="),
+        "series is attributed to its node: {}",
+        requests.key
+    );
+
+    let in_flight = by_name("requests_in_flight");
+    assert_eq!(in_flight.kind, "gauge");
+    // Range comes from the recorded series, not the end-of-run scrape: the
+    // workload runs one request at a time, so the gauge swings 0..1. A
+    // scrape-only aggregate would report 0/0 and hide that entirely.
+    assert!(
+        (in_flight.min - 0.0).abs() < f64::EPSILON,
+        "gauge returns to zero between requests, got {}",
+        in_flight.min
+    );
+    assert!(
+        (in_flight.max - 1.0).abs() < f64::EPSILON,
+        "gauge peaks at one in-flight request, got {}",
+        in_flight.max
+    );
+    assert_eq!(in_flight.observations, 10, "one point per inc() and dec()");
+
+    let latency = by_name("request_latency_seconds");
+    assert_eq!(latency.kind, "histogram");
+    let histogram = latency.histogram.as_ref().expect("histogram buckets");
+    assert_eq!(histogram.count, 5, "one observation per request");
+    assert!(
+        (histogram.mean() - 0.010).abs() < 1e-9,
+        "each request slept 10ms of simulated time, got {}",
+        histogram.mean()
+    );
+}
+
+#[test]
+fn recorded_series_tracks_every_mutation_in_simulated_time() {
+    let report = run_metered(3, 7);
+    let metrics = report.individual_metrics[0]
+        .as_ref()
+        .expect("iteration succeeded");
+
+    let counter = metrics
+        .app_series
+        .iter()
+        .find(|(key, _)| key.starts_with("requests_total"))
+        .map(|(_, points)| points)
+        .expect("counter series recorded");
+
+    assert_eq!(counter.len(), 3, "one point per inc(), not a sampled total");
+    assert_eq!(
+        counter.iter().map(|p| p.value).collect::<Vec<_>>(),
+        vec![1.0, 2.0, 3.0],
+        "series carries the running value"
+    );
+    // 10ms of simulated sleep between each increment.
+    assert_eq!(counter[0].time_ms, 10);
+    assert_eq!(counter[1].time_ms, 20);
+    assert_eq!(counter[2].time_ms, 30);
+    assert_eq!(metrics.dropped_metric_points, 0, "nothing truncated");
+}
+
+#[test]
+fn series_is_identical_across_replays_of_a_seed() {
+    let first = run_metered(4, 1234);
+    let second = run_metered(4, 1234);
+
+    let series = |r: &moonpool_sim::SimulationReport| {
+        r.individual_metrics[0]
+            .as_ref()
+            .expect("iteration succeeded")
+            .app_series
+            .clone()
+    };
+
+    let (a, b) = (series(&first), series(&second));
+    assert!(!a.is_empty(), "something was recorded");
+    assert_eq!(
+        a.keys().collect::<Vec<_>>(),
+        b.keys().collect::<Vec<_>>(),
+        "same series"
+    );
+    for (key, points) in &a {
+        assert_eq!(
+            points, &b[key],
+            "series {key} must replay bit-for-bit from the same seed"
+        );
+    }
+}

--- a/crates/moonpool-sim-examples/Cargo.toml
+++ b/crates/moonpool-sim-examples/Cargo.toml
@@ -12,6 +12,7 @@ documentation = "https://docs.rs/moonpool-sim-examples"
 [dependencies]
 moonpool-sim = { path = "../moonpool-sim", version = "0.8.0" }
 moonpool-hyper = { path = "../moonpool-hyper", version = "0.8.0" }
+moonpool-prometheus = { path = "../moonpool-prometheus", version = "0.8.0" }
 
 async-trait = "0.1"
 futures = "0.3"
@@ -33,6 +34,7 @@ thiserror = "2.0"
 tokio = { version = "1", features = ["full"] }
 # Runtime-free tonic core: gRPC framing + codegen support without
 # tonic::transport (which hard-codes tokio::spawn / TokioExecutor / TokioTimer).
+prometheus = { version = "0.14", default-features = false }
 prost = "0.14"
 tonic = { version = "0.14", default-features = false, features = ["codegen"] }
 tonic-prost = "0.14"
@@ -54,6 +56,10 @@ path = "src/bin/sim/dungeon_explore.rs"
 [[bin]]
 name = "sim-axum-web"
 path = "src/bin/sim/axum_web.rs"
+
+[[bin]]
+name = "sim-metrics-service"
+path = "src/bin/sim/metrics_service.rs"
 
 [[bin]]
 name = "sim-topology"

--- a/crates/moonpool-sim-examples/src/bin/sim/metrics_service.rs
+++ b/crates/moonpool-sim-examples/src/bin/sim/metrics_service.rs
@@ -1,0 +1,38 @@
+//! Binary target for the metered key/value simulation.
+//!
+//! Three nodes, each with its own `prometheus::Registry`, running under
+//! network chaos. The report's Metrics section shows what they recorded.
+
+use std::process;
+use std::sync::Arc;
+use std::time::Duration;
+
+use moonpool_prometheus::PrometheusSource;
+use moonpool_sim::{Chaos, ChaosMode, SimulationBuilder};
+use moonpool_sim_examples::metrics_service::{MeteredKvNode, MeteredKvWorkload};
+
+fn main() {
+    moonpool_sim::init_sim_tracing(tracing::Level::WARN);
+
+    let report = SimulationBuilder::new()
+        // One registry per node: every simulated node shares this OS process,
+        // so a single shared registry would merge their counters into one.
+        .metrics_factory(|_ip| Arc::new(PrometheusSource::default()))
+        .processes(3, || Box::new(MeteredKvNode::new()))
+        .workload(MeteredKvWorkload)
+        .enable_chaos([Chaos::Network(ChaosMode::Swarm)])
+        .chaos_duration(Duration::from_secs(3))
+        .set_iterations(10)
+        .run();
+
+    report.eprint();
+
+    if !report.seeds_failing.is_empty() {
+        eprintln!(
+            "ERROR: {} seeds failed: {:?}",
+            report.seeds_failing.len(),
+            report.seeds_failing
+        );
+        process::exit(1);
+    }
+}

--- a/crates/moonpool-sim-examples/src/lib.rs
+++ b/crates/moonpool-sim-examples/src/lib.rs
@@ -13,5 +13,6 @@ pub mod axum_web;
 pub mod dungeon;
 pub mod fdb;
 pub mod maze;
+pub mod metrics_service;
 pub mod tonic_grpc;
 pub mod topology;

--- a/crates/moonpool-sim-examples/src/metrics_service.rs
+++ b/crates/moonpool-sim-examples/src/metrics_service.rs
@@ -1,0 +1,233 @@
+//! A metered key/value service: the metrics story end to end.
+//!
+//! The process is instrumented the way a production service is — a request
+//! counter split by outcome, a gauge for in-flight work, a latency histogram —
+//! using nothing but a `prometheus::Registry`. Registering that registry with
+//! the simulation is the only moonpool-specific step; everything else is the
+//! instrumentation you would ship.
+//!
+//! What the simulation adds is a report: totals aggregated across every seed,
+//! attributed per node, plus an exact time series of every mutation stamped on
+//! the simulated clock — so a latency spike lines up with the partition that
+//! caused it.
+
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use moonpool_prometheus::{PrometheusSource, SimCounter, SimGauge, SimHistogram};
+use moonpool_sim::{
+    Process, RandomProvider, SimContext, SimulationError, SimulationResult, TaskProvider,
+    TimeProvider, Workload, assert_always, assert_sometimes,
+};
+
+/// Latency buckets in seconds, bracketing what this service actually produces
+/// (single-digit to ~100ms of simulated work). Prometheus' defaults are tuned
+/// for real HTTP latency and would put every observation in one bucket here.
+const LATENCY_BUCKETS: &[f64] = &[0.001, 0.005, 0.010, 0.025, 0.050, 0.100, 0.250];
+
+/// The service's metrics, resolved once per boot from the node's registry.
+///
+/// Looked up rather than registered afresh: the source is keyed by node IP and
+/// outlives reboots, so a process booting a second time finds its metrics
+/// already there.
+struct ServiceMetrics {
+    served: SimCounter,
+    rejected: SimCounter,
+    in_flight: SimGauge,
+    keys: SimGauge,
+    latency: SimHistogram,
+}
+
+impl ServiceMetrics {
+    fn resolve(source: &PrometheusSource) -> SimulationResult<Self> {
+        let err = |e: prometheus::Error| SimulationError::InvalidState(format!("metrics: {e}"));
+        Ok(Self {
+            served: source
+                .counter("kv_requests_served_total", "Requests served")
+                .map_err(err)?,
+            rejected: source
+                .counter(
+                    "kv_requests_rejected_total",
+                    "Requests rejected when overloaded",
+                )
+                .map_err(err)?,
+            in_flight: source
+                .gauge("kv_requests_in_flight", "Requests currently being served")
+                .map_err(err)?,
+            keys: source
+                .gauge("kv_keys_stored", "Keys currently held")
+                .map_err(err)?,
+            latency: source
+                .histogram_with_buckets(
+                    "kv_request_latency_seconds",
+                    "Time to serve one request",
+                    LATENCY_BUCKETS.to_vec(),
+                )
+                .map_err(err)?,
+        })
+    }
+}
+
+/// Beyond this many concurrent requests the node sheds load, which is what
+/// makes `kv_requests_rejected_total` a metric worth watching.
+const MAX_IN_FLIGHT: f64 = 3.0;
+
+/// Concurrent request handlers per node. More than [`MAX_IN_FLIGHT`], so the
+/// load-shedding path is actually exercised rather than being dead code.
+const WORKERS_PER_NODE: usize = 5;
+
+/// Distinct keys the workers cycle through.
+const KEY_SPACE: u64 = 16;
+
+/// A key/value node that meters everything it does.
+///
+/// The store is shared across the node's concurrent request handlers, which is
+/// what lets in-flight requests overlap and the shed-load counter move.
+#[derive(Default, Clone)]
+pub struct MeteredKvNode {
+    store: Arc<Mutex<BTreeMap<String, String>>>,
+}
+
+impl MeteredKvNode {
+    /// Create an empty node.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Admission control: refuse the request when the node is already at its
+    /// concurrency limit.
+    ///
+    /// Checked *before* the request is counted in-flight, so `MAX_IN_FLIGHT`
+    /// means what it says.
+    fn admit(metrics: &ServiceMetrics) -> bool {
+        // Evaluated on every request, not just inside the shed branch: that is
+        // what lets the assertion report *how often* the node saturates.
+        let saturated = metrics.in_flight.get() >= MAX_IN_FLIGHT;
+        assert_sometimes!(saturated, "kv node sheds load when saturated");
+        if saturated {
+            metrics.rejected.inc();
+            return false;
+        }
+        metrics.in_flight.inc();
+        true
+    }
+
+    /// Serve one admitted write, metering it exactly as production would.
+    fn serve(&self, metrics: &ServiceMetrics, key: String, value: String) {
+        let mut store = self
+            .store
+            .lock()
+            .expect("Mutex poisoned: prior task panicked");
+        store.insert(key, value);
+        metrics.served.inc();
+        // A gauge that tracks real state: it must never disagree with the map.
+        let stored = u32::try_from(store.len()).unwrap_or(u32::MAX);
+        metrics.keys.set(f64::from(stored));
+    }
+}
+
+#[async_trait]
+impl Process for MeteredKvNode {
+    fn name(&self) -> &'static str {
+        "metered-kv"
+    }
+
+    async fn run(&mut self, ctx: &SimContext) -> SimulationResult<()> {
+        let source = ctx.metrics::<PrometheusSource>().ok_or_else(|| {
+            SimulationError::InvalidState("no metrics factory registered".to_owned())
+        })?;
+        let metrics = ServiceMetrics::resolve(&source)?;
+
+        let metrics = Arc::new(metrics);
+        let mut handles = Vec::with_capacity(WORKERS_PER_NODE);
+        for worker in 0..WORKERS_PER_NODE {
+            let node = self.clone();
+            let metrics = metrics.clone();
+            let time = ctx.time().clone();
+            let random = ctx.random().clone();
+            let shutdown = ctx.shutdown().clone();
+            handles.push(
+                ctx.task()
+                    .spawn_task(&format!("kv-worker-{worker}"), async move {
+                        let mut counter = u64::try_from(worker).unwrap_or(0);
+                        let stride = u64::try_from(WORKERS_PER_NODE).unwrap_or(1);
+                        while !shutdown.is_cancelled() {
+                            if !MeteredKvNode::admit(&metrics) {
+                                // Shed: back off before trying again, as a client
+                                // seeing a 503 would.
+                                time.sleep(Duration::from_millis(10)).await.ok();
+                                continue;
+                            }
+
+                            // Timed on the simulated clock: `prometheus`' own
+                            // start_timer() reads the wall clock, which would
+                            // record host noise here and differ on every replay of
+                            // the same seed.
+                            let timer = metrics.latency.start_timer(&time);
+
+                            let work_ms = random.random_range(1..40);
+                            time.sleep(Duration::from_millis(work_ms)).await.ok();
+                            node.serve(
+                                &metrics,
+                                format!("key-{}", counter % KEY_SPACE),
+                                format!("value-{counter}"),
+                            );
+
+                            timer.stop_and_record();
+                            metrics.in_flight.dec();
+                            counter += stride;
+
+                            time.sleep(Duration::from_millis(5)).await.ok();
+                        }
+                    }),
+            );
+        }
+
+        for handle in handles {
+            handle.await.ok();
+        }
+
+        assert_always!(
+            metrics.in_flight.get() >= 0.0,
+            "in-flight gauge never goes negative"
+        );
+        Ok(())
+    }
+}
+
+/// Drives the nodes for a while, then checks the metrics tell a coherent story.
+#[derive(Default)]
+pub struct MeteredKvWorkload;
+
+#[async_trait]
+impl Workload for MeteredKvWorkload {
+    fn name(&self) -> &'static str {
+        "metered-kv-driver"
+    }
+
+    async fn run(&mut self, ctx: &SimContext) -> SimulationResult<()> {
+        ctx.time().sleep(Duration::from_secs(5)).await.ok();
+        Ok(())
+    }
+
+    async fn check(&mut self, ctx: &SimContext) -> SimulationResult<()> {
+        // Metrics are readable from the workload too, which is how a test
+        // asserts on what the system under test recorded about itself.
+        let handle = ctx.metrics_handle();
+        let samples = handle.collect_all();
+        assert_always!(
+            !samples.is_empty(),
+            "the nodes recorded something over five simulated seconds"
+        );
+
+        let series = handle.collect_series();
+        assert_sometimes!(
+            series.keys().any(|k| k.starts_with("kv_request_latency")),
+            "latency observations are recorded as a time series"
+        );
+        Ok(())
+    }
+}

--- a/crates/moonpool-sim/src/lib.rs
+++ b/crates/moonpool-sim/src/lib.rs
@@ -142,10 +142,16 @@ pub use locality::{DomainLevel, LinkClass, LocalityInfo};
 // Runner module re-exports
 pub use runner::{
     Attrition, AttritionScope, Chaos, ChaosMode, ClientId, FaultContext, FaultInjector,
-    IterationControl, LocalityConfig, MachineRegistry, Process, ProcessTags, RebootKind,
-    SimContext, SimulationBuilder, SimulationMetrics, SimulationReport, TagRegistry, Workload,
-    WorkloadCount, WorkloadTopology,
+    INSTANCE_LABEL, IterationControl, LocalityConfig, MachineRegistry, MetricsHandle, Process,
+    ProcessTags, RebootKind, SimContext, SimulationBuilder, SimulationMetrics, SimulationReport,
+    TagRegistry, Workload, WorkloadCount, WorkloadTopology,
 };
+
+// Application-metrics vocabulary, re-exported from moonpool-core so a
+// simulation using `.metrics_factory()` needs one import path. Adapters over a
+// concrete registry (moonpool-prometheus, and OpenTelemetry later) implement
+// `MetricsSource` against these types.
+pub use moonpool_core::metrics::{HistogramValue, MetricSample, MetricValue, MetricsSource};
 
 // Buggify macros live in the standalone zero-dependency moonpool-buggify
 // crate; re-exported here so existing `moonpool_sim::buggify!` call sites keep
@@ -193,6 +199,6 @@ pub use moonpool_assertions::{AssertCmp, AssertKind};
 // Exploration-only re-exports (fork-based multiverse engine).
 #[cfg(feature = "exploration")]
 pub use moonpool_explorer::{ExplorationConfig, Recipe, format_timeline, parse_timeline};
-pub use runner::report::{BugRecipe, ExplorationReport};
+pub use runner::report::{BugRecipe, ExplorationReport, MetricAggregate};
 
 // Macros are automatically available at crate root when defined with #[macro_export]

--- a/crates/moonpool-sim/src/runner/app_metrics.rs
+++ b/crates/moonpool-sim/src/runner/app_metrics.rs
@@ -1,0 +1,334 @@
+//! Per-node application metrics registered on the simulation builder.
+//!
+//! A simulation runs every node in one OS process, so a single shared metrics
+//! registry would merge all nodes' counters into one number. Instead the
+//! builder takes a *factory* keyed by IP
+//! ([`SimulationBuilder::metrics_factory`](super::builder::SimulationBuilder::metrics_factory)):
+//! each process and workload gets its own [`MetricsSource`], reachable from
+//! its [`SimContext`](super::context::SimContext) via
+//! [`SimContext::metrics`](super::context::SimContext::metrics).
+//!
+//! The factory also gives per-seed freshness. Most registries (a
+//! `prometheus::Registry` among them) have no reset, so reusing one instance
+//! would make seed 50 report the sum of fifty runs. A fresh
+//! [`MetricsHandle`] is built for every iteration, which is the same reasoning
+//! behind [`fault_factory`](super::builder::SimulationBuilder::fault_factory)
+//! versus [`fault`](super::builder::SimulationBuilder::fault).
+//!
+//! Reboots are the other way round: a process that crashes and restarts gets a
+//! fresh [`Process`](super::process::Process) instance but the *same* source,
+//! because its IP is unchanged. Counters therefore survive reboots, which
+//! matches what a real node's `/metrics` endpoint shows after a process
+//! restart on the same host — and means adapters must tolerate a metric being
+//! looked up again after a reboot rather than re-registered.
+
+use std::any::Any;
+use std::collections::BTreeMap;
+use std::sync::{Arc, RwLock};
+
+use moonpool_core::metrics::{MetricClock, MetricPoint, MetricSample, MetricsSource};
+
+use crate::observability::{Clock, SimulationLayerHandle};
+
+/// Label stamped onto every scraped sample, naming the node it came from.
+///
+/// `instance` is Prometheus' own label for the scraped target, so a simulated
+/// node maps onto it directly. A sample that already carries an `instance`
+/// label keeps the application's value.
+pub const INSTANCE_LABEL: &str = "instance";
+
+/// One node's source, kept twice: once as the trait object the runner scrapes,
+/// once as `Any` so [`MetricsHandle::get`] can hand the concrete type back to
+/// application code.
+#[derive(Clone)]
+struct SourceEntry {
+    source: Arc<dyn MetricsSource>,
+    concrete: Arc<dyn Any + Send + Sync>,
+}
+
+/// Builds one [`MetricsSource`] per node IP.
+///
+/// Produced by [`SimulationBuilder::metrics_factory`](super::builder::SimulationBuilder::metrics_factory);
+/// not constructed directly.
+pub(crate) type SourceFactory = Box<dyn Fn(&str) -> SourceEntryPair>;
+
+/// A source in both of the forms the runner needs. Opaque; see [`SourceFactory`].
+pub(crate) type SourceEntryPair = (Arc<dyn MetricsSource>, Arc<dyn Any + Send + Sync>);
+
+/// Shared, IP-keyed access to the simulation's application metrics.
+///
+/// Cheap to clone (`Arc`-based); every clone sees the same sources. One handle
+/// is built per iteration and handed to every process and workload context.
+#[derive(Clone, Default)]
+pub struct MetricsHandle {
+    sources: Arc<RwLock<BTreeMap<String, SourceEntry>>>,
+}
+
+impl MetricsHandle {
+    /// Create an empty handle — the no-metrics-configured case.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Build a handle holding one source per IP, arming each source's
+    /// event-driven recording against the simulated clock.
+    ///
+    /// `clock` is the observability layer's sim-time handle, which the
+    /// orchestrator advances after every `sim.step()`. Timestamping from it
+    /// rather than the wall clock is what makes a recorded series replay
+    /// identically for a given seed.
+    pub(crate) fn from_factory<'a>(
+        factory: &SourceFactory,
+        ips: impl IntoIterator<Item = &'a str>,
+        clock: &SimulationLayerHandle,
+    ) -> Self {
+        let handle = Self::new();
+        let clock: Arc<dyn MetricClock> = Arc::new(SimClock(clock.clone()));
+        {
+            let mut sources = handle.write();
+            for ip in ips {
+                let (source, concrete) = factory(ip);
+                source.set_clock(clock.clone());
+                sources.insert(ip.to_owned(), SourceEntry { source, concrete });
+            }
+        }
+        handle
+    }
+
+    /// Whether any source is registered.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.read().is_empty()
+    }
+
+    /// Get the source registered for `ip`, downcast to its concrete type.
+    ///
+    /// Returns `None` when no metrics factory was configured, when `ip` is not
+    /// a simulated node, or when `S` is not the type the factory produced.
+    #[must_use]
+    pub fn get<S: MetricsSource>(&self, ip: &str) -> Option<Arc<S>> {
+        self.read()
+            .get(ip)
+            .and_then(|entry| entry.concrete.clone().downcast::<S>().ok())
+    }
+
+    /// Scrape every source, stamping each sample with its node's
+    /// [`INSTANCE_LABEL`].
+    ///
+    /// Samples come back sorted by [`MetricSample::sort_key`] so that two
+    /// replays of a seed produce identical reports regardless of what order
+    /// the adapters emitted them in.
+    #[must_use]
+    pub fn collect_all(&self) -> Vec<MetricSample> {
+        let mut all: Vec<MetricSample> = Vec::new();
+        // BTreeMap iteration is ordered by IP, so the scrape itself is stable.
+        for (ip, entry) in self.read().iter() {
+            for mut sample in entry.source.collect() {
+                sample.label_if_absent(INSTANCE_LABEL, ip);
+                all.push(sample);
+            }
+        }
+        all.sort_by_cached_key(MetricSample::sort_key);
+        all
+    }
+
+    /// Collect every node's recorded series, keyed by
+    /// `instance` + series identity and ascending in time.
+    ///
+    /// Unlike [`collect_all`](Self::collect_all), which is a single snapshot,
+    /// these are pushed by instrumented handles as the application mutates
+    /// them — one point per `inc()` / `set()` / `observe()`, at the simulated
+    /// instant it happened. That is what makes them plottable as a time
+    /// series.
+    #[must_use]
+    pub fn collect_series(&self) -> BTreeMap<String, Vec<MetricPoint>> {
+        let mut all = BTreeMap::new();
+        for (ip, entry) in self.read().iter() {
+            for (key, points) in entry.source.series() {
+                all.insert(qualify_series_key(&key, ip), points);
+            }
+        }
+        all
+    }
+
+    /// Total points dropped across nodes because a series hit its capacity.
+    #[must_use]
+    pub fn dropped_points(&self) -> u64 {
+        self.read()
+            .values()
+            .map(|entry| entry.source.dropped_points())
+            .sum()
+    }
+
+    fn read(&self) -> std::sync::RwLockReadGuard<'_, BTreeMap<String, SourceEntry>> {
+        self.sources
+            .read()
+            .expect("RwLock poisoned: prior task panicked")
+    }
+
+    fn write(&self) -> std::sync::RwLockWriteGuard<'_, BTreeMap<String, SourceEntry>> {
+        self.sources
+            .write()
+            .expect("RwLock poisoned: prior task panicked")
+    }
+}
+
+impl std::fmt::Debug for MetricsHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MetricsHandle")
+            .field("nodes", &self.read().len())
+            .finish()
+    }
+}
+
+/// Insert the [`INSTANCE_LABEL`] into a recorded series' key.
+///
+/// Recorded keys come from the source, which knows nothing about which node it
+/// belongs to, so the IP is spliced in here — inside the brace group when the
+/// key already has labels, as a new group otherwise. The result matches the
+/// key a scraped [`MetricSample`] produces for the same series.
+fn qualify_series_key(key: &str, ip: &str) -> String {
+    let instance = format!("{INSTANCE_LABEL}=\"{ip}\"");
+    match key.split_once('{') {
+        // Already labelled by the application: keep its labels and add ours.
+        Some((name, rest)) if rest.ends_with('}') => {
+            let inner = &rest[..rest.len() - 1];
+            if inner.contains(&format!("{INSTANCE_LABEL}=")) {
+                key.to_owned()
+            } else {
+                let mut labels: Vec<&str> = inner.split(',').filter(|s| !s.is_empty()).collect();
+                labels.push(&instance);
+                labels.sort_unstable();
+                format!("{name}{{{}}}", labels.join(","))
+            }
+        }
+        _ => format!("{key}{{{instance}}}"),
+    }
+}
+
+/// Adapts the observability layer's sim clock to [`MetricClock`].
+struct SimClock(SimulationLayerHandle);
+
+impl MetricClock for SimClock {
+    fn now_ms(&self) -> u64 {
+        self.0.now_ms()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use moonpool_core::metrics::MetricValue;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    struct Counting {
+        hits: AtomicU64,
+    }
+
+    impl MetricsSource for Counting {
+        fn collect(&self) -> Vec<MetricSample> {
+            let hits =
+                u32::try_from(self.hits.load(Ordering::Relaxed)).map_or(f64::INFINITY, f64::from);
+            vec![MetricSample::new(
+                "hits_total",
+                Vec::new(),
+                MetricValue::Counter(hits),
+            )]
+        }
+    }
+
+    struct Other;
+
+    impl MetricsSource for Other {
+        fn collect(&self) -> Vec<MetricSample> {
+            Vec::new()
+        }
+    }
+
+    fn handle_for(ips: &[&str]) -> (MetricsHandle, crate::observability::InstallGuard) {
+        let factory: SourceFactory = Box::new(|_ip| {
+            let s = Arc::new(Counting {
+                hits: AtomicU64::new(0),
+            });
+            (
+                s.clone() as Arc<dyn MetricsSource>,
+                s as Arc<dyn Any + Send + Sync>,
+            )
+        });
+        let (obs, guard) = crate::observability::SimulationLayer::new().install();
+        (
+            MetricsHandle::from_factory(&factory, ips.iter().copied(), &obs),
+            guard,
+        )
+    }
+
+    #[test]
+    fn empty_handle_collects_nothing() {
+        let handle = MetricsHandle::new();
+        assert!(handle.is_empty());
+        assert!(handle.collect_all().is_empty());
+        assert!(handle.get::<Counting>("10.0.1.1").is_none());
+    }
+
+    #[test]
+    fn factory_builds_one_source_per_ip() {
+        let (handle, _guard) = handle_for(&["10.0.1.1", "10.0.1.2"]);
+        assert!(!handle.is_empty());
+
+        let a = handle.get::<Counting>("10.0.1.1").expect("source for .1");
+        a.hits.fetch_add(3, Ordering::Relaxed);
+
+        let samples = handle.collect_all();
+        assert_eq!(samples.len(), 2, "one series per node");
+        assert_eq!(
+            samples[0].sort_key(),
+            r#"hits_total{instance="10.0.1.1"}"#,
+            "sorted, and stamped with the node IP"
+        );
+        assert_eq!(samples[0].value, MetricValue::Counter(3.0));
+        assert_eq!(
+            samples[1].value,
+            MetricValue::Counter(0.0),
+            "the other node has its own registry"
+        );
+    }
+
+    #[test]
+    fn get_with_wrong_type_returns_none() {
+        let (handle, _guard) = handle_for(&["10.0.1.1"]);
+        assert!(handle.get::<Other>("10.0.1.1").is_none());
+        assert!(handle.get::<Counting>("10.0.9.9").is_none(), "unknown ip");
+    }
+
+    #[test]
+    fn qualify_series_key_adds_the_instance_label() {
+        assert_eq!(
+            qualify_series_key("hits_total", "10.0.1.1"),
+            r#"hits_total{instance="10.0.1.1"}"#
+        );
+        assert_eq!(
+            qualify_series_key(r#"hits_total{code="200"}"#, "10.0.1.1"),
+            r#"hits_total{code="200",instance="10.0.1.1"}"#,
+            "existing labels are kept and the result stays sorted"
+        );
+        assert_eq!(
+            qualify_series_key(r#"hits_total{instance="mine"}"#, "10.0.1.1"),
+            r#"hits_total{instance="mine"}"#,
+            "an application-set instance label wins"
+        );
+    }
+
+    #[test]
+    fn collect_all_is_sorted_regardless_of_insertion_order() {
+        let (first, _g1) = handle_for(&["10.0.1.2", "10.0.1.1"]);
+        let (second, _g2) = handle_for(&["10.0.1.1", "10.0.1.2"]);
+        let keys = |h: &MetricsHandle| {
+            h.collect_all()
+                .iter()
+                .map(MetricSample::sort_key)
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(keys(&first), keys(&second));
+    }
+}

--- a/crates/moonpool-sim/src/runner/builder.rs
+++ b/crates/moonpool-sim/src/runner/builder.rs
@@ -17,12 +17,14 @@ use crate::runner::process::{Attrition, Process};
 use crate::runner::tags::TagDistribution;
 use crate::runner::workload::Workload;
 
+use super::app_metrics::SourceFactory;
 pub use super::config::{
     Chaos, ChaosMode, ClientId, IterationControl, ProcessCount, WorkloadCount,
 };
 use super::iteration::IterationManager;
 use super::metrics::{GenerateReportInputs, MetricsCollector};
 use super::orchestrator::{OrchestrateInputs, OrchestrateOutput, WorkloadOrchestrator};
+use moonpool_core::metrics::MetricsSource;
 
 /// Client identity information for a single workload instance.
 #[derive(Debug, Clone, Copy)]
@@ -36,6 +38,7 @@ pub(crate) struct WorkloadClientInfo {
 /// Inputs to `run_orchestrator_blocking`.
 struct RunOrchestratorInputs<'a> {
     seed: u64,
+    metrics_factory: Option<&'a SourceFactory>,
     iteration_count: usize,
     workloads: Vec<Box<dyn Workload>>,
     workload_info: Vec<(String, String)>,
@@ -234,6 +237,9 @@ pub struct SimulationBuilder {
     /// Factories that build a fresh fault injector for every root and explored
     /// timeline, mirroring `workload_factory`. Compatible with exploration.
     fault_factories: Vec<Box<dyn Fn() -> Box<dyn FaultInjector> + 'static>>,
+    /// Builds one application-metrics source per node IP, rebuilt each
+    /// iteration so counters start from zero on every seed.
+    metrics_factory: Option<SourceFactory>,
     chaos_duration: Option<Duration>,
     exploration_config: Option<crate::chaos::exploration_glue::ExplorationConfig>,
     /// Replay breakpoints staged for the next orchestration run. Installed
@@ -276,6 +282,7 @@ impl SimulationBuilder {
             invariants: Vec::new(),
             fault_injectors: Vec::new(),
             fault_factories: Vec::new(),
+            metrics_factory: None,
             chaos_duration: None,
             exploration_config: None,
             pending_replay: None,
@@ -545,6 +552,54 @@ impl SimulationBuilder {
     ) -> Self {
         self.invariants
             .push(crate::observability::invariant_fn(name, f));
+        self
+    }
+
+    /// Register an application-metrics source per simulated node.
+    ///
+    /// `factory` is called once per node IP at the start of every iteration.
+    /// Whatever it returns — a `PrometheusSource` from `moonpool-prometheus`,
+    /// or any other [`MetricsSource`] implementation — is reachable from that
+    /// node's code as [`SimContext::metrics`](super::context::SimContext::metrics),
+    /// and is scraped after the check phase into
+    /// [`SimulationMetrics::app_metrics`](super::report::SimulationMetrics::app_metrics).
+    /// The report aggregates the samples across seeds and prints them.
+    ///
+    /// Per-node, because every simulated node shares one OS process: a single
+    /// registry would merge all of their counters into one number. Per
+    /// iteration, because most registries have no reset, so a reused instance
+    /// would make seed 50 report the sum of fifty runs.
+    ///
+    /// ```ignore
+    /// SimulationBuilder::new()
+    ///     .metrics_factory(|_ip| Arc::new(PrometheusSource::default()))
+    ///     .processes(3, || Box::new(MyNode::new()))
+    ///     .workload(MyWorkload::default())
+    ///     .run();
+    /// ```
+    ///
+    /// Metric values are reported, never used to steer the simulation: a
+    /// metric derived from the wall clock is not deterministic. Record
+    /// durations from `ctx.time()` for a metric that replays identically.
+    ///
+    /// Under fork-based exploration, only root timelines are scraped —
+    /// explored timelines report back through the shared assertion table,
+    /// which carries no metric values.
+    #[must_use]
+    pub fn metrics_factory<S, F>(mut self, factory: F) -> Self
+    where
+        S: MetricsSource,
+        F: Fn(&str) -> std::sync::Arc<S> + 'static,
+    {
+        self.metrics_factory = Some(Box::new(move |ip| {
+            let source = factory(ip);
+            // Kept twice: as the trait object the runner scrapes, and as `Any`
+            // so `ctx.metrics::<S>()` can hand the concrete type back.
+            (
+                source.clone() as std::sync::Arc<dyn MetricsSource>,
+                source as std::sync::Arc<dyn std::any::Any + Send + Sync>,
+            )
+        }));
         self
     }
 
@@ -830,6 +885,7 @@ impl SimulationBuilder {
     fn run_orchestrator_blocking(inputs: RunOrchestratorInputs<'_>) -> OrchestrationOutcome {
         let RunOrchestratorInputs {
             seed,
+            metrics_factory,
             iteration_count,
             workloads,
             workload_info,
@@ -856,6 +912,7 @@ impl SimulationBuilder {
                 seed,
                 sim,
                 chaos_duration,
+                metrics_factory,
                 iteration_count,
                 run_time_budget,
             })
@@ -1348,6 +1405,7 @@ impl SimulationBuilder {
             bucket_summaries: Vec::new(),
             convergence_timeout: false,
             saturation: None,
+            app_metrics: Vec::new(),
         }
     }
 
@@ -1657,6 +1715,7 @@ impl SimulationBuilder {
         );
         let outcome = Self::run_orchestrator_blocking(RunOrchestratorInputs {
             seed,
+            metrics_factory: self.metrics_factory.as_ref(),
             iteration_count,
             workloads,
             workload_info,

--- a/crates/moonpool-sim/src/runner/context.rs
+++ b/crates/moonpool-sim/src/runner/context.rs
@@ -16,6 +16,10 @@
 //! }
 //! ```
 
+use std::sync::Arc;
+
+use moonpool_core::metrics::MetricsSource;
+
 use crate::chaos::state_handle::StateHandle;
 use crate::network::SimNetworkProvider;
 use crate::observability::SimulationLayerHandle;
@@ -24,6 +28,7 @@ use crate::storage::SimStorageProvider;
 
 use moonpool_core::Providers;
 
+use super::app_metrics::MetricsHandle;
 use super::topology::WorkloadTopology;
 
 /// Simulation context provided to workloads.
@@ -35,6 +40,7 @@ pub struct SimContext {
     topology: WorkloadTopology,
     state: StateHandle,
     obs: SimulationLayerHandle,
+    metrics: MetricsHandle,
 }
 
 impl SimContext {
@@ -45,12 +51,14 @@ impl SimContext {
         topology: WorkloadTopology,
         state: StateHandle,
         obs: SimulationLayerHandle,
+        metrics: MetricsHandle,
     ) -> Self {
         Self {
             providers,
             topology,
             state,
             obs,
+            metrics,
         }
     }
 
@@ -172,5 +180,35 @@ impl SimContext {
     #[must_use]
     pub fn observability(&self) -> &SimulationLayerHandle {
         &self.obs
+    }
+
+    /// Get this node's application metrics source, downcast to its type.
+    ///
+    /// The source is the one
+    /// [`metrics_factory`](super::builder::SimulationBuilder::metrics_factory)
+    /// built for [`my_ip`](Self::my_ip), so each simulated node counts
+    /// independently. Returns `None` when no factory was configured, or when
+    /// `S` is not the type the factory produced.
+    ///
+    /// ```ignore
+    /// let metrics = ctx.metrics::<PrometheusSource>().expect("metrics configured");
+    /// metrics.int_counter("requests_total", "Requests served")?.inc();
+    /// ```
+    ///
+    /// The source outlives process reboots (it is keyed by IP, not by process
+    /// instance), so a metric registered on first boot is still registered
+    /// after a restart — look counters up rather than re-registering them.
+    #[must_use]
+    pub fn metrics<S: MetricsSource>(&self) -> Option<Arc<S>> {
+        self.metrics.get(self.my_ip())
+    }
+
+    /// Get the raw handle to every node's metrics sources.
+    ///
+    /// Workloads use this to read a *server's* counters in `check()`;
+    /// [`metrics`](Self::metrics) is the usual per-node accessor.
+    #[must_use]
+    pub fn metrics_handle(&self) -> &MetricsHandle {
+        &self.metrics
     }
 }

--- a/crates/moonpool-sim/src/runner/display.rs
+++ b/crates/moonpool-sim/src/runner/display.rs
@@ -6,6 +6,7 @@
 use std::io::{IsTerminal, Write};
 
 use moonpool_assertions::AssertKind;
+use moonpool_core::metrics::HistogramValue;
 
 use super::report::{
     AssertionDetail, AssertionStatus, BucketSiteSummary, ExplorationReport, SaturationSignal,
@@ -289,6 +290,11 @@ fn write_report(w: &mut impl Write, report: &SimulationReport, color: bool) {
         );
     }
 
+    // === Application Metrics ===
+    if !report.app_metrics.is_empty() {
+        write_app_metrics(w, report, color);
+    }
+
     // === Per-Seed Metrics ===
     if report.seeds_used.len() > 1 {
         write_seeds(w, report, color);
@@ -485,6 +491,85 @@ fn write_buckets(w: &mut impl Write, summaries: &[BucketSiteSummary], color: boo
             fmt_num(bs.total_hits),
         );
     }
+}
+
+/// Largest number of metric series printed before the rest are elided.
+///
+/// One series per node per label combination adds up fast; the full set is
+/// always available on the report itself.
+const MAX_METRIC_ROWS: usize = 30;
+
+fn write_app_metrics(w: &mut impl Write, report: &SimulationReport, color: bool) {
+    let metrics = &report.app_metrics;
+    section_header(
+        w,
+        &format!("Metrics ({} series)", metrics.len()),
+        color,
+        ansi::BOLD_CYAN,
+    );
+
+    for agg in metrics.iter().take(MAX_METRIC_ROWS) {
+        // Counters read as a run total; gauges as the range they moved over.
+        // A histogram adds its observation count, which its sum alone hides.
+        let summary = match agg.kind {
+            "gauge" => format!(
+                "{:>12} avg  {:>12} min  {:>12} max",
+                fmt_metric(agg.mean()),
+                fmt_metric(agg.min),
+                fmt_metric(agg.max),
+            ),
+            "histogram" => {
+                let count = agg.histogram.as_ref().map_or(0, |h| h.count);
+                format!(
+                    "{:>12} total  {:>12} obs  {:>12} avg",
+                    fmt_metric(agg.total),
+                    fmt_num(count),
+                    fmt_metric(agg.histogram.as_ref().map_or(0.0, HistogramValue::mean)),
+                )
+            }
+            _ => format!(
+                "{:>12} total  {:>12} per seed",
+                fmt_metric(agg.total),
+                fmt_metric(agg.per_seed_mean()),
+            ),
+        };
+        let _ = writeln!(w, "  {:<52}  {summary}", truncate_key(&agg.key, 52));
+    }
+
+    if metrics.len() > MAX_METRIC_ROWS {
+        let dim = if color { ansi::DIM } else { "" };
+        let reset = if color { ansi::RESET } else { "" };
+        let _ = writeln!(
+            w,
+            "  {dim}... {} more series (see SimulationReport::app_metrics){reset}",
+            metrics.len() - MAX_METRIC_ROWS,
+        );
+    }
+}
+
+/// Format a metric scalar: integral values print without a decimal tail, so a
+/// counter reads `1,234` rather than `1234.00`.
+fn fmt_metric(v: f64) -> String {
+    if v.is_finite() && v.fract() == 0.0 && v.abs() < 1e15 {
+        let magnitude = fmt_num(f64_to_u64_saturating(v.abs()));
+        if v.is_sign_negative() && v != 0.0 {
+            format!("-{magnitude}")
+        } else {
+            magnitude
+        }
+    } else {
+        format!("{v:.2}")
+    }
+}
+
+/// Shorten a series key to `width`, keeping the head (metric name plus the
+/// first labels) since that is what identifies the series.
+fn truncate_key(key: &str, width: usize) -> String {
+    if key.chars().count() <= width {
+        return key.to_owned();
+    }
+    let head: String = key.chars().take(width.saturating_sub(1)).collect();
+    format!("{head}…")
 }
 
 fn write_seeds(w: &mut impl Write, report: &SimulationReport, color: bool) {

--- a/crates/moonpool-sim/src/runner/metrics.rs
+++ b/crates/moonpool-sim/src/runner/metrics.rs
@@ -7,8 +7,8 @@ use crate::chaos::AssertionStats;
 use crate::{SimulationError, SimulationResult};
 
 use super::report::{
-    AssertionDetail, BucketSiteSummary, ExplorationReport, SaturationReport, SimulationMetrics,
-    SimulationReport,
+    AssertionDetail, BucketSiteSummary, ExplorationReport, MetricAggregate, SaturationReport,
+    SimulationMetrics, SimulationReport,
 };
 
 /// Collects and aggregates metrics across simulation iterations.
@@ -18,6 +18,8 @@ pub(crate) struct MetricsCollector {
     aggregated_metrics: SimulationMetrics,
     individual_metrics: Vec<SimulationResult<SimulationMetrics>>,
     faulty_seeds: Vec<u64>,
+    /// Application-metric series folded across seeds, keyed by series identity.
+    app_metrics: BTreeMap<String, MetricAggregate>,
 }
 
 impl MetricsCollector {
@@ -29,6 +31,7 @@ impl MetricsCollector {
             aggregated_metrics: SimulationMetrics::default(),
             individual_metrics: Vec::new(),
             faulty_seeds: Vec::new(),
+            app_metrics: BTreeMap::new(),
         }
     }
 
@@ -55,6 +58,14 @@ impl MetricsCollector {
         self.aggregated_metrics.wall_time += wall_time;
         self.aggregated_metrics.simulated_time += metrics.simulated_time;
         self.aggregated_metrics.events_processed += metrics.events_processed;
+        // Only successful seeds contribute: a failed iteration's counters
+        // describe a run that did not finish, so folding them into the totals
+        // would misreport the system's steady-state behavior.
+        MetricAggregate::absorb_samples(
+            &mut self.app_metrics,
+            &metrics.app_metrics,
+            &metrics.app_series,
+        );
 
         let mut individual = metrics;
         individual.wall_time = wall_time;
@@ -119,7 +130,10 @@ impl MetricsCollector {
     }
 
     /// Consume the collector and assemble the public report.
-    pub(crate) fn generate_report(self, inputs: GenerateReportInputs) -> SimulationReport {
+    pub(crate) fn generate_report(mut self, inputs: GenerateReportInputs) -> SimulationReport {
+        let app_metrics = std::mem::take(&mut self.app_metrics)
+            .into_values()
+            .collect::<Vec<_>>();
         SimulationReport {
             iterations: inputs.iteration_count,
             successful_runs: self.successful_runs,
@@ -137,6 +151,7 @@ impl MetricsCollector {
             bucket_summaries: inputs.bucket_summaries,
             convergence_timeout: inputs.convergence_timeout,
             saturation: inputs.saturation,
+            app_metrics,
         }
     }
 }

--- a/crates/moonpool-sim/src/runner/mod.rs
+++ b/crates/moonpool-sim/src/runner/mod.rs
@@ -7,9 +7,11 @@
 //!
 //! - `builder` - SimulationBuilder for configuring experiments
 //! - `report` - SimulationMetrics and SimulationReport types
+//! - `app_metrics` - per-node application metrics scraped from a user registry
 //! - `topology` - WorkloadTopology and workload configuration
 //! - `orchestrator` - Internal workload orchestration
 
+pub mod app_metrics;
 pub mod builder;
 mod config;
 pub mod context;
@@ -29,6 +31,7 @@ pub(crate) mod wall_clock;
 pub mod workload;
 
 // Re-export main types at module level
+pub use app_metrics::{INSTANCE_LABEL, MetricsHandle};
 pub use builder::{Chaos, ChaosMode, ClientId, WorkloadCount};
 pub use builder::{IterationControl, SimulationBuilder};
 pub use context::SimContext;

--- a/crates/moonpool-sim/src/runner/orchestrator.rs
+++ b/crates/moonpool-sim/src/runner/orchestrator.rs
@@ -10,6 +10,7 @@ use tracing::Instrument as _;
 use crate::chaos::fault_events::SimFaultEvent;
 use crate::chaos::state_handle::StateHandle;
 use crate::observability::SimulationLayerHandle;
+use crate::runner::app_metrics::{MetricsHandle, SourceFactory};
 use crate::runner::builder::WorkloadClientInfo;
 use crate::runner::context::SimContext;
 use crate::runner::fault_injector::{FaultContext, FaultInjector};
@@ -20,7 +21,7 @@ use crate::runner::workload::Workload;
 use crate::sim::ProcessKillKind;
 use crate::{SimulationResult, assert_reachable};
 
-use super::process_manager::{ProcessConfig, ProcessManager};
+use super::process_manager::{ProcessConfig, ProcessManager, RestartEnv};
 use super::report::SimulationMetrics;
 use super::stall::{RunStallGuard, StallOutcome};
 
@@ -52,6 +53,7 @@ type WorkloadHandleSlots = Vec<Option<crate::executor::JoinHandle<WorkloadResult
 /// Inputs needed to run the check phase.
 struct CheckPhaseInputs<'a> {
     sim: &'a mut crate::sim::SimWorld,
+    metrics: &'a MetricsHandle,
     workloads: Vec<Box<dyn Workload>>,
     workload_info: &'a [(String, String)],
     client_info: &'a [WorkloadClientInfo],
@@ -70,6 +72,7 @@ struct PhaseEnv<'a, 'pm> {
     sim: &'a mut crate::sim::SimWorld,
     process_manager: &'a mut ProcessManager<'pm>,
     seed: u64,
+    metrics: &'a MetricsHandle,
     state: &'a StateHandle,
     obs: &'a SimulationLayerHandle,
     shutdown_signal: &'a tokio_util::sync::CancellationToken,
@@ -79,6 +82,7 @@ struct PhaseEnv<'a, 'pm> {
 struct RunPhaseInputs<'a, 'pm> {
     sim: &'a mut crate::sim::SimWorld,
     process_manager: &'a mut ProcessManager<'pm>,
+    metrics: &'a MetricsHandle,
     obs: &'a SimulationLayerHandle,
     state: &'a StateHandle,
     shutdown_signal: &'a tokio_util::sync::CancellationToken,
@@ -95,6 +99,7 @@ struct RunPhaseInputs<'a, 'pm> {
 
 /// Aggregated borrows needed to build workload contexts.
 struct WorkloadContextEnv<'a> {
+    metrics: &'a MetricsHandle,
     workload_info: &'a [(String, String)],
     client_info: &'a [WorkloadClientInfo],
     all_entities: &'a [(String, String)],
@@ -131,6 +136,9 @@ pub(crate) struct OrchestrateInputs<'a> {
     pub(crate) sim: crate::sim::SimWorld,
     /// Optional chaos duration; `None` disables fault injection.
     pub(crate) chaos_duration: Option<Duration>,
+    /// Builds one application-metrics source per node IP, or `None` when the
+    /// simulation registered no metrics factory.
+    pub(crate) metrics_factory: Option<&'a SourceFactory>,
     /// Iteration count (used for diagnostics on deadlock).
     pub(crate) iteration_count: usize,
     /// Virtual-time budget for the run phase. If simulated time advances past
@@ -155,6 +163,7 @@ pub(crate) struct OrchestrateOutput {
 struct FinalizeOrchestration<'a, 'pm> {
     sim: &'a mut crate::sim::SimWorld,
     process_manager: &'a mut ProcessManager<'pm>,
+    metrics: &'a MetricsHandle,
     returned_workloads: Vec<Box<dyn Workload>>,
     returned_injectors: Vec<Box<dyn FaultInjector>>,
     results: Vec<SimulationResult<()>>,
@@ -178,8 +187,24 @@ struct TopologyMetadata {
     all_entities: Vec<(String, String)>,
 }
 
+/// Shared environment for booting processes: everything a fresh process
+/// context needs beyond the process configuration itself.
+///
+/// `Copy`, being nothing but shared borrows, so helpers can destructure it
+/// without giving up the caller's copy.
+#[derive(Clone, Copy)]
+struct ProcessBootEnv<'a> {
+    sim: &'a crate::sim::SimWorld,
+    seed: u64,
+    state: &'a StateHandle,
+    obs: &'a SimulationLayerHandle,
+    metrics: &'a MetricsHandle,
+    shutdown_signal: &'a tokio_util::sync::CancellationToken,
+}
+
 /// Inputs to [`WorkloadOrchestrator::boot_and_setup`].
 struct BootAndSetupInputs<'a, 'pm> {
+    metrics: &'a MetricsHandle,
     process_config: Option<ProcessConfig<'pm>>,
     workloads: Vec<Box<dyn Workload>>,
     workload_info: &'a [(String, String)],
@@ -218,6 +243,7 @@ enum BootAndSetupOutcome<'pm> {
 struct ChaosAndRunInputs<'a, 'pm> {
     sim: &'a mut crate::sim::SimWorld,
     process_manager: &'a mut ProcessManager<'pm>,
+    metrics: &'a MetricsHandle,
     workloads: Vec<Box<dyn Workload>>,
     contexts: Vec<SimContext>,
     fault_injectors: Vec<Box<dyn FaultInjector>>,
@@ -261,16 +287,12 @@ impl WorkloadOrchestrator {
             seed,
             mut sim,
             chaos_duration,
+            metrics_factory,
             iteration_count,
             run_time_budget,
         } = inputs;
 
-        tracing::debug!(
-            "Orchestrating {} workload(s), {} fault injector(s), {} process(es)",
-            workloads.len(),
-            fault_injectors.len(),
-            process_config.as_ref().map_or(0, |pc| pc.ips.len()),
-        );
+        Self::log_orchestration_start(&workloads, &fault_injectors, process_config.as_ref());
 
         let TopologyMetadata {
             process_ips,
@@ -282,10 +304,12 @@ impl WorkloadOrchestrator {
         // Shared state for cross-workload publish/get communication. Event
         // timelines and invariants live on `obs` (SimulationLayer).
         let state = StateHandle::new();
+        let metrics = Self::build_metrics(metrics_factory, &all_entities, &obs);
         let shutdown_signal = tokio_util::sync::CancellationToken::new();
 
         let (workloads, contexts, mut process_manager) =
             match Self::boot_and_setup(BootAndSetupInputs {
+                metrics: &metrics,
                 process_config,
                 workloads,
                 workload_info,
@@ -312,7 +336,7 @@ impl WorkloadOrchestrator {
                         workloads,
                         fault_injectors,
                         results,
-                        metrics: sim.extract_metrics(),
+                        metrics: Self::extract_metrics(&sim, &metrics),
                     });
                 }
             };
@@ -324,6 +348,7 @@ impl WorkloadOrchestrator {
         } = Self::do_chaos_and_run_phase(ChaosAndRunInputs {
             sim: &mut sim,
             process_manager: &mut process_manager,
+            metrics: &metrics,
             workloads,
             contexts,
             fault_injectors,
@@ -341,6 +366,7 @@ impl WorkloadOrchestrator {
         Self::finalize_orchestration(FinalizeOrchestration {
             sim: &mut sim,
             process_manager: &mut process_manager,
+            metrics: &metrics,
             returned_workloads,
             returned_injectors,
             results,
@@ -391,6 +417,7 @@ impl WorkloadOrchestrator {
         inputs: BootAndSetupInputs<'_, 'pm>,
     ) -> Result<BootAndSetupOutcome<'pm>, (Vec<u64>, usize)> {
         let BootAndSetupInputs {
+            metrics,
             process_config,
             workloads,
             workload_info,
@@ -409,15 +436,19 @@ impl WorkloadOrchestrator {
         let mut process_manager = Self::boot_and_wrap_process_manager(
             process_config,
             all_entities,
-            sim,
-            seed,
-            state,
-            obs,
-            shutdown_signal,
+            &ProcessBootEnv {
+                sim,
+                seed,
+                state,
+                obs,
+                metrics,
+                shutdown_signal,
+            },
         )
         .map_err(|()| (vec![seed], 1usize))?;
 
         let contexts = Self::build_workload_contexts(&WorkloadContextEnv {
+            metrics,
             workload_info,
             client_info,
             all_entities,
@@ -439,6 +470,7 @@ impl WorkloadOrchestrator {
                 sim,
                 process_manager: &mut process_manager,
                 seed,
+                metrics,
                 state,
                 obs,
                 shutdown_signal,
@@ -467,6 +499,7 @@ impl WorkloadOrchestrator {
         let ChaosAndRunInputs {
             sim,
             process_manager,
+            metrics,
             workloads,
             contexts,
             fault_injectors,
@@ -501,6 +534,7 @@ impl WorkloadOrchestrator {
         Self::drive_run_phase(RunPhaseInputs {
             sim,
             process_manager,
+            metrics,
             obs,
             state,
             shutdown_signal,
@@ -535,6 +569,7 @@ impl WorkloadOrchestrator {
         let FinalizeOrchestration {
             sim,
             process_manager,
+            metrics,
             returned_workloads,
             returned_injectors,
             results,
@@ -559,7 +594,7 @@ impl WorkloadOrchestrator {
                 workloads: returned_workloads,
                 fault_injectors: returned_injectors,
                 results: vec![Err(settle_err)],
-                metrics: sim.extract_metrics(),
+                metrics: Self::extract_metrics(sim, metrics),
             });
         }
         // Faults recorded during settle carry their own timestamps; one pump
@@ -569,6 +604,7 @@ impl WorkloadOrchestrator {
         // === 7. CHECK PHASE (executor spawn + cooperative stepping) ===
         let final_workloads = Self::do_check_phase(CheckPhaseInputs {
             sim,
+            metrics,
             workloads: returned_workloads,
             workload_info,
             client_info,
@@ -583,13 +619,15 @@ impl WorkloadOrchestrator {
         })
         .await
         .map_err(|()| (vec![seed], 1usize))?;
-        let metrics = sim.extract_metrics();
+        // Scraped last, after `check()` has run: a workload that drives its
+        // final requests from `check()` still has them counted.
+        let sim_metrics = Self::extract_metrics(sim, metrics);
 
         Ok(OrchestrateOutput {
             workloads: final_workloads,
             fault_injectors: returned_injectors,
             results,
-            metrics,
+            metrics: sim_metrics,
         })
     }
 
@@ -603,6 +641,7 @@ impl WorkloadOrchestrator {
     async fn do_check_phase(inputs: CheckPhaseInputs<'_>) -> Result<Vec<Box<dyn Workload>>, ()> {
         let CheckPhaseInputs {
             sim,
+            metrics,
             workloads,
             workload_info,
             client_info,
@@ -616,6 +655,7 @@ impl WorkloadOrchestrator {
             obs,
         } = inputs;
         let check_contexts = Self::build_workload_contexts(&WorkloadContextEnv {
+            metrics,
             workload_info,
             client_info,
             all_entities,
@@ -644,16 +684,7 @@ impl WorkloadOrchestrator {
         bool,
     ) {
         let setup_handles = Self::spawn_setup_tasks(workloads, contexts);
-        Self::cooperative_loop_until_done(
-            env.sim,
-            env.process_manager,
-            env.seed,
-            env.state,
-            env.obs,
-            env.shutdown_signal,
-            &setup_handles,
-        )
-        .await;
+        Self::cooperative_loop_until_done(env, &setup_handles).await;
         Self::collect_setup_results(setup_handles).await
     }
 
@@ -709,6 +740,7 @@ impl WorkloadOrchestrator {
         let RunPhaseInputs {
             sim,
             process_manager,
+            metrics,
             obs,
             state,
             shutdown_signal,
@@ -769,6 +801,7 @@ impl WorkloadOrchestrator {
                     seed,
                     state,
                     obs,
+                    metrics,
                     shutdown_signal,
                 );
                 Self::pump_observability(sim, obs);
@@ -864,21 +897,10 @@ impl WorkloadOrchestrator {
     fn boot_and_wrap_process_manager<'pm>(
         process_config: Option<ProcessConfig<'pm>>,
         all_entities: &[(String, String)],
-        sim: &crate::sim::SimWorld,
-        seed: u64,
-        state: &StateHandle,
-        obs: &SimulationLayerHandle,
-        shutdown_signal: &tokio_util::sync::CancellationToken,
+        env: &ProcessBootEnv<'_>,
     ) -> Result<ProcessManager<'pm>, ()> {
-        let (process_handles, process_tokens) = Self::boot_processes(
-            process_config.as_ref(),
-            all_entities,
-            sim,
-            seed,
-            state,
-            obs,
-            shutdown_signal,
-        )?;
+        let (process_handles, process_tokens) =
+            Self::boot_processes(process_config.as_ref(), all_entities, env)?;
         Ok(match process_config {
             Some(pc) => ProcessManager::new(
                 pc.factory,
@@ -903,12 +925,16 @@ impl WorkloadOrchestrator {
     fn boot_processes(
         process_config: Option<&ProcessConfig<'_>>,
         all_entities: &[(String, String)],
-        sim: &crate::sim::SimWorld,
-        seed: u64,
-        state: &StateHandle,
-        obs: &SimulationLayerHandle,
-        shutdown_signal: &tokio_util::sync::CancellationToken,
+        env: &ProcessBootEnv<'_>,
     ) -> Result<(ProcessHandleSlots, ProcessTokenSlots), ()> {
+        let ProcessBootEnv {
+            sim,
+            seed,
+            state,
+            obs,
+            metrics,
+            shutdown_signal,
+        } = *env;
         let mut process_handles: ProcessHandleSlots = Vec::new();
         let mut process_tokens: ProcessTokenSlots = Vec::new();
         let Some(pc) = process_config else {
@@ -938,7 +964,13 @@ impl WorkloadOrchestrator {
                 shutdown_signal: process_token.clone(),
             });
             let providers = crate::SimProviders::new(sim.downgrade(), seed, ip_addr);
-            let ctx = SimContext::new(providers, topology, state.clone(), obs.clone());
+            let ctx = SimContext::new(
+                providers,
+                topology,
+                state.clone(),
+                obs.clone(),
+                metrics.clone(),
+            );
             let ip_for_log = ip.clone();
             let span_ip = ip.clone();
             let handle = crate::executor::spawn(
@@ -1038,7 +1070,13 @@ impl WorkloadOrchestrator {
                 shutdown_signal: env.shutdown_signal.clone(),
             });
             let providers = crate::SimProviders::new(env.sim.downgrade(), env.seed, ip_addr);
-            let ctx = SimContext::new(providers, topology, env.state.clone(), env.obs.clone());
+            let ctx = SimContext::new(
+                providers,
+                topology,
+                env.state.clone(),
+                env.obs.clone(),
+                env.metrics.clone(),
+            );
             contexts.push(ctx);
         }
         Ok(contexts)
@@ -1157,14 +1195,18 @@ impl WorkloadOrchestrator {
     /// Drive the simulation cooperatively until every handle in `handles`
     /// reports finished.
     async fn cooperative_loop_until_done<T: 'static>(
-        sim: &mut crate::sim::SimWorld,
-        process_manager: &mut ProcessManager<'_>,
-        seed: u64,
-        state: &StateHandle,
-        obs: &SimulationLayerHandle,
-        shutdown_signal: &tokio_util::sync::CancellationToken,
+        env: PhaseEnv<'_, '_>,
         handles: &[crate::executor::JoinHandle<T>],
     ) {
+        let PhaseEnv {
+            sim,
+            process_manager,
+            seed,
+            metrics,
+            state,
+            obs,
+            shutdown_signal,
+        } = env;
         loop {
             if handles.iter().all(crate::executor::JoinHandle::is_finished) {
                 break;
@@ -1177,6 +1219,7 @@ impl WorkloadOrchestrator {
                     seed,
                     state,
                     obs,
+                    metrics,
                     shutdown_signal,
                 );
                 Self::pump_observability(sim, obs);
@@ -1267,6 +1310,52 @@ impl WorkloadOrchestrator {
         None
     }
 
+    /// Log the shape of the iteration about to run.
+    fn log_orchestration_start(
+        workloads: &[Box<dyn Workload>],
+        fault_injectors: &[Box<dyn FaultInjector>],
+        process_config: Option<&ProcessConfig<'_>>,
+    ) {
+        tracing::debug!(
+            "Orchestrating {} workload(s), {} fault injector(s), {} process(es)",
+            workloads.len(),
+            fault_injectors.len(),
+            process_config.map_or(0, |pc| pc.ips.len()),
+        );
+    }
+
+    /// Build this iteration's application-metrics handle: one source per node,
+    /// rebuilt per iteration so counters start at zero for every seed, and
+    /// armed against the simulated clock. Empty when no factory was
+    /// registered, which is the no-metrics-configured case.
+    fn build_metrics(
+        factory: Option<&SourceFactory>,
+        all_entities: &[(String, String)],
+        obs: &SimulationLayerHandle,
+    ) -> MetricsHandle {
+        factory.map_or_else(MetricsHandle::new, |factory| {
+            MetricsHandle::from_factory(
+                factory,
+                all_entities.iter().map(|(_, ip)| ip.as_str()),
+                obs,
+            )
+        })
+    }
+
+    /// Snapshot engine metrics and scrape every node's application metrics
+    /// into one [`SimulationMetrics`].
+    ///
+    /// The scrape happens once per iteration rather than per step: reading a
+    /// registry is an observation, and doing it on every step would cost more
+    /// than it reveals while producing a timeline nothing consumes.
+    fn extract_metrics(sim: &crate::sim::SimWorld, metrics: &MetricsHandle) -> SimulationMetrics {
+        let mut out = sim.extract_metrics();
+        out.app_metrics = metrics.collect_all();
+        out.app_series = metrics.collect_series();
+        out.dropped_metric_points = metrics.dropped_points();
+        out
+    }
+
     /// Handle process lifecycle events from the last simulation step.
     fn handle_process_events(
         sim: &mut crate::sim::SimWorld,
@@ -1274,6 +1363,7 @@ impl WorkloadOrchestrator {
         seed: u64,
         state: &StateHandle,
         obs: &SimulationLayerHandle,
+        metrics: &MetricsHandle,
         shutdown_signal: &tokio_util::sync::CancellationToken,
     ) {
         match sim.last_processed_event() {
@@ -1333,7 +1423,20 @@ impl WorkloadOrchestrator {
                 let event = SimFaultEvent::ProcessRestart { ip: ip.to_string() };
                 obs.record_sim_fault(Self::sim_now_ms(sim), &event);
                 let weak_sim = sim.downgrade();
-                process_manager.restart(ip, &weak_sim, seed, state, obs, shutdown_signal);
+                // The restarted process keeps its node's metrics source: the
+                // IP is unchanged, so counters survive the reboot exactly as a
+                // real node's do across a process restart on the same host.
+                process_manager.restart(
+                    ip,
+                    &RestartEnv {
+                        sim: &weak_sim,
+                        seed,
+                        state,
+                        obs,
+                        metrics,
+                        shutdown_signal,
+                    },
+                );
             }
             _ => {}
         }

--- a/crates/moonpool-sim/src/runner/process_manager.rs
+++ b/crates/moonpool-sim/src/runner/process_manager.rs
@@ -7,6 +7,7 @@ use tracing::Instrument as _;
 
 use crate::chaos::state_handle::StateHandle;
 use crate::observability::SimulationLayerHandle;
+use crate::runner::app_metrics::MetricsHandle;
 use crate::runner::context::SimContext;
 use crate::runner::fault_injector::ProcessInfo;
 use crate::runner::locality::MachineRegistry;
@@ -22,6 +23,19 @@ pub(crate) struct ProcessConfig<'a> {
     pub(crate) ips: Vec<String>,
     pub(crate) tag_registry: TagRegistry,
     pub(crate) machine_registry: MachineRegistry,
+}
+
+/// Everything a restarted process needs to rebuild its [`SimContext`].
+///
+/// `Copy`, being nothing but shared borrows and a seed.
+#[derive(Clone, Copy)]
+pub(crate) struct RestartEnv<'a> {
+    pub(crate) sim: &'a crate::sim::WeakSimWorld,
+    pub(crate) seed: u64,
+    pub(crate) state: &'a StateHandle,
+    pub(crate) obs: &'a SimulationLayerHandle,
+    pub(crate) metrics: &'a MetricsHandle,
+    pub(crate) shutdown_signal: &'a tokio_util::sync::CancellationToken,
 }
 
 /// Owns running process tasks and their restart state.
@@ -116,15 +130,15 @@ impl<'a> ProcessManager<'a> {
         self.process_tokens[index] = None;
     }
 
-    pub(crate) fn restart(
-        &mut self,
-        ip: std::net::IpAddr,
-        sim: &crate::sim::WeakSimWorld,
-        seed: u64,
-        state: &StateHandle,
-        obs: &SimulationLayerHandle,
-        shutdown_signal: &tokio_util::sync::CancellationToken,
-    ) {
+    pub(crate) fn restart(&mut self, ip: std::net::IpAddr, env: &RestartEnv<'_>) {
+        let RestartEnv {
+            sim,
+            seed,
+            state,
+            obs,
+            metrics,
+            shutdown_signal,
+        } = *env;
         let ip_string = ip.to_string();
         let Some(index) = self.index_for_ip(ip) else {
             tracing::warn!(%ip, "ProcessRestart for unknown IP");
@@ -159,6 +173,7 @@ impl<'a> ProcessManager<'a> {
             topology,
             state.clone(),
             obs.clone(),
+            metrics.clone(),
         );
         let log_ip = ip_string.clone();
         let handle = crate::executor::spawn(

--- a/crates/moonpool-sim/src/runner/report.rs
+++ b/crates/moonpool-sim/src/runner/report.rs
@@ -7,6 +7,7 @@ use std::fmt;
 use std::time::Duration;
 
 use moonpool_assertions::AssertKind;
+use moonpool_core::metrics::{HistogramValue, MetricPoint, MetricSample, MetricValue};
 
 use crate::SimulationResult;
 use crate::chaos::AssertionStats;
@@ -31,6 +32,28 @@ pub struct SimulationMetrics {
     pub simulated_time: Duration,
     /// Number of events processed
     pub events_processed: u64,
+    /// Application metrics scraped from this iteration's
+    /// [`MetricsSource`](moonpool_core::metrics::MetricsSource)s, one entry
+    /// per series per node, sorted by
+    /// [`MetricSample::sort_key`]. Empty unless the simulation registered a
+    /// [`metrics_factory`](super::builder::SimulationBuilder::metrics_factory).
+    pub app_metrics: Vec<MetricSample>,
+    /// Per-series time series for this iteration, keyed by series identity and
+    /// ascending in simulated time.
+    ///
+    /// Points are pushed by instrumented metric handles as the application
+    /// mutates them — one per `inc()` / `set()` / `observe()`, stamped with
+    /// the simulated clock — so this is an exact history, not a sampled one,
+    /// and it replays identically for a given seed. Plot it, diff it between
+    /// seeds, or assert on its shape in a test.
+    ///
+    /// Only sources that hand out instrumented handles populate this; a source
+    /// wrapping a foreign registry appears in
+    /// [`app_metrics`](Self::app_metrics) only.
+    pub app_series: BTreeMap<String, Vec<MetricPoint>>,
+    /// Points dropped because a series hit its capacity. Non-zero means
+    /// [`app_series`](Self::app_series) is truncated.
+    pub dropped_metric_points: u64,
 }
 
 impl Default for SimulationMetrics {
@@ -39,6 +62,133 @@ impl Default for SimulationMetrics {
             wall_time: Duration::ZERO,
             simulated_time: Duration::ZERO,
             events_processed: 0,
+            app_metrics: Vec::new(),
+            app_series: BTreeMap::new(),
+            dropped_metric_points: 0,
+        }
+    }
+}
+
+/// One application-metric series, aggregated across every simulation seed
+/// that reported it.
+///
+/// Two sources feed this. [`total`](Self::total) comes from the end-of-run
+/// scrape, which is the right read for a counter (its run total) and a
+/// histogram (its sum). [`min`](Self::min), [`max`](Self::max) and
+/// [`mean`](Self::mean) come from the *recorded series* when one exists —
+/// every mutation, in simulated-time order — because a scrape catches a gauge
+/// only at its resting value and would report a queue that peaked at 50 as
+/// `0`.
+#[derive(Debug, Clone)]
+pub struct MetricAggregate {
+    /// Series identity: `name{key="value",...}`, including the
+    /// [`instance`](super::app_metrics::INSTANCE_LABEL) label naming the node.
+    pub key: String,
+    /// Metric name without labels.
+    pub name: String,
+    /// Value kind: `counter`, `gauge`, or `histogram`.
+    pub kind: &'static str,
+    /// Number of seeds that reported this series.
+    pub seeds: usize,
+    /// Sum of the per-seed scrape scalars (a histogram contributes its sum).
+    pub total: f64,
+    /// Smallest value observed, over recorded points when available.
+    pub min: f64,
+    /// Largest value observed, over recorded points when available.
+    pub max: f64,
+    /// Number of recorded points folded in; `0` when the source is
+    /// scrape-only.
+    pub observations: u64,
+    /// Sum of the recorded point values, for [`mean`](Self::mean).
+    pub observation_sum: f64,
+    /// Histogram buckets merged across seeds; `None` for counters and gauges.
+    pub histogram: Option<HistogramValue>,
+}
+
+impl MetricAggregate {
+    /// Mean value over the recorded series, falling back to the per-seed mean
+    /// of the scrape when nothing was recorded.
+    #[must_use]
+    pub fn mean(&self) -> f64 {
+        if self.observations > 0 {
+            // Precision loss acceptable: point counts fit well within 2^52.
+            return self.observation_sum
+                / u32::try_from(self.observations).map_or(f64::INFINITY, f64::from);
+        }
+        self.per_seed_mean()
+    }
+
+    /// Mean of the per-seed scrape scalars — a counter's average run total.
+    #[must_use]
+    pub fn per_seed_mean(&self) -> f64 {
+        if self.seeds == 0 {
+            0.0
+        } else {
+            // Precision loss acceptable: seed counts fit well within 2^52.
+            self.total / u32::try_from(self.seeds).map_or(f64::INFINITY, f64::from)
+        }
+    }
+
+    fn new(sample: &MetricSample) -> Self {
+        let scalar = sample.value.scalar();
+        Self {
+            key: sample.sort_key(),
+            name: sample.name.clone(),
+            kind: sample.value.kind(),
+            seeds: 1,
+            total: scalar,
+            min: f64::INFINITY,
+            max: f64::NEG_INFINITY,
+            observations: 0,
+            observation_sum: 0.0,
+            histogram: match &sample.value {
+                MetricValue::Histogram(h) => Some(h.clone()),
+                MetricValue::Counter(_) | MetricValue::Gauge(_) => None,
+            },
+        }
+    }
+
+    fn absorb(&mut self, sample: &MetricSample) {
+        self.seeds += 1;
+        self.total += sample.value.scalar();
+        if let (Some(existing), MetricValue::Histogram(h)) = (&mut self.histogram, &sample.value) {
+            existing.merge(h);
+        }
+    }
+
+    /// Fold recorded points, or the scrape scalar when this seed recorded none.
+    fn absorb_points(&mut self, points: Option<&Vec<MetricPoint>>, scalar: f64) {
+        match points {
+            Some(points) if !points.is_empty() => {
+                for point in points {
+                    self.min = self.min.min(point.value);
+                    self.max = self.max.max(point.value);
+                    self.observation_sum += point.value;
+                }
+                self.observations += points.len() as u64;
+            }
+            // Scrape-only source: the single end-of-run value is all there is.
+            _ => {
+                self.min = self.min.min(scalar);
+                self.max = self.max.max(scalar);
+            }
+        }
+    }
+
+    /// Fold one seed's scrape and recorded series into a keyed set of
+    /// aggregates.
+    pub(crate) fn absorb_samples(
+        into: &mut BTreeMap<String, MetricAggregate>,
+        samples: &[MetricSample],
+        series: &BTreeMap<String, Vec<MetricPoint>>,
+    ) {
+        for sample in samples {
+            let key = sample.sort_key();
+            let entry = into
+                .entry(key.clone())
+                .and_modify(|agg| agg.absorb(sample))
+                .or_insert_with(|| MetricAggregate::new(sample));
+            entry.absorb_points(series.get(&key), sample.value.scalar());
         }
     }
 }
@@ -192,6 +342,10 @@ pub struct SimulationReport {
     /// Saturation outcome for an `UntilCoverageStable` run (signal + coverage
     /// numbers); `None` for other iteration-control modes.
     pub saturation: Option<SaturationReport>,
+    /// Application metrics aggregated across every successful seed, sorted by
+    /// series key. Empty unless the simulation registered a
+    /// [`metrics_factory`](super::builder::SimulationBuilder::metrics_factory).
+    pub app_metrics: Vec<MetricAggregate>,
 }
 
 impl SimulationReport {

--- a/crates/moonpool-sim/src/sim/world.rs
+++ b/crates/moonpool-sim/src/sim/world.rs
@@ -351,6 +351,11 @@ impl SimWorld {
             wall_time: Duration::ZERO,
             simulated_time: inner.now(),
             events_processed: inner.events_processed,
+            // Filled in by the runner, which owns the per-node metrics
+            // sources; the engine has no view of application registries.
+            app_metrics: Vec::new(),
+            app_series: std::collections::BTreeMap::new(),
+            dropped_metric_points: 0,
         }
     }
 

--- a/crates/moonpool/Cargo.toml
+++ b/crates/moonpool/Cargo.toml
@@ -22,10 +22,16 @@ tokio = ["moonpool-core/tokio-providers", "moonpool-core/select"]
 # batteries-included default above: a stack that speaks no HTTP should not
 # compile h2 and tower, and the lean production tree stays free of hyper.
 hyper = ["dep:moonpool-hyper"]
+# Prometheus registry adapter (moonpool::prometheus): scrape the metrics your
+# code already keeps into the simulation report. Off by default, including in
+# the batteries-included default above — a stack that keeps no metrics should
+# not compile the prometheus crate.
+prometheus = ["dep:moonpool-prometheus"]
 
 [dependencies]
 moonpool-core = { path = "../moonpool-core", version = "0.8.0", default-features = false }
 moonpool-hyper = { path = "../moonpool-hyper", version = "0.8.0", optional = true }
+moonpool-prometheus = { path = "../moonpool-prometheus", version = "0.8.0", optional = true }
 moonpool-sim = { path = "../moonpool-sim", version = "0.8.0", optional = true }
 
 [dev-dependencies]

--- a/crates/moonpool/src/lib.rs
+++ b/crates/moonpool/src/lib.rs
@@ -24,6 +24,10 @@
 //! │  • hyper runtime adapters   • HyperIo over provider streams │
 //! │  • Reconnecting h2 channel  • Per-connection serve helper   │
 //! ├─────────────────────────────────────────────────────────────┤
+//! │    moonpool-prometheus (feature "prometheus", opt-in)       │
+//! │  • Scrapes a prometheus::Registry into the sim report       │
+//! │  • Instrumented handles record on the simulated clock       │
+//! ├─────────────────────────────────────────────────────────────┤
 //! │                     moonpool-core                           │
 //! │  Provider traits: Time, Task, Network, Random, Storage      │
 //! └─────────────────────────────────────────────────────────────┘
@@ -48,6 +52,7 @@
 //! | Provider traits only | `moonpool-core` |
 //! | Simulation runtime | `moonpool-sim` |
 //! | An HTTP/2 stack (tonic, axum, hyper) on the providers | `moonpool` with feature `hyper`, or `moonpool-hyper` |
+//! | Prometheus metrics in the simulation report | `moonpool` with feature `prometheus`, or `moonpool-prometheus` |
 //! | Fork-based exploration internals | `moonpool-explorer` |
 //!
 //! ## Documentation
@@ -55,6 +60,7 @@
 //! - [`moonpool_core`] - Provider traits and core types
 //! - [`moonpool_sim`] - Simulation runtime and chaos testing
 //! - `moonpool::hyper` - hyper 1.x integration, behind the `hyper` feature
+//! - `moonpool::prometheus` - Prometheus metrics adapter, behind the `prometheus` feature
 
 #![deny(missing_docs)]
 
@@ -84,6 +90,29 @@ pub use moonpool_sim::*;
 #[cfg(feature = "hyper")]
 pub mod hyper {
     pub use moonpool_hyper::*;
+}
+
+/// Prometheus metrics in the simulation report.
+///
+/// ```ignore
+/// use moonpool::prometheus::PrometheusSource;
+///
+/// SimulationBuilder::new()
+///     .metrics_factory(|_ip| Arc::new(PrometheusSource::default()))
+///     .processes(3, || Box::new(MyNode::new()))
+///     .workload(MyWorkload::default())
+///     .run();
+/// ```
+///
+/// Register a source per simulated node and the counters, gauges and
+/// histograms your code already keeps are reported at the end of the run.
+/// Metrics created through the source hand back instrumented handles that
+/// record every mutation on the *simulated* clock, giving an exact time
+/// series; anything else in the registry is caught by a final scrape.
+/// Requires the `prometheus` feature.
+#[cfg(feature = "prometheus")]
+pub mod prometheus {
+    pub use moonpool_prometheus::*;
 }
 
 /// Common imports for application code.

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -42,6 +42,11 @@ const SIM_BINARIES: &[SimBinary] = &[
         "moonpool_explorer",
     ),
     SimBinary::new("sim-axum-web", SIM_EXAMPLES_PACKAGE, SIM_EXAMPLES_CRATE),
+    SimBinary::new(
+        "sim-metrics-service",
+        SIM_EXAMPLES_PACKAGE,
+        SIM_EXAMPLES_CRATE,
+    ),
     SimBinary::new("sim-topology", SIM_EXAMPLES_PACKAGE, SIM_EXAMPLES_CRATE),
     SimBinary::new("sim-tonic-grpc", SIM_EXAMPLES_PACKAGE, SIM_EXAMPLES_CRATE),
 ];

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -36,6 +36,20 @@ version_group = "moonpool"
 name = "moonpool-hyper"
 version_group = "moonpool"
 
+# Prometheus registry adapter for simulation metrics; depends only on
+# moonpool-core, so it publishes in the same tier as moonpool-hyper.
+[[package]]
+name = "moonpool-prometheus"
+changelog_path = "crates/moonpool-prometheus/CHANGELOG.md"
+version_group = "moonpool"
+
+# Standalone buggify state + macros. moonpool-sim depends on it, so it must
+# publish first.
+[[package]]
+name = "moonpool-buggify"
+changelog_path = "crates/moonpool-buggify/CHANGELOG.md"
+version_group = "moonpool"
+
 # Leaf accounting crate; moonpool-explorer depends on it, so it must publish first.
 [[package]]
 name = "moonpool-assertions"


### PR DESCRIPTION
Simulations could report on the engine — sim time, events processed — but were blind to what the code under test recorded about itself. A service instrumented with a `prometheus::Registry` got nothing back from a run.

This adds a registry-agnostic seam and a Prometheus adapter over it, so the counters, gauges and histograms your code already keeps become simulation output.

```rust
SimulationBuilder::new()
    .metrics_factory(|_ip| Arc::new(PrometheusSource::default()))
    .processes(3, || Box::new(MyNode::new()))
    .workload(MyWorkload::default())
    .run();
```

```
━━━ Metrics (15 series) ━━━━━━━━━━━━━━━━━━━━━━━━━━
  kv_keys_stored{instance="10.0.1.1"}                      15.80 avg         1 min       16 max
  kv_request_latency_seconds{instance="10.0.1.1"}         131.20 total   6,579 obs     0.02 avg
  kv_requests_in_flight{instance="10.0.1.1"}                2.24 avg         0 min        3 max
  kv_requests_rejected_total{instance="10.0.1.1"}          8,638 total  863.80 per seed
  kv_requests_served_total{instance="10.0.1.1"}            6,579 total  657.90 per seed
```

## The seam

`moonpool-core` gains `MetricsSource` plus the `MetricSample` / `MetricValue` / `MetricPoint` vocabulary — deliberately the smallest shape common to Prometheus and OpenTelemetry, so an OTEL adapter drops in later without touching the simulation runner. Zero new dependencies, and `moonpool-sim` stays wasm-clean because the adapter lives in its own crate.

## Push, not poll

Metrics created through `PrometheusSource` hand back instrumented handles. Every `inc()`, `set()` and `observe()` records a point stamped with the **simulated** clock — an exact time series with no scrape interval and no sampling, replaying bit-for-bit for a given seed. It lands on `SimulationMetrics::app_series`, ready to plot or assert on.

The stock `prometheus` crate exposes no mutation hook (an `IntCounter::inc()` just bumps an atomic), so metrics registered directly into a raw `Registry` by third-party code can't be intercepted. Those are caught by a single end-of-iteration scrape instead — totals, just not history.

## Per node, per iteration, across reboots

- **Per node**, because every simulated node shares one OS process: a shared registry would merge three nodes' counters into one number. Each sample carries an `instance` label.
- **Per iteration**, because most registries have no reset — a reused instance would make seed 50 report the sum of fifty runs. Same reasoning as `fault_factory` vs `fault`.
- **Across reboots**, because a source is keyed by IP, matching what a real node's `/metrics` shows after a restart on the same host. The `counter`/`gauge`/`histogram` methods are get-or-register so a second boot doesn't hit `AlreadyReg`.

## Determinism

`SimHistogram::start_timer` times from `TimeProvider`. Prometheus' own `start_timer()` reads the wall clock, which inside a simulation records host noise rather than simulated latency and gives a different answer on every replay. A test asserts a recorded series is byte-identical across two runs of the same seed.

Metric values are reported, never used to steer the simulation. Under fork-based exploration only root timelines are scraped, since explored timelines report back through the shared assertion table.

## Report

New Metrics section and `SimulationReport::app_metrics`. Aggregates take min/max/mean from the recorded series rather than the scrape — otherwise a gauge reports whatever value it happened to rest at when the run ended, which for `requests_in_flight` is `0` even when it peaked at 3.

## Also

- `sim-metrics-service` example: a metered KV service with admission control under network chaos, wired into the CI sim matrix.
- Book chapter (`part3-building/25-metrics.md`) and crate-map entry.
- `release-plz.toml` entry for `moonpool-prometheus`, plus `moonpool-buggify`, which was missing from that config despite being a published dependency of `moonpool-sim`.
- Facade feature `prometheus` (off by default), with a CI guard that the lean production tree stays free of it.

## Validation

`cargo fmt --check`, `cargo clippy --workspace --all-targets`, and `cargo nextest run --workspace` (624 passed) are clean, as are both portability gates — `moonpool-sim --no-default-features` and the `wasm32-unknown-unknown` check. `cargo xtask sim run metrics-service` passes 10/10 seeds.

Note: `nix develop` could not be used in this environment — the sandbox blocks the flake's GitHub tarball inputs — so the above ran on the rustup toolchain pinned by `rust-toolchain.toml` (1.95.0) rather than through the nix shell. CI will be the authoritative check.

---
_Generated by [Claude Code](https://claude.ai/code/session_01URyeN6jgZNVKkUgQ2wF77Y)_