### PR TITLE
feat(core): typed metric query and reporting layer

### DIFF
--- a/book/src/appendix/02-crate-map.md
+++ b/book/src/appendix/02-crate-map.md
@@ -54,6 +54,12 @@ select only `tokio`, then add `hyper` if it speaks HTTP or gRPC.
 The Tokio implementations provide real production I/O. Simulation supplies
 deterministic implementations of the same traits.
 
+It also holds the registry-agnostic metrics vocabulary (`MetricsSource`,
+`MetricSample`, `SeriesRecorder`) and, in `metrics::query`, the typed
+SELECT / RATE / BUCKETIZE / MAP / REDUCE model a runner uses to declare what it
+wants summarized. Both are pure std and wasm-clean. See
+[Application Metrics](../part3-building/25-metrics.md).
+
 ### moonpool-assertions
 
 **Role**: Antithesis-style assertion accounting with no dependencies.

--- a/book/src/part3-building/25-metrics.md
+++ b/book/src/part3-building/25-metrics.md
@@ -158,7 +158,8 @@ from raw snapshots: the runner already knew what mattered.
 | `select(name)` + `.label(k, v)` | pick series by name and label subset |
 | `.rate()` | monotonic counter → per-second rate, on simulated time |
 | `.bucketize(width, agg)` | regularize into fixed simulated-time buckets |
-| `.fill(policy)` | give the empty buckets a value |
+| `.fill(policy)` | repeat an existing value into the empty buckets |
+| `.interpolate()` | compute the empty buckets from their neighbours |
 | `.map(window, agg)` | rolling window over one series' points |
 | `.reduce(agg)` / `.reduce_by(label, agg)` | combine across series |
 
@@ -175,19 +176,36 @@ rated too.
 
 `bucketize` omits a bucket nothing landed in, because a gap and a zero are
 different facts: a workload that stopped reporting is not a workload reporting
-zero. `.fill(policy)` is where you say which one this metric means, with the
-four Warp 10 policies:
+zero. Two ops say which one this metric means, split the way Warp 10 splits
+them — `.fill(policy)` **repeats a value the series already has**, while
+`.interpolate()` **computes one it never had**:
 
-| Policy | Fills | Leaves empty |
-|--------|-------|--------------|
-| `Fill::Previous` | interior and trailing gaps, with the last known value | leading gaps |
-| `Fill::Next` | interior and leading gaps, with the next known value | trailing gaps |
-| `Fill::Interpolate` | interior gaps, linearly between neighbours | leading and trailing gaps |
-| `Fill::Value(v)` | every gap — it needs no neighbour | nothing |
+| Op | Gives empty buckets | Leaves empty |
+|----|---------------------|--------------|
+| `.fill(Fill::Previous)` | the last known value | leading gaps |
+| `.fill(Fill::Next)` | the next known value | trailing gaps |
+| `.fill(Fill::Value(v))` | `v` — no neighbour needed | nothing |
+| `.interpolate()` | a point on the line between the two neighbours | leading and trailing gaps |
 
-The grid runs from bucket zero to the bucket holding the run's end, so a
-workload that went quiet halfway through gets buckets for the silence instead
-of the series just stopping.
+Reach for a fill when the quantity holds its value between observations (or is
+simply zero when nothing happened), and `.interpolate()` when it moves
+continuously — a queue depth, a replication lag.
+
+```text
+bucket                     0 |    1 |    2 |    3 |    4
+no fill                   10 |    - |    - |   40 |    -
+.fill(Fill::Previous)     10 |   10 |   10 |   40 |   40
+.fill(Fill::Next)         10 |   40 |   40 |   40 |    -
+.fill(Fill::Value(0.0))   10 |    0 |    0 |   40 |    0
+.interpolate()            10 |   20 |   30 |   40 |    -
+```
+
+They compose, in call order: `.interpolate().fill(Fill::Value(0.0))` draws the
+line through the interior gaps and zeroes the ends interpolation cannot reach.
+
+Either way the grid runs from bucket zero to the bucket holding the run's end,
+so a workload that went quiet halfway through gets buckets for the silence
+instead of the series just stopping.
 
 That matters for more than tidiness. Without a fill, a seed's bucket set
 depends on when *that* seed happened to be busy, so the across-run summary
@@ -205,10 +223,13 @@ splits one window into several — each with a fraction of the runs in it, and
 [120s,180s)  runs: 2   min 0  max 5
 ```
 
-Filling neither collapses nor restores a distribution, so it leaves the stage —
-and with it whether `Percentile` still applies — unchanged. A series that
-recorded nothing at all stays empty: a policy alone must not conjure a metric
-the run never touched.
+Neither op collapses nor restores a distribution, so both leave the stage — and
+with it whether `Percentile` still applies — unchanged. Both read the
+*recorded* buckets only, never the ones they just synthesized, so a carried
+value is the last real observation and a run of interpolated gaps is one
+straight line rather than a curve that drifts. A series that recorded nothing
+at all stays empty: a policy alone must not conjure a metric the run never
+touched.
 
 **Series identity is name plus label set**, canonically ordered, so two
 label sets that differ only in insertion order are the same series. Matching is

--- a/book/src/part3-building/25-metrics.md
+++ b/book/src/part3-building/25-metrics.md
@@ -101,6 +101,114 @@ Series are capped (10,000 points each by default; see
 memory without bound. `SimulationMetrics::dropped_metric_points` is non-zero
 when a series was truncated.
 
+## Asking questions: metric queries
+
+A raw series is data, not an answer. After five hundred seeds the question is
+usually "what throughput did this hold, and which seed was the worst?" — so the
+**runner declares what it wants to know**, and the report answers it.
+
+```rust,ignore
+use std::time::Duration;
+use moonpool_sim::{Mean, MetricQuery, Percentile};
+
+let report = SimulationBuilder::new()
+    .metrics_factory(|_ip| Arc::new(PrometheusSource::default()))
+    .metric(
+        MetricQuery::select("requests_total")
+            .label("operation", "write")
+            .rate()
+            .bucketize(Duration::from_secs(60), Mean)
+            .reduce(Mean)
+            .named("write_throughput"),
+    )
+    .metric(
+        MetricQuery::select("request_latency_seconds")
+            .bucketize(Duration::from_secs(60), Percentile(0.99))
+            .named("write_p99"),
+    )
+    .processes(3, || Box::new(MyNode::new()))
+    .workload(MyWorkload::default())
+    .set_iterations(500)
+    .run();
+```
+
+```text
+━━━ Metric Queries (2) ━━━━━━━━━━━━━━━━━━━━━━━━━━
+  write_throughput
+    requests_total{operation="write"} → rate → 60s buckets (mean) → reduce (mean)  ·  scalar per run  ·  runs: 500
+    min            5,421   seed=9182
+    mean           5,973
+    max            6,102   seed=224
+    across runs:  p50 5,991  p95 6,071  p99 6,094
+```
+
+`min` and `max` name the seed that produced them, so the worst run goes
+straight into `set_debug_seeds(vec![9182])`.
+
+Queries are declared before `run()` and their results travel with the report,
+in `SimulationReport::metric_queries`. Nothing reconstructs them afterwards
+from raw snapshots: the runner already knew what mattered.
+
+### The five operations
+
+| Op | What it does |
+|----|--------------|
+| `select(name)` + `.label(k, v)` | pick series by name and label subset |
+| `.rate()` | monotonic counter → per-second rate, on simulated time |
+| `.bucketize(width, agg)` | regularize into fixed simulated-time buckets |
+| `.map(window, agg)` | rolling window over one series' points |
+| `.reduce(agg)` / `.reduce_by(label, agg)` | combine across series |
+
+The aggregators are `Min`, `Mean`, `Max` and `Percentile(p)` — nothing else.
+
+**Counter semantics are explicit.** `.rate()` is the only place a series is
+read as a counter; `bucketize(_, Mean)` on a raw counter honestly reports the
+mean *cumulative value*, not a throughput. A drop in a counter's value is read
+as a reset, Prometheus style. Because a fresh source is built per iteration,
+every counter is zero at simulated time zero, so the very first increment is
+rated too.
+
+**Series identity is name plus label set**, canonically ordered, so two
+label sets that differ only in insertion order are the same series. Matching is
+by subset: a query naming `operation="write"` also matches a series carrying
+`instance="10.0.1.1"`.
+
+**Moonpool's own metadata stays out of your labels.** Every result row carries
+`seed` (the replayable identity of one iteration) and `run_id` (the identity of
+the whole `run()` invocation) as moonpool-side fields, never injected into the
+application's Prometheus labels.
+
+### Percentiles that mean something
+
+`mean(p99(node_a), p99(node_b))` is not a p99, and `p99(p99(a), p99(b))` is not
+one either. Once observations are collapsed into a percentile, the percentile
+of *that* is a number without a meaning.
+
+The builder enforces this at compile time. Each stage tracks what its values
+are, and `Percentile` only applies where the individual observations survive:
+
+```rust,ignore
+// Compiles: the raw histogram observations are still there.
+MetricQuery::select("request_latency_seconds")
+    .bucketize(Duration::from_secs(60), Percentile(0.99))
+    .named("p99");
+
+// Does NOT compile: p99 of per-bucket p99s.
+MetricQuery::select("request_latency_seconds")
+    .bucketize(Duration::from_secs(60), Percentile(0.99))
+    .reduce(Percentile(0.99))
+    .named("nonsense");
+```
+
+`Min`, `Mean` and `Max` apply anywhere — "the mean of each node's p99" is a
+useful number as long as nobody calls it a p99, which is why the report prints
+each query's provenance (`observations`, `scalar` or `percentile-derived`).
+
+The percentiles in the summary block are a different dimension: they are taken
+*across runs*, where every seed contributes one equally-weighted value. `p95`
+there names the 95th-percentile run, which is why the report labels it
+`across runs`.
+
 ## Timing on the simulated clock
 
 Use `start_timer` from this crate, not `prometheus`' own:

--- a/book/src/part3-building/25-metrics.md
+++ b/book/src/part3-building/25-metrics.md
@@ -109,7 +109,7 @@ usually "what throughput did this hold, and which seed was the worst?" — so th
 
 ```rust,ignore
 use std::time::Duration;
-use moonpool_sim::{Mean, MetricQuery, Percentile};
+use moonpool_sim::{Fill, Mean, MetricQuery, Percentile};
 
 let report = SimulationBuilder::new()
     .metrics_factory(|_ip| Arc::new(PrometheusSource::default()))
@@ -118,6 +118,8 @@ let report = SimulationBuilder::new()
             .label("operation", "write")
             .rate()
             .bucketize(Duration::from_secs(60), Mean)
+            // A minute with no requests is zero per second, not missing data.
+            .fill(Fill::Value(0.0))
             .reduce(Mean)
             .named("write_throughput"),
     )
@@ -156,6 +158,7 @@ from raw snapshots: the runner already knew what mattered.
 | `select(name)` + `.label(k, v)` | pick series by name and label subset |
 | `.rate()` | monotonic counter → per-second rate, on simulated time |
 | `.bucketize(width, agg)` | regularize into fixed simulated-time buckets |
+| `.fill(policy)` | give the empty buckets a value |
 | `.map(window, agg)` | rolling window over one series' points |
 | `.reduce(agg)` / `.reduce_by(label, agg)` | combine across series |
 
@@ -167,6 +170,45 @@ mean *cumulative value*, not a throughput. A drop in a counter's value is read
 as a reset, Prometheus style. Because a fresh source is built per iteration,
 every counter is zero at simulated time zero, so the very first increment is
 rated too.
+
+### Empty buckets
+
+`bucketize` omits a bucket nothing landed in, because a gap and a zero are
+different facts: a workload that stopped reporting is not a workload reporting
+zero. `.fill(policy)` is where you say which one this metric means, with the
+four Warp 10 policies:
+
+| Policy | Fills | Leaves empty |
+|--------|-------|--------------|
+| `Fill::Previous` | interior and trailing gaps, with the last known value | leading gaps |
+| `Fill::Next` | interior and leading gaps, with the next known value | trailing gaps |
+| `Fill::Interpolate` | interior gaps, linearly between neighbours | leading and trailing gaps |
+| `Fill::Value(v)` | every gap — it needs no neighbour | nothing |
+
+The grid runs from bucket zero to the bucket holding the run's end, so a
+workload that went quiet halfway through gets buckets for the silence instead
+of the series just stopping.
+
+That matters for more than tidiness. Without a fill, a seed's bucket set
+depends on when *that* seed happened to be busy, so the across-run summary
+splits one window into several — each with a fraction of the runs in it, and
+`min`/`max` no longer comparing like with like:
+
+```text
+# unfilled: two seeds busy in different minutes
+[0s,60s)     runs: 1
+[120s,180s)  runs: 1
+
+# Fill::Value(0.0): one grid, every window sees every seed
+[0s,60s)     runs: 2   min 0  max 5
+[60s,120s)   runs: 2   min 0  max 0
+[120s,180s)  runs: 2   min 0  max 5
+```
+
+Filling neither collapses nor restores a distribution, so it leaves the stage —
+and with it whether `Percentile` still applies — unchanged. A series that
+recorded nothing at all stays empty: a policy alone must not conjure a metric
+the run never touched.
 
 **Series identity is name plus label set**, canonically ordered, so two
 label sets that differ only in insertion order are the same series. Matching is

--- a/crates/moonpool-core/src/metrics.rs
+++ b/crates/moonpool-core/src/metrics.rs
@@ -24,8 +24,8 @@
 //! # Asking questions of the recorded series
 //!
 //! [`query`] turns the points a run recorded into numbers a report can print:
-//! a small typed SELECT / RATE / BUCKETIZE / MAP / REDUCE model, evaluated
-//! against one run's [`query::MetricSnapshot`].
+//! a small typed SELECT / RATE / BUCKETIZE / FILL / MAP / REDUCE model,
+//! evaluated against one run's [`query::MetricSnapshot`].
 //!
 //! Adapters must emit samples in a deterministic order — sort by
 //! [`MetricSample::sort_key`] if the backing registry does not already

--- a/crates/moonpool-core/src/metrics.rs
+++ b/crates/moonpool-core/src/metrics.rs
@@ -21,10 +21,18 @@
 //! noise and vary run to run. Record durations from the simulated clock
 //! (`ctx.time()`) if you want a metric that is stable across replays of a seed.
 //!
+//! # Asking questions of the recorded series
+//!
+//! [`query`] turns the points a run recorded into numbers a report can print:
+//! a small typed SELECT / RATE / BUCKETIZE / MAP / REDUCE model, evaluated
+//! against one run's [`query::MetricSnapshot`].
+//!
 //! Adapters must emit samples in a deterministic order — sort by
 //! [`MetricSample::sort_key`] if the backing registry does not already
 //! guarantee one — so that two replays of the same seed produce byte-identical
 //! reports.
+
+pub mod query;
 
 /// The value carried by a single metric sample.
 ///

--- a/crates/moonpool-core/src/metrics/query.rs
+++ b/crates/moonpool-core/src/metrics/query.rs
@@ -14,7 +14,8 @@
 //! | `SELECT` | pick series by metric name and label matchers |
 //! | `RATE` | monotonic counter → per-second rate, on simulated time |
 //! | `BUCKETIZE` | regularize points into fixed simulated-time buckets |
-//! | `FILL` | give the empty buckets a value, Warp 10 style |
+//! | `FILL` | repeat an existing value into the empty buckets |
+//! | `INTERPOLATE` | compute the empty buckets from their neighbours |
 //! | `MAP` | rolling window over one series' points |
 //! | `REDUCE` | combine across series, optionally grouped by a label |
 //!
@@ -406,15 +407,19 @@ fn trim_float(v: f64) -> String {
     }
 }
 
-/// What to put in a bucket that no observation landed in.
+/// Which existing value to repeat into a bucket that no observation landed in.
 ///
 /// [`bucketize`](MetricQuery::bucketize) omits empty buckets, because a gap
 /// and a zero are different facts: a workload that stopped reporting is not a
 /// workload reporting zero. [`fill`](MetricQuery::fill) is where you say which
 /// of the two this metric means.
 ///
-/// The names and the edge behaviour follow Warp 10's `FILLPREVIOUS`,
-/// `FILLNEXT`, `FILLVALUE` and `INTERPOLATE`: carrying a value forward cannot
+/// Every policy here *repeats* a value that is already there — which is the
+/// line Warp 10 draws between its `FILLPREVIOUS` / `FILLNEXT` / `FILLVALUE`
+/// and its separate `INTERPOLATE`. To compute a new value from the shape of
+/// the series instead, use [`interpolate`](MetricQuery::interpolate).
+///
+/// The edge behaviour follows Warp 10 too: carrying a value forward cannot
 /// invent one before the series started, and carrying backward cannot invent
 /// one after it ended.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -424,9 +429,6 @@ pub enum Fill {
     Previous,
     /// Carry the next known value backward. Trailing gaps stay empty.
     Next,
-    /// Linearly interpolate between the surrounding known values. Only
-    /// interior gaps are filled: both neighbours must exist.
-    Interpolate,
     /// A constant. `Fill::Value(0.0)` is the honest answer for a rate — no
     /// requests in that minute really is zero per second — and the only policy
     /// that fills leading and trailing gaps, since it needs no neighbour.
@@ -440,7 +442,6 @@ impl Fill {
         match self {
             Self::Previous => "previous".to_owned(),
             Self::Next => "next".to_owned(),
-            Self::Interpolate => "interpolate".to_owned(),
             Self::Value(v) => trim_float(v),
         }
     }
@@ -602,6 +603,7 @@ enum QueryOp {
     Map { window: usize, agg: Aggregator },
     Reduce { by: Option<String>, agg: Aggregator },
     Fill { policy: Fill },
+    Interpolate,
 }
 
 /// A metric query under construction.
@@ -753,7 +755,8 @@ impl<S: Stage> MetricQuery<S> {
         self.retag()
     }
 
-    /// Give every empty bucket a value, so the series has no holes.
+    /// Repeat an existing value into every empty bucket, so the series has no
+    /// holes.
     ///
     /// Two things go wrong with holes. A gap reads as "no data" where the
     /// metric may well mean "zero", and — because a bucket set that depends on
@@ -777,6 +780,10 @@ impl<S: Stage> MetricQuery<S> {
     ///     .named("write_throughput");
     /// ```
     ///
+    /// This only ever repeats a value the series already has. To compute one
+    /// from the slope between the surrounding buckets, use
+    /// [`interpolate`](Self::interpolate).
+    ///
     /// Filling neither collapses nor un-collapses anything, so the stage — and
     /// with it whether [`Percentile`] still applies — is unchanged. Without a
     /// preceding [`bucketize`](Self::bucketize) there is no grid and so no
@@ -784,6 +791,39 @@ impl<S: Stage> MetricQuery<S> {
     #[must_use]
     pub fn fill(mut self, policy: Fill) -> Self {
         self.ops.push(QueryOp::Fill { policy });
+        self
+    }
+
+    /// Give every empty bucket a value on the straight line between its two
+    /// recorded neighbours.
+    ///
+    /// Separate from [`fill`](Self::fill), as `INTERPOLATE` is in Warp 10,
+    /// because it is a different kind of operation: a fill repeats a value the
+    /// series already has, while this computes one it never had. Use it for a
+    /// quantity that moves continuously between observations — a queue depth,
+    /// a replication lag — and a fill for one that does not.
+    ///
+    /// Only interior gaps are filled: interpolation needs a neighbour on each
+    /// side, so a leading or trailing gap stays empty. Neighbours are the
+    /// *recorded* buckets, never previously-interpolated ones, so a run of
+    /// gaps is one straight line rather than a curve that drifts.
+    ///
+    /// ```
+    /// # use std::time::Duration;
+    /// # use moonpool_core::metrics::query::{Fill, Mean, MetricQuery};
+    /// MetricQuery::select("replication_lag_seconds")
+    ///     .bucketize(Duration::from_secs(60), Mean)
+    ///     .interpolate()
+    ///     // Interpolation cannot reach past the ends; a fill can.
+    ///     .fill(Fill::Value(0.0))
+    ///     .named("lag");
+    /// ```
+    ///
+    /// Like a fill, this changes no stage, and does nothing without a
+    /// preceding [`bucketize`](Self::bucketize).
+    #[must_use]
+    pub fn interpolate(mut self) -> Self {
+        self.ops.push(QueryOp::Interpolate);
         self
     }
 
@@ -856,6 +896,7 @@ impl MetricQueryPlan {
                     format!("reduce by {label} ({})", agg.label())
                 }
                 QueryOp::Fill { policy } => format!("fill ({})", policy.label()),
+                QueryOp::Interpolate => "interpolate".to_owned(),
             }))
             .collect::<Vec<_>>()
             .join(" → ")
@@ -996,6 +1037,13 @@ impl EvalState {
                 if let Some(every_ms) = self.grid {
                     for s in &mut self.series {
                         s.windows = fill_gaps(&s.windows, every_ms, self.end_time_ms, *policy);
+                    }
+                }
+            }
+            QueryOp::Interpolate => {
+                if let Some(every_ms) = self.grid {
+                    for s in &mut self.series {
+                        s.windows = interpolate_gaps(&s.windows, every_ms, self.end_time_ms);
                     }
                 }
             }
@@ -1149,13 +1197,23 @@ fn bucketize(windows: &[Window], every_ms: u64, agg: Aggregator) -> Vec<Window> 
         .collect()
 }
 
-/// Give every empty bucket in the grid a value, per `policy`.
+/// Walk the whole bucket grid, giving each empty bucket whatever `value_for`
+/// returns for it — `None` leaving it empty.
 ///
 /// The grid runs from bucket zero to whichever is later: the bucket holding
 /// the run's end, or the last bucket that actually has data. Bucket zero
 /// rather than the series' first bucket, so two seeds that started producing
 /// at different moments still land on the same windows.
-fn fill_gaps(windows: &[Window], every_ms: u64, end_time_ms: u64, policy: Fill) -> Vec<Window> {
+///
+/// `value_for` is handed the *recorded* buckets only, never the ones this walk
+/// has already synthesized, so neither a carried value nor an interpolated one
+/// is ever computed from another synthetic value.
+fn regrid(
+    windows: &[Window],
+    every_ms: u64,
+    end_time_ms: u64,
+    value_for: impl Fn(&BTreeMap<u64, f64>, u64) -> Option<f64>,
+) -> Vec<Window> {
     let known: BTreeMap<u64, f64> = windows
         .iter()
         .map(|w| (w.start_ms / every_ms, w.value))
@@ -1172,7 +1230,7 @@ fn fill_gaps(windows: &[Window], every_ms: u64, end_time_ms: u64, policy: Fill) 
         .filter_map(|index| {
             let value = match known.get(&index) {
                 Some(value) => Some(*value),
-                None => fill_value(&known, index, policy),
+                None => value_for(&known, index),
             }?;
             let start_ms = index.saturating_mul(every_ms);
             Some(Window {
@@ -1184,28 +1242,37 @@ fn fill_gaps(windows: &[Window], every_ms: u64, end_time_ms: u64, policy: Fill) 
         .collect()
 }
 
-/// The value `policy` puts in empty bucket `index`, or `None` when the policy
-/// has no neighbour to work from — a leading gap for [`Fill::Previous`], a
-/// trailing one for [`Fill::Next`], either for [`Fill::Interpolate`].
+/// Repeat an existing value into every empty bucket, per `policy`.
 ///
-/// Neighbours are always looked up among the *recorded* buckets, never among
-/// already-filled ones, so carrying a value forward carries the last real
-/// observation rather than a copy of a copy.
-fn fill_value(known: &BTreeMap<u64, f64>, index: u64, policy: Fill) -> Option<f64> {
-    let previous = || known.range(..index).next_back().map(|(i, v)| (*i, *v));
-    let next = || known.range(index..).next().map(|(i, v)| (*i, *v));
-    match policy {
-        Fill::Value(value) => Some(value),
-        Fill::Previous => previous().map(|(_, v)| v),
-        Fill::Next => next().map(|(_, v)| v),
-        Fill::Interpolate => {
-            let (before, before_value) = previous()?;
-            let (after, after_value) = next()?;
-            let span = u32::try_from(after - before).map_or(f64::INFINITY, f64::from);
-            let offset = u32::try_from(index - before).map_or(f64::INFINITY, f64::from);
-            Some(before_value + (after_value - before_value) * (offset / span))
-        }
-    }
+/// A policy with no neighbour to repeat leaves the bucket empty: a leading gap
+/// for [`Fill::Previous`], a trailing one for [`Fill::Next`].
+/// [`Fill::Value`] needs no neighbour and so fills the whole grid.
+fn fill_gaps(windows: &[Window], every_ms: u64, end_time_ms: u64, policy: Fill) -> Vec<Window> {
+    regrid(
+        windows,
+        every_ms,
+        end_time_ms,
+        |known, index| match policy {
+            Fill::Value(value) => Some(value),
+            Fill::Previous => known.range(..index).next_back().map(|(_, v)| *v),
+            Fill::Next => known.range(index..).next().map(|(_, v)| *v),
+        },
+    )
+}
+
+/// Put every empty bucket on the straight line between its two recorded
+/// neighbours.
+///
+/// Interior gaps only: a bucket with no recorded neighbour on one side has no
+/// line to sit on and stays empty.
+fn interpolate_gaps(windows: &[Window], every_ms: u64, end_time_ms: u64) -> Vec<Window> {
+    regrid(windows, every_ms, end_time_ms, |known, index| {
+        let (&before, &before_value) = known.range(..index).next_back()?;
+        let (&after, &after_value) = known.range(index..).next()?;
+        let span = u32::try_from(after - before).map_or(f64::INFINITY, f64::from);
+        let offset = u32::try_from(index - before).map_or(f64::INFINITY, f64::from);
+        Some(before_value + (after_value - before_value) * (offset / span))
+    })
 }
 
 /// Trailing rolling window of `window` consecutive points.
@@ -1703,11 +1770,16 @@ mod tests {
     }
 
     fn filled(policy: Fill) -> Vec<(u64, f64)> {
-        MetricQuery::select("v")
-            .bucketize(Duration::from_mins(1), Mean)
-            .fill(policy)
-            .named("q")
-            .evaluate(&gapped(), 1, 1)
+        buckets_of(
+            &MetricQuery::select("v")
+                .bucketize(Duration::from_mins(1), Mean)
+                .fill(policy)
+                .named("q"),
+        )
+    }
+
+    fn buckets_of(plan: &MetricQueryPlan) -> Vec<(u64, f64)> {
+        plan.evaluate(&gapped(), 1, 1)
             .into_iter()
             .map(|row| (row.bucket_start_ms / 60_000, row.value))
             .collect()
@@ -1771,11 +1843,33 @@ mod tests {
     }
 
     #[test]
-    fn interpolate_fills_only_between_known_values() {
+    fn interpolate_computes_only_between_known_values() {
         assert_eq!(
-            filled(Fill::Interpolate),
+            buckets_of(
+                &MetricQuery::select("v")
+                    .bucketize(Duration::from_mins(1), Mean)
+                    .interpolate()
+                    .named("q")
+            ),
             vec![(0, 10.0), (1, 20.0), (2, 30.0), (3, 40.0)],
             "linear between bucket 0 and bucket 3; nothing to interpolate after"
+        );
+    }
+
+    #[test]
+    fn interpolate_and_fill_compose_to_cover_the_ends() {
+        // Interpolation cannot reach past the last recorded bucket, so the
+        // trailing gap needs a fill — and the two ops apply in call order.
+        assert_eq!(
+            buckets_of(
+                &MetricQuery::select("v")
+                    .bucketize(Duration::from_mins(1), Mean)
+                    .interpolate()
+                    .fill(Fill::Value(0.0))
+                    .named("q")
+            ),
+            vec![(0, 10.0), (1, 20.0), (2, 30.0), (3, 40.0), (4, 0.0)],
+            "interior gaps interpolated, the trailing one zero-filled"
         );
     }
 
@@ -1787,7 +1881,7 @@ mod tests {
         let snap = snapshot(&[("v", &[(0, 0.0), (240_000, 100.0)])], 240_000);
         let values: Vec<f64> = MetricQuery::select("v")
             .bucketize(Duration::from_mins(1), Mean)
-            .fill(Fill::Interpolate)
+            .interpolate()
             .named("q")
             .evaluate(&snap, 1, 1)
             .into_iter()
@@ -1815,7 +1909,7 @@ mod tests {
     }
 
     #[test]
-    fn filling_a_series_that_never_reported_stays_empty() {
+    fn a_series_that_never_reported_stays_empty() {
         // No observations at all: there is nothing to have holes in, and a
         // policy alone must not conjure a series the run never touched.
         let snap = snapshot(&[("other", &[(0, 1.0)])], 120_000);
@@ -1828,29 +1922,35 @@ mod tests {
     }
 
     #[test]
-    fn fill_without_bucketize_does_nothing() {
+    fn fill_and_interpolate_without_bucketize_do_nothing() {
         let snap = snapshot(&[("v", &[(0, 1.0), (5_000, 2.0)])], 10_000);
-        let rows = MetricQuery::select("v")
-            .fill(Fill::Value(0.0))
-            .named("q")
-            .evaluate(&snap, 1, 1);
-        assert_eq!(rows.len(), 2, "no grid means no empty buckets to fill");
+        for plan in [
+            MetricQuery::select("v").fill(Fill::Value(0.0)).named("q"),
+            MetricQuery::select("v").interpolate().named("q"),
+        ] {
+            assert_eq!(
+                plan.evaluate(&snap, 1, 1).len(),
+                2,
+                "no grid means no empty buckets to give a value to"
+            );
+        }
     }
 
     #[test]
-    fn fill_preserves_the_stage_so_percentiles_stay_gated() {
+    fn fill_and_interpolate_preserve_the_stage_so_percentiles_stay_gated() {
         let quantile = MetricQuery::select("v")
             .bucketize(Duration::from_mins(1), Percentile(0.99))
+            .interpolate()
             .fill(Fill::Previous)
             .named("q");
         assert_eq!(
             quantile.provenance(),
             Provenance::Quantile,
-            "filling neither collapses nor restores a distribution"
+            "neither op collapses nor restores a distribution"
         );
         assert_eq!(
             quantile.description(),
-            "v → 60s buckets (p99) → fill (previous)"
+            "v → 60s buckets (p99) → interpolate → fill (previous)"
         );
     }
 

--- a/crates/moonpool-core/src/metrics/query.rs
+++ b/crates/moonpool-core/src/metrics/query.rs
@@ -14,6 +14,7 @@
 //! | `SELECT` | pick series by metric name and label matchers |
 //! | `RATE` | monotonic counter → per-second rate, on simulated time |
 //! | `BUCKETIZE` | regularize points into fixed simulated-time buckets |
+//! | `FILL` | give the empty buckets a value, Warp 10 style |
 //! | `MAP` | rolling window over one series' points |
 //! | `REDUCE` | combine across series, optionally grouped by a label |
 //!
@@ -23,12 +24,14 @@
 //!
 //! ```
 //! use std::time::Duration;
-//! use moonpool_core::metrics::query::{Mean, MetricQuery, Percentile};
+//! use moonpool_core::metrics::query::{Fill, Mean, MetricQuery, Percentile};
 //!
 //! let throughput = MetricQuery::select("requests_total")
 //!     .label("operation", "write")
 //!     .rate()
 //!     .bucketize(Duration::from_secs(60), Mean)
+//!     // A minute with no requests is zero per second, not missing data.
+//!     .fill(Fill::Value(0.0))
 //!     .named("write_throughput");
 //!
 //! let tail = MetricQuery::select("request_latency_seconds")
@@ -403,6 +406,46 @@ fn trim_float(v: f64) -> String {
     }
 }
 
+/// What to put in a bucket that no observation landed in.
+///
+/// [`bucketize`](MetricQuery::bucketize) omits empty buckets, because a gap
+/// and a zero are different facts: a workload that stopped reporting is not a
+/// workload reporting zero. [`fill`](MetricQuery::fill) is where you say which
+/// of the two this metric means.
+///
+/// The names and the edge behaviour follow Warp 10's `FILLPREVIOUS`,
+/// `FILLNEXT`, `FILLVALUE` and `INTERPOLATE`: carrying a value forward cannot
+/// invent one before the series started, and carrying backward cannot invent
+/// one after it ended.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Fill {
+    /// Carry the last known value forward. Leading gaps stay empty — there is
+    /// nothing before the series to carry.
+    Previous,
+    /// Carry the next known value backward. Trailing gaps stay empty.
+    Next,
+    /// Linearly interpolate between the surrounding known values. Only
+    /// interior gaps are filled: both neighbours must exist.
+    Interpolate,
+    /// A constant. `Fill::Value(0.0)` is the honest answer for a rate — no
+    /// requests in that minute really is zero per second — and the only policy
+    /// that fills leading and trailing gaps, since it needs no neighbour.
+    Value(f64),
+}
+
+impl Fill {
+    /// Short label for reports, e.g. `previous` or `0`.
+    #[must_use]
+    fn label(self) -> String {
+        match self {
+            Self::Previous => "previous".to_owned(),
+            Self::Next => "next".to_owned(),
+            Self::Interpolate => "interpolate".to_owned(),
+            Self::Value(v) => trim_float(v),
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Stages and type-level percentile enforcement
 // ---------------------------------------------------------------------------
@@ -558,6 +601,7 @@ enum QueryOp {
     Bucketize { every_ms: u64, agg: Aggregator },
     Map { window: usize, agg: Aggregator },
     Reduce { by: Option<String>, agg: Aggregator },
+    Fill { policy: Fill },
 }
 
 /// A metric query under construction.
@@ -709,7 +753,41 @@ impl<S: Stage> MetricQuery<S> {
         self.retag()
     }
 
-    /// Finish the query, naming it for the report.
+    /// Give every empty bucket a value, so the series has no holes.
+    ///
+    /// Two things go wrong with holes. A gap reads as "no data" where the
+    /// metric may well mean "zero", and — because a bucket set that depends on
+    /// when a seed happened to be busy differs from seed to seed — the
+    /// across-run summary splits one window into several, each with fewer runs
+    /// in it. Filling puts every seed on the same grid.
+    ///
+    /// The grid runs from bucket zero to the bucket holding the run's end, so
+    /// a workload that went quiet halfway through gets buckets for the silence
+    /// rather than stopping early. Which of those get a value depends on the
+    /// policy: see [`Fill`].
+    ///
+    /// ```
+    /// # use std::time::Duration;
+    /// # use moonpool_core::metrics::query::{Fill, Mean, MetricQuery};
+    /// MetricQuery::select("requests_total")
+    ///     .rate()
+    ///     .bucketize(Duration::from_secs(60), Mean)
+    ///     // A minute with no requests is zero per second, not missing data.
+    ///     .fill(Fill::Value(0.0))
+    ///     .named("write_throughput");
+    /// ```
+    ///
+    /// Filling neither collapses nor un-collapses anything, so the stage — and
+    /// with it whether [`Percentile`] still applies — is unchanged. Without a
+    /// preceding [`bucketize`](Self::bucketize) there is no grid and so no
+    /// empty buckets to fill, and this does nothing.
+    #[must_use]
+    pub fn fill(mut self, policy: Fill) -> Self {
+        self.ops.push(QueryOp::Fill { policy });
+        self
+    }
+
+    /// Finish the query, naming it for the report.    /// Finish the query, naming it for the report.
     #[must_use]
     pub fn named(self, name: impl Into<String>) -> MetricQueryPlan {
         MetricQueryPlan {
@@ -777,6 +855,7 @@ impl MetricQueryPlan {
                 } => {
                     format!("reduce by {label} ({})", agg.label())
                 }
+                QueryOp::Fill { policy } => format!("fill ({})", policy.label()),
             }))
             .collect::<Vec<_>>()
             .join(" → ")
@@ -857,9 +936,13 @@ struct EvalSeries {
 /// The working set a query pipeline transforms.
 struct EvalState {
     series: Vec<EvalSeries>,
-    /// True while every series sits on the same bucket grid, which is what
-    /// makes a bucket-by-bucket [`QueryOp::Reduce`] meaningful.
-    aligned: bool,
+    /// Bucket width, once [`QueryOp::Bucketize`] has put every series on one
+    /// grid. `Some` is also what makes a bucket-by-bucket
+    /// [`QueryOp::Reduce`] meaningful and what [`QueryOp::Fill`] needs to know
+    /// where the empty buckets are.
+    grid: Option<u64>,
+    /// Simulated time the run ended at, which bounds the grid a fill spans.
+    end_time_ms: u64,
 }
 
 impl EvalState {
@@ -883,7 +966,8 @@ impl EvalState {
             .collect();
         Self {
             series,
-            aligned: false,
+            grid: None,
+            end_time_ms: snapshot.end_time_ms(),
         }
     }
 
@@ -893,13 +977,13 @@ impl EvalState {
                 for s in &mut self.series {
                     s.windows = rate(&s.windows);
                 }
-                self.aligned = false;
+                self.grid = None;
             }
             QueryOp::Bucketize { every_ms, agg } => {
                 for s in &mut self.series {
                     s.windows = bucketize(&s.windows, *every_ms, *agg);
                 }
-                self.aligned = true;
+                self.grid = Some(*every_ms);
             }
             QueryOp::Map { window, agg } => {
                 for s in &mut self.series {
@@ -907,6 +991,14 @@ impl EvalState {
                 }
             }
             QueryOp::Reduce { by, agg } => self.reduce(by.as_deref(), *agg),
+            QueryOp::Fill { policy } => {
+                // Without a grid there are no empty buckets to fill.
+                if let Some(every_ms) = self.grid {
+                    for s in &mut self.series {
+                        s.windows = fill_gaps(&s.windows, every_ms, self.end_time_ms, *policy);
+                    }
+                }
+            }
         }
         self.series.retain(|s| !s.windows.is_empty());
     }
@@ -930,7 +1022,7 @@ impl EvalState {
             groups.entry(group).or_default().push(s);
         }
 
-        let aligned = self.aligned;
+        let aligned = self.grid.is_some();
         self.series = groups
             .into_iter()
             .map(|(group, members)| EvalSeries {
@@ -1055,6 +1147,65 @@ fn bucketize(windows: &[Window], every_ms: u64, agg: Aggregator) -> Vec<Window> 
             })
         })
         .collect()
+}
+
+/// Give every empty bucket in the grid a value, per `policy`.
+///
+/// The grid runs from bucket zero to whichever is later: the bucket holding
+/// the run's end, or the last bucket that actually has data. Bucket zero
+/// rather than the series' first bucket, so two seeds that started producing
+/// at different moments still land on the same windows.
+fn fill_gaps(windows: &[Window], every_ms: u64, end_time_ms: u64, policy: Fill) -> Vec<Window> {
+    let known: BTreeMap<u64, f64> = windows
+        .iter()
+        .map(|w| (w.start_ms / every_ms, w.value))
+        .collect();
+    let Some(last_known) = known.keys().next_back().copied() else {
+        // Nothing was ever recorded: there is no series to give holes to, and
+        // inventing a whole run of values out of a policy alone would be
+        // reporting on a metric the run never touched.
+        return Vec::new();
+    };
+    let last_index = (end_time_ms / every_ms).max(last_known);
+
+    (0..=last_index)
+        .filter_map(|index| {
+            let value = match known.get(&index) {
+                Some(value) => Some(*value),
+                None => fill_value(&known, index, policy),
+            }?;
+            let start_ms = index.saturating_mul(every_ms);
+            Some(Window {
+                start_ms,
+                end_ms: start_ms.saturating_add(every_ms),
+                value,
+            })
+        })
+        .collect()
+}
+
+/// The value `policy` puts in empty bucket `index`, or `None` when the policy
+/// has no neighbour to work from — a leading gap for [`Fill::Previous`], a
+/// trailing one for [`Fill::Next`], either for [`Fill::Interpolate`].
+///
+/// Neighbours are always looked up among the *recorded* buckets, never among
+/// already-filled ones, so carrying a value forward carries the last real
+/// observation rather than a copy of a copy.
+fn fill_value(known: &BTreeMap<u64, f64>, index: u64, policy: Fill) -> Option<f64> {
+    let previous = || known.range(..index).next_back().map(|(i, v)| (*i, *v));
+    let next = || known.range(index..).next().map(|(i, v)| (*i, *v));
+    match policy {
+        Fill::Value(value) => Some(value),
+        Fill::Previous => previous().map(|(_, v)| v),
+        Fill::Next => next().map(|(_, v)| v),
+        Fill::Interpolate => {
+            let (before, before_value) = previous()?;
+            let (after, after_value) = next()?;
+            let span = u32::try_from(after - before).map_or(f64::INFINITY, f64::from);
+            let offset = u32::try_from(index - before).map_or(f64::INFINITY, f64::from);
+            Some(before_value + (after_value - before_value) * (offset / span))
+        }
+    }
 }
 
 /// Trailing rolling window of `window` consecutive points.
@@ -1541,6 +1692,213 @@ mod tests {
         // Linear interpolation on rank p*(n-1): 0.99 * 99 = 98.01.
         assert!(is_close(value(Aggregator::Percentile(0.99)), 99.01));
         assert!(is_close(value(Aggregator::Percentile(0.5)), 50.5));
+    }
+
+    // --- fill ------------------------------------------------------------
+
+    /// Buckets 0 and 3 have data; 1, 2 and 4 are empty. The run ends inside
+    /// bucket 4, so the grid is 0..=4.
+    fn gapped() -> MetricSnapshot {
+        snapshot(&[("v", &[(0, 10.0), (180_000, 40.0)])], 240_000)
+    }
+
+    fn filled(policy: Fill) -> Vec<(u64, f64)> {
+        MetricQuery::select("v")
+            .bucketize(Duration::from_mins(1), Mean)
+            .fill(policy)
+            .named("q")
+            .evaluate(&gapped(), 1, 1)
+            .into_iter()
+            .map(|row| (row.bucket_start_ms / 60_000, row.value))
+            .collect()
+    }
+
+    #[test]
+    fn without_fill_a_gap_stays_a_gap() {
+        let rows = MetricQuery::select("v")
+            .bucketize(Duration::from_mins(1), Mean)
+            .named("q")
+            .evaluate(&gapped(), 1, 1);
+        assert_eq!(
+            rows.iter()
+                .map(|r| r.bucket_start_ms / 60_000)
+                .collect::<Vec<_>>(),
+            vec![0, 3],
+            "empty buckets are omitted unless a fill policy asks otherwise"
+        );
+    }
+
+    #[test]
+    fn fill_previous_carries_forward_but_invents_no_prologue() {
+        assert_eq!(
+            filled(Fill::Previous),
+            vec![(0, 10.0), (1, 10.0), (2, 10.0), (3, 40.0), (4, 40.0)],
+            "interior and trailing gaps take the last known value"
+        );
+
+        // Bucket 0 empty: nothing precedes it, so it stays empty.
+        let late = snapshot(&[("v", &[(120_000, 7.0)])], 180_000);
+        let rows = MetricQuery::select("v")
+            .bucketize(Duration::from_mins(1), Mean)
+            .fill(Fill::Previous)
+            .named("q")
+            .evaluate(&late, 1, 1);
+        assert_eq!(
+            rows.iter()
+                .map(|r| r.bucket_start_ms / 60_000)
+                .collect::<Vec<_>>(),
+            vec![2, 3],
+            "a leading gap has nothing to carry forward"
+        );
+    }
+
+    #[test]
+    fn fill_next_carries_backward_but_invents_no_epilogue() {
+        assert_eq!(
+            filled(Fill::Next),
+            vec![(0, 10.0), (1, 40.0), (2, 40.0), (3, 40.0)],
+            "interior gaps take the next known value; the trailing one stays empty"
+        );
+    }
+
+    #[test]
+    fn fill_value_covers_the_whole_grid() {
+        assert_eq!(
+            filled(Fill::Value(0.0)),
+            vec![(0, 10.0), (1, 0.0), (2, 0.0), (3, 40.0), (4, 0.0)],
+            "a constant needs no neighbour, so leading and trailing gaps fill too"
+        );
+    }
+
+    #[test]
+    fn interpolate_fills_only_between_known_values() {
+        assert_eq!(
+            filled(Fill::Interpolate),
+            vec![(0, 10.0), (1, 20.0), (2, 30.0), (3, 40.0)],
+            "linear between bucket 0 and bucket 3; nothing to interpolate after"
+        );
+    }
+
+    #[test]
+    fn interpolation_walks_the_recorded_neighbours_not_the_filled_ones() {
+        // 0 → 100 over four buckets must step by 25, which it only does if
+        // each gap looks back at bucket 0 rather than at the value just
+        // synthesized for the bucket before it.
+        let snap = snapshot(&[("v", &[(0, 0.0), (240_000, 100.0)])], 240_000);
+        let values: Vec<f64> = MetricQuery::select("v")
+            .bucketize(Duration::from_mins(1), Mean)
+            .fill(Fill::Interpolate)
+            .named("q")
+            .evaluate(&snap, 1, 1)
+            .into_iter()
+            .map(|row| row.value)
+            .collect();
+        assert_eq!(values.len(), 5);
+        for (i, value) in values.iter().enumerate() {
+            let expected = 25.0 * u32::try_from(i).map_or(f64::INFINITY, f64::from);
+            assert!(is_close(*value, expected), "bucket {i}: {value}");
+        }
+    }
+
+    #[test]
+    fn fill_extends_the_grid_to_the_end_of_the_run() {
+        // All the data is in the first minute, but the run lasted five.
+        let snap = snapshot(&[("v", &[(0, 3.0)])], 300_000);
+        let rows = MetricQuery::select("v")
+            .bucketize(Duration::from_mins(1), Mean)
+            .fill(Fill::Value(0.0))
+            .named("q")
+            .evaluate(&snap, 1, 1);
+        assert_eq!(rows.len(), 6, "the silence gets buckets too");
+        assert!(is_close(rows[5].value, 0.0));
+        assert_eq!(rows[5].bucket_start_ms, 300_000);
+    }
+
+    #[test]
+    fn filling_a_series_that_never_reported_stays_empty() {
+        // No observations at all: there is nothing to have holes in, and a
+        // policy alone must not conjure a series the run never touched.
+        let snap = snapshot(&[("other", &[(0, 1.0)])], 120_000);
+        let rows = MetricQuery::select("v")
+            .bucketize(Duration::from_mins(1), Mean)
+            .fill(Fill::Value(0.0))
+            .named("q")
+            .evaluate(&snap, 1, 1);
+        assert!(rows.is_empty());
+    }
+
+    #[test]
+    fn fill_without_bucketize_does_nothing() {
+        let snap = snapshot(&[("v", &[(0, 1.0), (5_000, 2.0)])], 10_000);
+        let rows = MetricQuery::select("v")
+            .fill(Fill::Value(0.0))
+            .named("q")
+            .evaluate(&snap, 1, 1);
+        assert_eq!(rows.len(), 2, "no grid means no empty buckets to fill");
+    }
+
+    #[test]
+    fn fill_preserves_the_stage_so_percentiles_stay_gated() {
+        let quantile = MetricQuery::select("v")
+            .bucketize(Duration::from_mins(1), Percentile(0.99))
+            .fill(Fill::Previous)
+            .named("q");
+        assert_eq!(
+            quantile.provenance(),
+            Provenance::Quantile,
+            "filling neither collapses nor restores a distribution"
+        );
+        assert_eq!(
+            quantile.description(),
+            "v → 60s buckets (p99) → fill (previous)"
+        );
+    }
+
+    #[test]
+    fn filling_puts_every_seed_on_the_same_windows() {
+        let plan = MetricQuery::select("v")
+            .bucketize(Duration::from_mins(1), Mean)
+            .fill(Fill::Value(0.0))
+            .named("q");
+        // Two seeds busy in different minutes of a three-minute run.
+        let rows: Vec<MetricQueryRow> = [(1u64, 0u64), (2, 120_000)]
+            .iter()
+            .flat_map(|(seed, at_ms)| {
+                let snap = snapshot(&[("v", &[(*at_ms, 5.0)])], 180_000);
+                plan.evaluate(&snap, 7, *seed)
+            })
+            .collect();
+        let report = MetricQueryReport::from_rows(&plan, rows);
+
+        assert_eq!(report.windows.len(), 4, "one window per bucket of the grid");
+        assert!(
+            report.windows.iter().all(|w| w.runs == 2),
+            "every window has both runs in it, so min/max compare like for like"
+        );
+        // Bucket 0: seed 1 saw 5, seed 2 saw nothing (filled to 0).
+        assert!(is_close(report.windows[0].min, 0.0));
+        assert_eq!(report.windows[0].min_seed, 2);
+        assert!(is_close(report.windows[0].max, 5.0));
+        assert_eq!(report.windows[0].max_seed, 1);
+    }
+
+    #[test]
+    fn unfilled_windows_fragment_the_summary() {
+        // The same two seeds without a fill: each bucket has one run in it,
+        // which is exactly the reporting problem fill exists to solve.
+        let plan = MetricQuery::select("v")
+            .bucketize(Duration::from_mins(1), Mean)
+            .named("q");
+        let rows: Vec<MetricQueryRow> = [(1u64, 0u64), (2, 120_000)]
+            .iter()
+            .flat_map(|(seed, at_ms)| {
+                let snap = snapshot(&[("v", &[(*at_ms, 5.0)])], 180_000);
+                plan.evaluate(&snap, 7, *seed)
+            })
+            .collect();
+        let report = MetricQueryReport::from_rows(&plan, rows);
+        assert_eq!(report.windows.len(), 2);
+        assert!(report.windows.iter().all(|w| w.runs == 1));
     }
 
     // --- map -------------------------------------------------------------

--- a/crates/moonpool-core/src/metrics/query.rs
+++ b/crates/moonpool-core/src/metrics/query.rs
@@ -1,0 +1,1868 @@
+//! Typed metric queries over one run's recorded series.
+//!
+//! [`SeriesRecorder`](super::SeriesRecorder) gives every simulation run an
+//! exact history of each metric: one [`MetricPoint`] per `inc()` / `set()` /
+//! `observe()`, stamped with the simulated clock. That is enough to answer
+//! real questions — "what throughput did this seed sustain?", "which seed had
+//! the worst p99?" — but only if something turns points into numbers. This
+//! module is that something.
+//!
+//! The vocabulary is Warp 10's, cut down to what a simulation report needs:
+//!
+//! | Op | Meaning |
+//! |----|---------|
+//! | `SELECT` | pick series by metric name and label matchers |
+//! | `RATE` | monotonic counter → per-second rate, on simulated time |
+//! | `BUCKETIZE` | regularize points into fixed simulated-time buckets |
+//! | `MAP` | rolling window over one series' points |
+//! | `REDUCE` | combine across series, optionally grouped by a label |
+//!
+//! There is no expression language, no parser and no storage engine: a query
+//! is a Rust value built by a typed builder, and it runs against the
+//! [`MetricSnapshot`] one simulation iteration produced.
+//!
+//! ```
+//! use std::time::Duration;
+//! use moonpool_core::metrics::query::{Mean, MetricQuery, Percentile};
+//!
+//! let throughput = MetricQuery::select("requests_total")
+//!     .label("operation", "write")
+//!     .rate()
+//!     .bucketize(Duration::from_secs(60), Mean)
+//!     .named("write_throughput");
+//!
+//! let tail = MetricQuery::select("request_latency_seconds")
+//!     .bucketize(Duration::from_secs(60), Percentile(0.99))
+//!     .named("write_p99");
+//!
+//! assert_eq!(throughput.name(), "write_throughput");
+//! assert_eq!(tail.name(), "write_p99");
+//! ```
+//!
+//! # Percentile correctness
+//!
+//! `mean(p99(node_a), p99(node_b))` is not a p99, and `p99(p99(a), p99(b))` is
+//! not one either. A percentile is only meaningful while the individual
+//! observations beneath it are still there, so the builder tracks what each
+//! stage's values *are* in the type system:
+//!
+//! | Stage | Values are | `Percentile` allowed? |
+//! |-------|-----------|-----------------------|
+//! | [`Observations`] | individual observations (or rates between consecutive ones) | yes |
+//! | [`Scalar`] | already collapsed by min/mean/max | no |
+//! | [`Quantile`] | already collapsed by a percentile | no |
+//!
+//! [`Min`], [`Mean`] and [`Max`] apply at any stage — "the mean of each node's
+//! p99" is a fine number as long as nobody calls it a p99, and the report
+//! labels it by the query's [`Provenance`]. [`Percentile`] only implements
+//! [`ValidOn<Observations>`], so the invalid compositions fail to compile:
+//!
+//! ```compile_fail
+//! use std::time::Duration;
+//! use moonpool_core::metrics::query::{MetricQuery, Percentile};
+//!
+//! // p99 of per-bucket p99s: rejected, the observations are already gone.
+//! MetricQuery::select("request_latency_seconds")
+//!     .bucketize(Duration::from_secs(60), Percentile(0.99))
+//!     .reduce(Percentile(0.99))
+//!     .named("nonsense");
+//! ```
+//!
+//! ```compile_fail
+//! use std::time::Duration;
+//! use moonpool_core::metrics::query::{Mean, MetricQuery, Percentile};
+//!
+//! // p99 of per-bucket means: rejected for the same reason.
+//! MetricQuery::select("request_latency_seconds")
+//!     .bucketize(Duration::from_secs(60), Mean)
+//!     .reduce(Percentile(0.99))
+//!     .named("nonsense");
+//! ```
+//!
+//! Aggregating *across runs* is a different dimension and stays legitimate:
+//! each seed contributes one equally-weighted value, so "the p95 seed's p99
+//! latency" is a real statistic. [`MetricQueryReport`] computes it and names
+//! it as across-run.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+use std::marker::PhantomData;
+use std::time::Duration;
+
+use super::{MetricPoint, MetricSample};
+
+// ---------------------------------------------------------------------------
+// Series identity
+// ---------------------------------------------------------------------------
+
+/// A Prometheus series identity: a metric name plus a label set.
+///
+/// Labels are kept sorted by key, so two label sets that differ only in
+/// insertion order are the same series. [`Display`](fmt::Display) renders the
+/// canonical form `name{key="value",...}` — byte-identical to
+/// [`MetricSample::sort_key`], which is what recorded series are keyed by.
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SeriesKey {
+    /// Metric name, e.g. `http_requests_total`.
+    pub metric: String,
+    /// Label pairs, sorted by key.
+    pub labels: Vec<(String, String)>,
+}
+
+impl SeriesKey {
+    /// Build a key, sorting `labels` into canonical order.
+    #[must_use]
+    pub fn new(metric: impl Into<String>, mut labels: Vec<(String, String)>) -> Self {
+        labels.sort();
+        Self {
+            metric: metric.into(),
+            labels,
+        }
+    }
+
+    /// Parse the canonical `name{key="value",...}` form.
+    ///
+    /// Anything that is not that shape is taken as a bare metric name with no
+    /// labels. Label values are not unescaped: moonpool's own key formatter
+    /// does not escape them either, so a value containing `,` or `"` round
+    /// trips inexactly — keep such characters out of label values.
+    #[must_use]
+    pub fn parse(key: &str) -> Self {
+        let Some((metric, rest)) = key.split_once('{') else {
+            return Self::new(key, Vec::new());
+        };
+        let Some(inner) = rest.strip_suffix('}') else {
+            return Self::new(key, Vec::new());
+        };
+        let labels = inner
+            .split(',')
+            .filter(|part| !part.is_empty())
+            .filter_map(|part| {
+                let (k, v) = part.split_once('=')?;
+                let v = v.trim_matches('"');
+                Some((k.to_owned(), v.to_owned()))
+            })
+            .collect();
+        Self::new(metric, labels)
+    }
+
+    /// The value of `key`, when this series carries that label.
+    #[must_use]
+    pub fn label(&self, key: &str) -> Option<&str> {
+        self.labels
+            .iter()
+            .find(|(k, _)| k == key)
+            .map(|(_, v)| v.as_str())
+    }
+
+    /// Whether this series has `metric` as its name and carries every matcher.
+    ///
+    /// Matching is by subset: a series may carry labels the query does not
+    /// mention, but every label the query names must be present with exactly
+    /// that value.
+    #[must_use]
+    pub fn matches(&self, metric: &str, matchers: &[(String, String)]) -> bool {
+        self.metric == metric
+            && matchers
+                .iter()
+                .all(|(k, v)| self.label(k).is_some_and(|found| found == v))
+    }
+}
+
+impl fmt::Display for SeriesKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.metric)?;
+        if self.labels.is_empty() {
+            return Ok(());
+        }
+        f.write_str("{")?;
+        for (i, (k, v)) in self.labels.iter().enumerate() {
+            if i > 0 {
+                f.write_str(",")?;
+            }
+            write!(f, "{k}=\"{v}\"")?;
+        }
+        f.write_str("}")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot
+// ---------------------------------------------------------------------------
+
+/// Every series one simulation run produced, in query-ready form.
+///
+/// Built from a run's recorded series plus its end-of-run scrape. A series the
+/// application recorded through instrumented handles keeps its full history; a
+/// series that only appears in the scrape (a foreign registry, a `lazy_static!`
+/// global) contributes a single point at the run's end time, which is enough
+/// for [`rate`](MetricQuery::rate) to read as "this much, over the whole run".
+#[derive(Debug, Clone, Default)]
+pub struct MetricSnapshot {
+    series: BTreeMap<SeriesKey, Vec<MetricPoint>>,
+    end_time_ms: u64,
+}
+
+impl MetricSnapshot {
+    /// An empty snapshot for a run that ended at `end_time_ms`.
+    #[must_use]
+    pub fn new(end_time_ms: u64) -> Self {
+        Self {
+            series: BTreeMap::new(),
+            end_time_ms,
+        }
+    }
+
+    /// Build a snapshot from one iteration's metrics.
+    ///
+    /// `series` is keyed by [`MetricSample::sort_key`] (what
+    /// `SimulationMetrics::app_series` holds); `samples` is the end-of-run
+    /// scrape. Recorded series win, and any scraped series without a recorded
+    /// history is added as a single end-of-run point.
+    #[must_use]
+    pub fn from_run(
+        samples: &[MetricSample],
+        series: &BTreeMap<String, Vec<MetricPoint>>,
+        end_time_ms: u64,
+    ) -> Self {
+        let mut snapshot = Self::new(end_time_ms);
+        for (key, points) in series {
+            snapshot.insert(SeriesKey::parse(key), points.clone());
+        }
+        for sample in samples {
+            let key = SeriesKey::new(sample.name.clone(), sample.labels.clone());
+            if !snapshot.series.contains_key(&key) {
+                snapshot.insert(
+                    key,
+                    vec![MetricPoint {
+                        time_ms: end_time_ms,
+                        value: sample.value.scalar(),
+                    }],
+                );
+            }
+        }
+        snapshot
+    }
+
+    /// Add or replace one series' points, sorting them ascending in time.
+    pub fn insert(&mut self, key: SeriesKey, mut points: Vec<MetricPoint>) {
+        points.sort_by_key(|p| p.time_ms);
+        self.series.insert(key, points);
+    }
+
+    /// Simulated time the run ended at, in milliseconds.
+    #[must_use]
+    pub fn end_time_ms(&self) -> u64 {
+        self.end_time_ms
+    }
+
+    /// Whether the snapshot holds no series at all.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.series.is_empty()
+    }
+
+    /// The series matching `metric` and every matcher, in canonical key order.
+    #[must_use]
+    pub fn select(&self, metric: &str, matchers: &[(String, String)]) -> Vec<&SeriesKey> {
+        self.series
+            .keys()
+            .filter(|key| key.matches(metric, matchers))
+            .collect()
+    }
+
+    /// The points recorded for one series.
+    #[must_use]
+    pub fn points(&self, key: &SeriesKey) -> Option<&[MetricPoint]> {
+        self.series.get(key).map(Vec::as_slice)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Aggregators
+// ---------------------------------------------------------------------------
+
+/// The four aggregations a query can apply, as a runtime value.
+///
+/// Queries name them through the marker types [`Min`], [`Mean`], [`Max`] and
+/// [`Percentile`], which additionally carry what the result means for
+/// percentile composition; this enum is what the compiled plan stores.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Aggregator {
+    /// Smallest value.
+    Min,
+    /// Arithmetic mean.
+    Mean,
+    /// Largest value.
+    Max,
+    /// Percentile at the given rank in `[0.0, 1.0]`, linearly interpolated.
+    Percentile(f64),
+}
+
+impl Aggregator {
+    /// Apply to a non-empty set of values; `None` when `values` is empty.
+    #[must_use]
+    pub fn apply(self, values: &[f64]) -> Option<f64> {
+        if values.is_empty() {
+            return None;
+        }
+        Some(match self {
+            Self::Min => values.iter().copied().fold(f64::INFINITY, f64::min),
+            Self::Max => values.iter().copied().fold(f64::NEG_INFINITY, f64::max),
+            Self::Mean => mean(values),
+            Self::Percentile(p) => {
+                let mut sorted = values.to_vec();
+                sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+                percentile_of_sorted(&sorted, p)
+            }
+        })
+    }
+
+    /// What applying this aggregator leaves behind.
+    #[must_use]
+    pub fn provenance(self) -> Provenance {
+        match self {
+            Self::Min | Self::Mean | Self::Max => Provenance::Scalar,
+            Self::Percentile(_) => Provenance::Quantile,
+        }
+    }
+
+    /// Short label for reports, e.g. `mean` or `p99`.
+    #[must_use]
+    pub fn label(self) -> String {
+        match self {
+            Self::Min => "min".to_owned(),
+            Self::Mean => "mean".to_owned(),
+            Self::Max => "max".to_owned(),
+            Self::Percentile(p) => format!("p{}", trim_float(p * 100.0)),
+        }
+    }
+}
+
+/// Arithmetic mean of a non-empty slice.
+fn mean(values: &[f64]) -> f64 {
+    let n = u32::try_from(values.len()).map_or(f64::INFINITY, f64::from);
+    values.iter().sum::<f64>() / n
+}
+
+/// Percentile of an already-sorted slice, linearly interpolated between the
+/// two neighbours of rank `p * (n - 1)`.
+///
+/// `p` is clamped to `[0.0, 1.0]`; a NaN rank reads as `0.0`.
+fn percentile_of_sorted(sorted: &[f64], p: f64) -> f64 {
+    debug_assert!(!sorted.is_empty(), "caller checked for emptiness");
+    let p = if p.is_nan() { 0.0 } else { p.clamp(0.0, 1.0) };
+    let last = sorted.len() - 1;
+    let last_f = u32::try_from(last).map_or(f64::INFINITY, f64::from);
+    let rank = p * last_f;
+    let lower = rank.floor();
+    let upper = rank.ceil();
+    // SAFETY-adjacent: `rank` is finite and within `[0, last]`, so both bounds
+    // index the slice. `f64 as usize` saturates, and `min(last)` pins it.
+    let lower_idx = f64_to_index(lower).min(last);
+    let upper_idx = f64_to_index(upper).min(last);
+    if lower_idx == upper_idx {
+        return sorted[lower_idx];
+    }
+    let weight = rank - lower;
+    sorted[lower_idx] + (sorted[upper_idx] - sorted[lower_idx]) * weight
+}
+
+/// Convert a non-negative finite `f64` to an index, saturating at `usize::MAX`.
+fn f64_to_index(v: f64) -> usize {
+    if !v.is_finite() || v <= 0.0 {
+        0
+    } else {
+        // Ranks are bounded by the slice length, so a plain cast is exact here.
+        // `usize::try_from` on the u64 form keeps the conversion lint-clean.
+        usize::try_from(f64_to_u64(v)).unwrap_or(usize::MAX)
+    }
+}
+
+/// Truncate a non-negative finite `f64` to `u64`, saturating.
+fn f64_to_u64(v: f64) -> u64 {
+    const TWO_POW_64: f64 = 18_446_744_073_709_551_616.0;
+    if !v.is_finite() || v <= 0.0 {
+        0
+    } else if v >= TWO_POW_64 {
+        u64::MAX
+    } else {
+        // SAFETY: `v` is finite, non-negative and strictly below `2^64`.
+        unsafe { v.to_int_unchecked::<u64>() }
+    }
+}
+
+/// Render a float without a trailing `.0`, so `p99` beats `p99.0`.
+fn trim_float(v: f64) -> String {
+    let s = format!("{v:.4}");
+    let s = s.trim_end_matches('0').trim_end_matches('.');
+    if s.is_empty() {
+        "0".to_owned()
+    } else {
+        s.to_owned()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Stages and type-level percentile enforcement
+// ---------------------------------------------------------------------------
+
+mod sealed {
+    /// Prevents downstream crates from adding stages or aggregators, which
+    /// would let them route around the percentile rule.
+    pub trait Sealed {}
+}
+
+/// What the values flowing through a query stage still represent.
+///
+/// Carried on [`MetricQueryPlan`] so the report can label a number honestly:
+/// a [`Quantile`](Provenance::Quantile) result is a percentile, a
+/// [`Scalar`](Provenance::Scalar) one is not.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Provenance {
+    /// Individual observations, or rates between consecutive ones. The
+    /// distribution is intact, so a percentile over them is exact.
+    Observations,
+    /// Values collapsed by min, mean or max. The distribution is gone.
+    Scalar,
+    /// Values collapsed by a percentile. The distribution is gone, and the
+    /// values are already order statistics of it.
+    Quantile,
+}
+
+impl Provenance {
+    /// Short label for reports.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Observations => "observations",
+            Self::Scalar => "scalar",
+            Self::Quantile => "percentile-derived",
+        }
+    }
+}
+
+/// A stage of a query pipeline, as a type. See [`Provenance`].
+pub trait Stage: sealed::Sealed {
+    /// What values at this stage represent.
+    const PROVENANCE: Provenance;
+}
+
+/// Stage marker: values are individual observations — percentile-capable.
+#[derive(Debug, Clone, Copy)]
+pub struct Observations;
+
+/// Stage marker: values were collapsed by min, mean or max.
+#[derive(Debug, Clone, Copy)]
+pub struct Scalar;
+
+/// Stage marker: values were collapsed by a percentile.
+#[derive(Debug, Clone, Copy)]
+pub struct Quantile;
+
+impl sealed::Sealed for Observations {}
+impl sealed::Sealed for Scalar {}
+impl sealed::Sealed for Quantile {}
+
+impl Stage for Observations {
+    const PROVENANCE: Provenance = Provenance::Observations;
+}
+impl Stage for Scalar {
+    const PROVENANCE: Provenance = Provenance::Scalar;
+}
+impl Stage for Quantile {
+    const PROVENANCE: Provenance = Provenance::Quantile;
+}
+
+/// Aggregator marker: smallest value.
+#[derive(Debug, Clone, Copy)]
+pub struct Min;
+
+/// Aggregator marker: arithmetic mean.
+#[derive(Debug, Clone, Copy)]
+pub struct Mean;
+
+/// Aggregator marker: largest value.
+#[derive(Debug, Clone, Copy)]
+pub struct Max;
+
+/// Aggregator marker: percentile at rank `p` in `[0.0, 1.0]`.
+///
+/// Only implements [`ValidOn<Observations>`], which is what keeps
+/// percentile-of-percentile from compiling.
+#[derive(Debug, Clone, Copy)]
+pub struct Percentile(pub f64);
+
+impl sealed::Sealed for Min {}
+impl sealed::Sealed for Mean {}
+impl sealed::Sealed for Max {}
+impl sealed::Sealed for Percentile {}
+
+/// An aggregation the query builder accepts, and the stage it produces.
+pub trait Aggregate: sealed::Sealed + Copy {
+    /// The stage values are in after this aggregation.
+    type Out: Stage;
+
+    /// The runtime aggregator this marker compiles to.
+    fn aggregator(self) -> Aggregator;
+}
+
+impl Aggregate for Min {
+    type Out = Scalar;
+    fn aggregator(self) -> Aggregator {
+        Aggregator::Min
+    }
+}
+
+impl Aggregate for Mean {
+    type Out = Scalar;
+    fn aggregator(self) -> Aggregator {
+        Aggregator::Mean
+    }
+}
+
+impl Aggregate for Max {
+    type Out = Scalar;
+    fn aggregator(self) -> Aggregator {
+        Aggregator::Max
+    }
+}
+
+impl Aggregate for Percentile {
+    type Out = Quantile;
+    fn aggregator(self) -> Aggregator {
+        Aggregator::Percentile(self.0)
+    }
+}
+
+/// Marker: aggregation `Self` is mathematically valid on values at stage `S`.
+///
+/// [`Min`], [`Mean`] and [`Max`] are valid everywhere. [`Percentile`] is valid
+/// only on [`Observations`], because a percentile of already-collapsed values
+/// is not a percentile of the distribution they came from.
+pub trait ValidOn<S: Stage>: Aggregate {}
+
+impl<S: Stage> ValidOn<S> for Min {}
+impl<S: Stage> ValidOn<S> for Mean {}
+impl<S: Stage> ValidOn<S> for Max {}
+impl ValidOn<Observations> for Percentile {}
+
+// ---------------------------------------------------------------------------
+// Query builder
+// ---------------------------------------------------------------------------
+
+/// One step of a compiled query, applied in the order it was declared.
+#[derive(Debug, Clone, PartialEq)]
+enum QueryOp {
+    Rate,
+    Bucketize { every_ms: u64, agg: Aggregator },
+    Map { window: usize, agg: Aggregator },
+    Reduce { by: Option<String>, agg: Aggregator },
+}
+
+/// A metric query under construction.
+///
+/// `S` tracks what the values currently are, which is what gates
+/// [`Percentile`] — see the [module docs](self). Build with
+/// [`select`](Self::select) and finish with [`named`](Self::named), which
+/// erases the stage into a [`MetricQueryPlan`].
+#[derive(Debug, Clone)]
+pub struct MetricQuery<S: Stage = Observations> {
+    metric: String,
+    matchers: Vec<(String, String)>,
+    ops: Vec<QueryOp>,
+    // `fn() -> S` so the query stays `Send + Sync` whatever the marker is.
+    stage: PhantomData<fn() -> S>,
+}
+
+impl MetricQuery<Observations> {
+    /// Start a query selecting every series named `metric`.
+    #[must_use]
+    pub fn select(metric: impl Into<String>) -> Self {
+        Self {
+            metric: metric.into(),
+            matchers: Vec::new(),
+            ops: Vec::new(),
+            stage: PhantomData,
+        }
+    }
+
+    /// Narrow the selection to series carrying `key="value"`.
+    ///
+    /// Matching is by subset — a series may carry other labels — and repeating
+    /// this method ANDs the matchers together.
+    #[must_use]
+    pub fn label(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.matchers.push((key.into(), value.into()));
+        self.matchers.sort();
+        self
+    }
+
+    /// Read the selected series as monotonically increasing counters and turn
+    /// them into a per-second rate on the simulated clock.
+    ///
+    /// Counter semantics are explicit here and nowhere else: no other stage
+    /// infers them, so `bucketize(_, Mean)` on a raw counter honestly reports
+    /// the mean *cumulative value*, not a rate.
+    ///
+    /// Each consecutive pair of points becomes one rate over the interval
+    /// between them. A drop in value is read as a counter reset, Prometheus
+    /// style: the new value is taken as the whole delta rather than producing
+    /// a negative rate. Because the simulation builds a fresh metrics source
+    /// per iteration, every counter is zero at simulated time zero, so an
+    /// implicit origin point is prepended and the very first increment is
+    /// rated too.
+    #[must_use]
+    pub fn rate(mut self) -> Self {
+        self.ops.push(QueryOp::Rate);
+        self
+    }
+
+    /// Regularize each series' points into fixed simulated-time buckets,
+    /// aggregating the points that fall in each.
+    ///
+    /// A point belongs to bucket `n` when its timestamp is in
+    /// `[n * every, (n + 1) * every)`; for a rate, the timestamp is the end of
+    /// the interval the rate covers. Empty buckets are omitted rather than
+    /// zero-filled — a gap is a gap, not a zero.
+    ///
+    /// Only available before any aggregation: bucketizing already-collapsed
+    /// values would double-aggregate them.
+    #[must_use]
+    pub fn bucketize<A>(mut self, every: Duration, agg: A) -> MetricQuery<A::Out>
+    where
+        A: ValidOn<Observations>,
+    {
+        let every_ms = u64::try_from(every.as_millis()).unwrap_or(u64::MAX).max(1);
+        self.ops.push(QueryOp::Bucketize {
+            every_ms,
+            agg: agg.aggregator(),
+        });
+        self.retag()
+    }
+}
+
+impl<S: Stage> MetricQuery<S> {
+    /// Re-tag the stage marker after an op that changes what values represent.
+    fn retag<T: Stage>(self) -> MetricQuery<T> {
+        MetricQuery {
+            metric: self.metric,
+            matchers: self.matchers,
+            ops: self.ops,
+            stage: PhantomData,
+        }
+    }
+
+    /// Aggregate over a rolling window of `window` consecutive points of each
+    /// series, one output per position where a full window is available.
+    ///
+    /// The output point spans from the first point of the window to the last,
+    /// so a rolling mean over 60s buckets keeps bucket-aligned boundaries. A
+    /// window of `0`, or one longer than the series, produces nothing.
+    #[must_use]
+    pub fn map<A>(mut self, window: usize, agg: A) -> MetricQuery<A::Out>
+    where
+        A: ValidOn<S>,
+    {
+        self.ops.push(QueryOp::Map {
+            window,
+            agg: agg.aggregator(),
+        });
+        self.retag()
+    }
+
+    /// Combine every selected series into one.
+    ///
+    /// After [`bucketize`](Self::bucketize) the series are aligned, so values
+    /// are combined bucket by bucket and the buckets survive. Without it there
+    /// is no shared time grid, so every value of every series is pooled into a
+    /// single whole-run result ([`WHOLE_RUN_MS`] bounds) — which is how a
+    /// global p99 across nodes is expressed.
+    #[must_use]
+    pub fn reduce<A>(mut self, agg: A) -> MetricQuery<A::Out>
+    where
+        A: ValidOn<S>,
+    {
+        self.ops.push(QueryOp::Reduce {
+            by: None,
+            agg: agg.aggregator(),
+        });
+        self.retag()
+    }
+
+    /// Combine series that share the same value of `label`, keeping one result
+    /// series per distinct value.
+    ///
+    /// Alignment works as in [`reduce`](Self::reduce). Series that do not
+    /// carry `label` at all are dropped — there is no group to put them in,
+    /// which includes every series a previous reduce already collapsed, since
+    /// those no longer carry the original label set.
+    #[must_use]
+    pub fn reduce_by<A>(mut self, label: impl Into<String>, agg: A) -> MetricQuery<A::Out>
+    where
+        A: ValidOn<S>,
+    {
+        self.ops.push(QueryOp::Reduce {
+            by: Some(label.into()),
+            agg: agg.aggregator(),
+        });
+        self.retag()
+    }
+
+    /// Finish the query, naming it for the report.
+    #[must_use]
+    pub fn named(self, name: impl Into<String>) -> MetricQueryPlan {
+        MetricQueryPlan {
+            name: name.into(),
+            metric: self.metric,
+            matchers: self.matchers,
+            ops: self.ops,
+            provenance: S::PROVENANCE,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Compiled plan
+// ---------------------------------------------------------------------------
+
+/// A finished, stage-erased query, ready to evaluate against any run.
+///
+/// Registered on the runner with `SimulationBuilder::metric` and evaluated
+/// once per successful seed.
+#[derive(Debug, Clone)]
+pub struct MetricQueryPlan {
+    name: String,
+    metric: String,
+    matchers: Vec<(String, String)>,
+    ops: Vec<QueryOp>,
+    provenance: Provenance,
+}
+
+impl MetricQueryPlan {
+    /// The name this query reports under.
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// The metric name this query selects.
+    #[must_use]
+    pub fn metric(&self) -> &str {
+        &self.metric
+    }
+
+    /// What the query's values represent, for honest labelling.
+    #[must_use]
+    pub fn provenance(&self) -> Provenance {
+        self.provenance
+    }
+
+    /// One-line rendering of the pipeline, e.g.
+    /// `requests_total{operation="write"} → rate → 60s buckets (mean)`.
+    #[must_use]
+    pub fn description(&self) -> String {
+        let selector = SeriesKey::new(self.metric.clone(), self.matchers.clone()).to_string();
+        std::iter::once(selector)
+            .chain(self.ops.iter().map(|op| match op {
+                QueryOp::Rate => "rate".to_owned(),
+                QueryOp::Bucketize { every_ms, agg } => {
+                    format!("{} buckets ({})", fmt_millis(*every_ms), agg.label())
+                }
+                QueryOp::Map { window, agg } => format!("map {window} ({})", agg.label()),
+                QueryOp::Reduce { by: None, agg } => format!("reduce ({})", agg.label()),
+                QueryOp::Reduce {
+                    by: Some(label),
+                    agg,
+                } => {
+                    format!("reduce by {label} ({})", agg.label())
+                }
+            }))
+            .collect::<Vec<_>>()
+            .join(" → ")
+    }
+
+    /// Evaluate against one run's snapshot.
+    ///
+    /// Rows come back in deterministic order — by group, then by window — and
+    /// each carries the `run_id` and `seed` that produced it, so a bad value
+    /// is replayable without any further bookkeeping.
+    #[must_use]
+    pub fn evaluate(
+        &self,
+        snapshot: &MetricSnapshot,
+        run_id: u64,
+        seed: u64,
+    ) -> Vec<MetricQueryRow> {
+        let mut state = EvalState::select(snapshot, &self.metric, &self.matchers);
+        for op in &self.ops {
+            state.apply(op);
+        }
+        let mut rows: Vec<MetricQueryRow> = state
+            .series
+            .into_iter()
+            .flat_map(|series| {
+                let group = series.group.clone();
+                series.windows.into_iter().map(move |w| MetricQueryRow {
+                    run_id,
+                    seed,
+                    query: self.name.clone(),
+                    group: group.clone(),
+                    bucket_start_ms: w.start_ms,
+                    bucket_end_ms: w.end_ms,
+                    value: w.value,
+                })
+            })
+            .collect();
+        rows.sort_by(row_order);
+        rows
+    }
+}
+
+/// Format a bucket width in the shortest exact unit, e.g. `60s` or `1500ms`.
+fn fmt_millis(ms: u64) -> String {
+    if ms.is_multiple_of(1000) {
+        format!("{}s", ms / 1000)
+    } else {
+        format!("{ms}ms")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Evaluation
+// ---------------------------------------------------------------------------
+
+/// Window bounds for a value that covers a whole run rather than a slice of
+/// one. See [`MetricQueryRow::bucket_start_ms`].
+pub const WHOLE_RUN_MS: u64 = 0;
+
+/// One value covering a half-open simulated-time window `[start_ms, end_ms)`.
+///
+/// A raw observation has `start_ms == end_ms`: it happened at an instant.
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct Window {
+    start_ms: u64,
+    end_ms: u64,
+    value: f64,
+}
+
+/// One logical series while a query runs.
+#[derive(Debug, Clone)]
+struct EvalSeries {
+    /// `None` once the series has been reduced away into a single result.
+    group: Option<String>,
+    windows: Vec<Window>,
+}
+
+/// The working set a query pipeline transforms.
+struct EvalState {
+    series: Vec<EvalSeries>,
+    /// True while every series sits on the same bucket grid, which is what
+    /// makes a bucket-by-bucket [`QueryOp::Reduce`] meaningful.
+    aligned: bool,
+}
+
+impl EvalState {
+    fn select(snapshot: &MetricSnapshot, metric: &str, matchers: &[(String, String)]) -> Self {
+        let series = snapshot
+            .select(metric, matchers)
+            .into_iter()
+            .map(|key| EvalSeries {
+                group: Some(key.to_string()),
+                windows: snapshot
+                    .points(key)
+                    .unwrap_or_default()
+                    .iter()
+                    .map(|p| Window {
+                        start_ms: p.time_ms,
+                        end_ms: p.time_ms,
+                        value: p.value,
+                    })
+                    .collect(),
+            })
+            .collect();
+        Self {
+            series,
+            aligned: false,
+        }
+    }
+
+    fn apply(&mut self, op: &QueryOp) {
+        match op {
+            QueryOp::Rate => {
+                for s in &mut self.series {
+                    s.windows = rate(&s.windows);
+                }
+                self.aligned = false;
+            }
+            QueryOp::Bucketize { every_ms, agg } => {
+                for s in &mut self.series {
+                    s.windows = bucketize(&s.windows, *every_ms, *agg);
+                }
+                self.aligned = true;
+            }
+            QueryOp::Map { window, agg } => {
+                for s in &mut self.series {
+                    s.windows = rolling_map(&s.windows, *window, *agg);
+                }
+            }
+            QueryOp::Reduce { by, agg } => self.reduce(by.as_deref(), *agg),
+        }
+        self.series.retain(|s| !s.windows.is_empty());
+    }
+
+    fn reduce(&mut self, by: Option<&str>, agg: Aggregator) {
+        // Group series: everything into one, or one group per label value.
+        let mut groups: BTreeMap<Option<String>, Vec<&EvalSeries>> = BTreeMap::new();
+        for s in &self.series {
+            let group = match by {
+                None => None,
+                Some(label) => {
+                    let Some(key) = s.group.as_ref().map(|g| SeriesKey::parse(g)) else {
+                        continue;
+                    };
+                    let Some(value) = key.label(label) else {
+                        continue;
+                    };
+                    Some(value.to_owned())
+                }
+            };
+            groups.entry(group).or_default().push(s);
+        }
+
+        let aligned = self.aligned;
+        self.series = groups
+            .into_iter()
+            .map(|(group, members)| EvalSeries {
+                group,
+                windows: combine(&members, aligned, agg),
+            })
+            .collect();
+    }
+}
+
+/// Combine several series into one, bucket by bucket when they share a grid
+/// and by pooling every value otherwise.
+fn combine(members: &[&EvalSeries], aligned: bool, agg: Aggregator) -> Vec<Window> {
+    if aligned {
+        let mut windows: BTreeSet<(u64, u64)> = BTreeSet::new();
+        for s in members {
+            for w in &s.windows {
+                windows.insert((w.start_ms, w.end_ms));
+            }
+        }
+        return windows
+            .into_iter()
+            .filter_map(|(start_ms, end_ms)| {
+                let values: Vec<f64> = members
+                    .iter()
+                    .flat_map(|s| s.windows.iter())
+                    .filter(|w| w.start_ms == start_ms && w.end_ms == end_ms)
+                    .map(|w| w.value)
+                    .collect();
+                agg.apply(&values).map(|value| Window {
+                    start_ms,
+                    end_ms,
+                    value,
+                })
+            })
+            .collect();
+    }
+
+    let values: Vec<f64> = members
+        .iter()
+        .flat_map(|s| s.windows.iter())
+        .map(|w| w.value)
+        .collect();
+    // A pooled reduce covers the whole run, so it gets the whole-run window
+    // rather than the span its observations happened to occupy. Those spans
+    // differ from seed to seed, and stamping them here would split the
+    // across-run summary into one single-run window per seed.
+    agg.apply(&values)
+        .map(|value| {
+            vec![Window {
+                start_ms: WHOLE_RUN_MS,
+                end_ms: WHOLE_RUN_MS,
+                value,
+            }]
+        })
+        .unwrap_or_default()
+}
+
+/// Per-second rate between consecutive counter readings.
+///
+/// Readings at the same instant are coalesced to the last one first, so a
+/// burst of increments inside one simulated millisecond does not divide by
+/// zero. A decrease is read as a counter reset.
+fn rate(windows: &[Window]) -> Vec<Window> {
+    if windows.is_empty() {
+        return Vec::new();
+    }
+
+    // Coalesce same-instant readings, keeping the final value.
+    let mut readings: Vec<(u64, f64)> = Vec::with_capacity(windows.len() + 1);
+    // A fresh metrics source starts every counter at zero at simulated time
+    // zero, so the first increment has a real interval to be rated over.
+    if windows[0].end_ms > 0 {
+        readings.push((0, 0.0));
+    }
+    for w in windows {
+        match readings.last_mut() {
+            Some((t, v)) if *t == w.end_ms => *v = w.value,
+            _ => readings.push((w.end_ms, w.value)),
+        }
+    }
+
+    readings
+        .windows(2)
+        .filter_map(|pair| {
+            let (t0, v0) = pair[0];
+            let (t1, v1) = pair[1];
+            let elapsed_ms = t1.checked_sub(t0)?;
+            if elapsed_ms == 0 {
+                return None;
+            }
+            // Prometheus' reset rule: a drop means the counter restarted, so
+            // the new value is the whole delta rather than a negative rate.
+            let delta = if v1 >= v0 { v1 - v0 } else { v1 };
+            let seconds = u32::try_from(elapsed_ms).map_or(f64::INFINITY, f64::from) / 1000.0;
+            Some(Window {
+                start_ms: t0,
+                end_ms: t1,
+                value: delta / seconds,
+            })
+        })
+        .collect()
+}
+
+/// Aggregate points into fixed-width buckets keyed off their end timestamp.
+fn bucketize(windows: &[Window], every_ms: u64, agg: Aggregator) -> Vec<Window> {
+    let mut buckets: BTreeMap<u64, Vec<f64>> = BTreeMap::new();
+    for w in windows {
+        buckets
+            .entry(w.end_ms / every_ms)
+            .or_default()
+            .push(w.value);
+    }
+    buckets
+        .into_iter()
+        .filter_map(|(index, values)| {
+            let start_ms = index.saturating_mul(every_ms);
+            agg.apply(&values).map(|value| Window {
+                start_ms,
+                end_ms: start_ms.saturating_add(every_ms),
+                value,
+            })
+        })
+        .collect()
+}
+
+/// Trailing rolling window of `window` consecutive points.
+fn rolling_map(windows: &[Window], window: usize, agg: Aggregator) -> Vec<Window> {
+    if window == 0 || window > windows.len() {
+        return Vec::new();
+    }
+    windows
+        .windows(window)
+        .filter_map(|slice| {
+            let values: Vec<f64> = slice.iter().map(|w| w.value).collect();
+            let last = slice.last()?;
+            let first = slice.first()?;
+            agg.apply(&values).map(|value| Window {
+                start_ms: first.start_ms,
+                end_ms: last.end_ms,
+                value,
+            })
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Results
+// ---------------------------------------------------------------------------
+
+/// One evaluated value of one query, in one run.
+///
+/// Deliberately flat: this is the row a CSV export writes, and the shape that
+/// makes "which seed produced this?" answerable without a join.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MetricQueryRow {
+    /// Identity of the whole exploration invocation that produced this row.
+    pub run_id: u64,
+    /// The seed of the iteration that produced it — replay this to get it back.
+    pub seed: u64,
+    /// The name the query was registered under.
+    pub query: String,
+    /// Series or group identity: the series key before any reduce, the label
+    /// value after [`reduce_by`](MetricQuery::reduce_by), and `None` once the
+    /// query has reduced everything into one series.
+    pub group: Option<String>,
+    /// Start of the simulated-time window this value covers, in milliseconds.
+    ///
+    /// A value that covers the whole run rather than a slice of one — what a
+    /// [`reduce`](MetricQuery::reduce) without
+    /// [`bucketize`](MetricQuery::bucketize) produces — reports
+    /// [`WHOLE_RUN_MS`] for both bounds, so every seed's value lands in the
+    /// same across-run summary instead of in a window of its own.
+    pub bucket_start_ms: u64,
+    /// End of that window, exclusive. Equal to the start for an instant value
+    /// and for a whole-run value.
+    pub bucket_end_ms: u64,
+    /// The value.
+    pub value: f64,
+}
+
+/// Deterministic row order: group, then window, then seed.
+fn row_order(a: &MetricQueryRow, b: &MetricQueryRow) -> std::cmp::Ordering {
+    a.group
+        .cmp(&b.group)
+        .then(a.bucket_start_ms.cmp(&b.bucket_start_ms))
+        .then(a.bucket_end_ms.cmp(&b.bucket_end_ms))
+        .then(a.seed.cmp(&b.seed))
+}
+
+/// One query's values for one window, summarized across every run.
+///
+/// The percentiles here are over *runs*: each seed contributes one value, so
+/// `p95` names the 95th-percentile run, not a percentile of the underlying
+/// observations. That stays valid whatever the query's own
+/// [`Provenance`] is, because it aggregates a different dimension.
+#[derive(Debug, Clone)]
+pub struct MetricWindowSummary {
+    /// Series or group identity; see [`MetricQueryRow::group`].
+    pub group: Option<String>,
+    /// Start of the window, in simulated milliseconds.
+    pub bucket_start_ms: u64,
+    /// End of the window, exclusive.
+    pub bucket_end_ms: u64,
+    /// Number of distinct seeds that contributed a value.
+    pub runs: usize,
+    /// Smallest value seen in any run.
+    pub min: f64,
+    /// Seed that produced [`min`](Self::min) — the smallest such seed on ties.
+    pub min_seed: u64,
+    /// Largest value seen in any run.
+    pub max: f64,
+    /// Seed that produced [`max`](Self::max) — the smallest such seed on ties.
+    pub max_seed: u64,
+    /// Mean across runs.
+    pub mean: f64,
+    /// Median run.
+    pub p50: f64,
+    /// 95th-percentile run.
+    pub p95: f64,
+    /// 99th-percentile run.
+    pub p99: f64,
+}
+
+/// Every evaluated row of one named query, plus its across-run summary.
+///
+/// This is what the end-of-exploration report prints, and what a future CSV
+/// export will serialize — [`rows`](Self::rows) is already the row set.
+#[derive(Debug, Clone)]
+pub struct MetricQueryReport {
+    /// The query's registered name.
+    pub name: String,
+    /// One-line rendering of the pipeline; see [`MetricQueryPlan::description`].
+    pub description: String,
+    /// What each run's values represent.
+    pub provenance: Provenance,
+    /// Number of distinct seeds that contributed at least one row.
+    pub runs: usize,
+    /// Every row, in deterministic order.
+    pub rows: Vec<MetricQueryRow>,
+    /// Across-run summary, one entry per (group, window), in the same order.
+    pub windows: Vec<MetricWindowSummary>,
+}
+
+impl MetricQueryReport {
+    /// Summarize a query's rows across every run that produced them.
+    #[must_use]
+    pub fn from_rows(plan: &MetricQueryPlan, mut rows: Vec<MetricQueryRow>) -> Self {
+        rows.sort_by(row_order);
+
+        let runs = rows.iter().map(|r| r.seed).collect::<BTreeSet<_>>().len();
+
+        // Rows are sorted by (group, window), so equal keys are contiguous.
+        let mut windows = Vec::new();
+        let mut start = 0usize;
+        while start < rows.len() {
+            let head = &rows[start];
+            let mut end = start + 1;
+            while end < rows.len()
+                && rows[end].group == head.group
+                && rows[end].bucket_start_ms == head.bucket_start_ms
+                && rows[end].bucket_end_ms == head.bucket_end_ms
+            {
+                end += 1;
+            }
+            windows.push(summarize_window(&rows[start..end]));
+            start = end;
+        }
+
+        Self {
+            name: plan.name.clone(),
+            description: plan.description(),
+            provenance: plan.provenance,
+            runs,
+            rows,
+            windows,
+        }
+    }
+}
+
+/// Summarize one contiguous run of rows sharing a (group, window) key.
+fn summarize_window(rows: &[MetricQueryRow]) -> MetricWindowSummary {
+    debug_assert!(!rows.is_empty(), "caller groups non-empty slices");
+    let head = &rows[0];
+
+    // Rows are seed-ordered within a window, so the first extremum wins ties
+    // with the smallest seed — which keeps the reported seed deterministic.
+    let mut min = f64::INFINITY;
+    let mut min_seed = head.seed;
+    let mut max = f64::NEG_INFINITY;
+    let mut max_seed = head.seed;
+    for row in rows {
+        if row.value < min {
+            min = row.value;
+            min_seed = row.seed;
+        }
+        if row.value > max {
+            max = row.value;
+            max_seed = row.seed;
+        }
+    }
+
+    let mut values: Vec<f64> = rows.iter().map(|r| r.value).collect();
+    values.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+
+    MetricWindowSummary {
+        group: head.group.clone(),
+        bucket_start_ms: head.bucket_start_ms,
+        bucket_end_ms: head.bucket_end_ms,
+        runs: rows.iter().map(|r| r.seed).collect::<BTreeSet<_>>().len(),
+        min,
+        min_seed,
+        max,
+        max_seed,
+        mean: mean(&values),
+        p50: percentile_of_sorted(&values, 0.50),
+        p95: percentile_of_sorted(&values, 0.95),
+        p99: percentile_of_sorted(&values, 0.99),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::metrics::MetricValue;
+
+    /// Floating-point comparison for the expected values in these tests, which
+    /// are small and exactly representable up to accumulated rounding.
+    fn is_close(a: f64, b: f64) -> bool {
+        (a - b).abs() < 1e-9
+    }
+
+    fn snapshot(series: &[(&str, &[(u64, f64)])], end_time_ms: u64) -> MetricSnapshot {
+        let mut snap = MetricSnapshot::new(end_time_ms);
+        for (key, points) in series {
+            snap.insert(
+                SeriesKey::parse(key),
+                points
+                    .iter()
+                    .map(|(time_ms, value)| MetricPoint {
+                        time_ms: *time_ms,
+                        value: *value,
+                    })
+                    .collect(),
+            );
+        }
+        snap
+    }
+
+    // --- series identity -------------------------------------------------
+
+    #[test]
+    fn labels_are_canonically_ordered() {
+        let a = SeriesKey::new(
+            "requests_total",
+            vec![
+                ("method".to_owned(), "GET".to_owned()),
+                ("code".to_owned(), "200".to_owned()),
+            ],
+        );
+        let b = SeriesKey::new(
+            "requests_total",
+            vec![
+                ("code".to_owned(), "200".to_owned()),
+                ("method".to_owned(), "GET".to_owned()),
+            ],
+        );
+        assert_eq!(a, b, "insertion order must not change series identity");
+        assert_eq!(a.to_string(), r#"requests_total{code="200",method="GET"}"#);
+    }
+
+    #[test]
+    fn parse_round_trips_the_canonical_form() {
+        let key = SeriesKey::parse(r#"requests_total{method="GET",code="200"}"#);
+        assert_eq!(key.metric, "requests_total");
+        assert_eq!(key.label("code"), Some("200"));
+        assert_eq!(
+            key.to_string(),
+            r#"requests_total{code="200",method="GET"}"#
+        );
+
+        let bare = SeriesKey::parse("uptime");
+        assert_eq!(bare.metric, "uptime");
+        assert!(bare.labels.is_empty());
+        assert_eq!(bare.to_string(), "uptime");
+    }
+
+    #[test]
+    fn a_sample_and_its_recorded_series_agree_on_identity() {
+        let sample = MetricSample::new(
+            "requests_total",
+            vec![
+                ("op".to_owned(), "write".to_owned()),
+                ("instance".to_owned(), "10.0.1.1".to_owned()),
+            ],
+            MetricValue::Counter(1.0),
+        );
+        assert_eq!(
+            SeriesKey::parse(&sample.sort_key()),
+            SeriesKey::new(sample.name.clone(), sample.labels.clone()),
+        );
+    }
+
+    // --- selection -------------------------------------------------------
+
+    #[test]
+    fn selection_is_by_name_then_label_subset() {
+        let snap = snapshot(
+            &[
+                (r#"requests_total{instance="a",op="write"}"#, &[(0, 1.0)]),
+                (r#"requests_total{instance="b",op="read"}"#, &[(0, 2.0)]),
+                (r#"other_total{op="write"}"#, &[(0, 3.0)]),
+            ],
+            1_000,
+        );
+
+        let all = snap.select("requests_total", &[]);
+        assert_eq!(all.len(), 2, "name match only");
+
+        let writes = snap.select("requests_total", &[("op".to_owned(), "write".to_owned())]);
+        assert_eq!(writes.len(), 1);
+        assert_eq!(writes[0].label("instance"), Some("a"));
+
+        let none = snap.select("requests_total", &[("op".to_owned(), "purge".to_owned())]);
+        assert!(none.is_empty(), "no series carries that label value");
+
+        let subset = snap.select("requests_total", &[("instance".to_owned(), "a".to_owned())]);
+        assert_eq!(subset.len(), 1, "extra labels on the series are fine");
+    }
+
+    #[test]
+    fn a_scrape_only_series_becomes_one_end_of_run_point() {
+        let samples = vec![MetricSample::new(
+            "foreign_total",
+            Vec::new(),
+            MetricValue::Counter(50.0),
+        )];
+        let snap = MetricSnapshot::from_run(&samples, &BTreeMap::new(), 10_000);
+        let key = SeriesKey::parse("foreign_total");
+        let points = snap.points(&key).expect("scraped series is selectable");
+        assert_eq!(points.len(), 1);
+        assert_eq!(points[0].time_ms, 10_000);
+
+        // And rate() reads it as "50 over the whole run" = 5/s.
+        let rows = MetricQuery::select("foreign_total")
+            .rate()
+            .reduce(Mean)
+            .named("foreign_rate")
+            .evaluate(&snap, 7, 42);
+        assert_eq!(rows.len(), 1);
+        assert!(is_close(rows[0].value, 5.0));
+    }
+
+    #[test]
+    fn a_recorded_series_wins_over_the_scrape() {
+        let samples = vec![MetricSample::new(
+            "hits_total",
+            Vec::new(),
+            MetricValue::Counter(9.0),
+        )];
+        let mut series = BTreeMap::new();
+        series.insert(
+            "hits_total".to_owned(),
+            vec![
+                MetricPoint {
+                    time_ms: 1_000,
+                    value: 1.0,
+                },
+                MetricPoint {
+                    time_ms: 2_000,
+                    value: 2.0,
+                },
+            ],
+        );
+        let snap = MetricSnapshot::from_run(&samples, &series, 3_000);
+        let points = snap
+            .points(&SeriesKey::parse("hits_total"))
+            .expect("recorded");
+        assert_eq!(points.len(), 2, "history beats the single scrape value");
+    }
+
+    // --- rate ------------------------------------------------------------
+
+    #[test]
+    fn rate_divides_by_simulated_time() {
+        // 10 increments over 1s starting from an implicit zero at t=0.
+        let snap = snapshot(&[("hits_total", &[(1_000, 10.0), (3_000, 30.0)])], 3_000);
+        let rows = MetricQuery::select("hits_total")
+            .rate()
+            .named("r")
+            .evaluate(&snap, 1, 1);
+
+        assert_eq!(rows.len(), 2, "origin point makes the first interval real");
+        assert_eq!((rows[0].bucket_start_ms, rows[0].bucket_end_ms), (0, 1_000));
+        assert!(is_close(rows[0].value, 10.0), "10 over 1s");
+        assert_eq!(
+            (rows[1].bucket_start_ms, rows[1].bucket_end_ms),
+            (1_000, 3_000)
+        );
+        assert!(is_close(rows[1].value, 10.0), "20 over 2s");
+    }
+
+    #[test]
+    fn rate_coalesces_same_instant_readings() {
+        // Three increments inside the same simulated millisecond: the counter
+        // reads 3 at t=1000, and nothing divides by a zero interval.
+        let snap = snapshot(
+            &[("hits_total", &[(1_000, 1.0), (1_000, 2.0), (1_000, 3.0)])],
+            1_000,
+        );
+        let rows = MetricQuery::select("hits_total")
+            .rate()
+            .named("r")
+            .evaluate(&snap, 1, 1);
+        assert_eq!(rows.len(), 1);
+        assert!(is_close(rows[0].value, 3.0));
+    }
+
+    #[test]
+    fn rate_reads_a_drop_as_a_counter_reset() {
+        // 0 → 10 → (reset) → 4: the last interval contributes 4, not -6.
+        let snap = snapshot(&[("hits_total", &[(1_000, 10.0), (2_000, 4.0)])], 2_000);
+        let rows = MetricQuery::select("hits_total")
+            .rate()
+            .named("r")
+            .evaluate(&snap, 1, 1);
+        assert_eq!(rows.len(), 2);
+        assert!(is_close(rows[1].value, 4.0), "reset, not a negative rate");
+    }
+
+    #[test]
+    fn bucketize_alone_does_not_infer_counter_semantics() {
+        // Same counter, no rate(): the mean of the cumulative readings, which
+        // is honestly not a throughput.
+        let snap = snapshot(&[("hits_total", &[(1_000, 10.0), (3_000, 30.0)])], 3_000);
+        let rows = MetricQuery::select("hits_total")
+            .bucketize(Duration::from_mins(1), Mean)
+            .named("m")
+            .evaluate(&snap, 1, 1);
+        assert_eq!(rows.len(), 1);
+        assert!(is_close(rows[0].value, 20.0));
+    }
+
+    // --- bucketize -------------------------------------------------------
+
+    #[test]
+    fn bucket_boundaries_are_half_open() {
+        let snap = snapshot(
+            &[(
+                "latency",
+                &[
+                    (0, 1.0),
+                    (59_999, 3.0),
+                    (60_000, 100.0),
+                    (119_999, 200.0),
+                    (180_000, 7.0),
+                ],
+            )],
+            180_000,
+        );
+        let rows = MetricQuery::select("latency")
+            .bucketize(Duration::from_mins(1), Mean)
+            .named("b")
+            .evaluate(&snap, 1, 1);
+
+        assert_eq!(rows.len(), 3, "the empty 120-180s bucket is omitted");
+        assert_eq!(
+            (rows[0].bucket_start_ms, rows[0].bucket_end_ms),
+            (0, 60_000)
+        );
+        assert!(is_close(rows[0].value, 2.0), "1 and 3, not 100");
+        assert_eq!(
+            (rows[1].bucket_start_ms, rows[1].bucket_end_ms),
+            (60_000, 120_000)
+        );
+        assert!(is_close(rows[1].value, 150.0));
+        assert_eq!(
+            (rows[2].bucket_start_ms, rows[2].bucket_end_ms),
+            (180_000, 240_000)
+        );
+    }
+
+    #[test]
+    fn bucketize_supports_min_mean_max_and_percentile() {
+        let points: Vec<(u64, f64)> = (1u32..=100).map(|i| (u64::from(i), f64::from(i))).collect();
+        let snap = snapshot(&[("v", points.as_slice())], 100);
+        let value = |agg: Aggregator| {
+            let plan = match agg {
+                Aggregator::Min => MetricQuery::select("v")
+                    .bucketize(Duration::from_mins(1), Min)
+                    .named("q"),
+                Aggregator::Mean => MetricQuery::select("v")
+                    .bucketize(Duration::from_mins(1), Mean)
+                    .named("q"),
+                Aggregator::Max => MetricQuery::select("v")
+                    .bucketize(Duration::from_mins(1), Max)
+                    .named("q"),
+                Aggregator::Percentile(p) => MetricQuery::select("v")
+                    .bucketize(Duration::from_mins(1), Percentile(p))
+                    .named("q"),
+            };
+            plan.evaluate(&snap, 1, 1)[0].value
+        };
+
+        assert!(is_close(value(Aggregator::Min), 1.0));
+        assert!(is_close(value(Aggregator::Max), 100.0));
+        assert!(is_close(value(Aggregator::Mean), 50.5));
+        // Linear interpolation on rank p*(n-1): 0.99 * 99 = 98.01.
+        assert!(is_close(value(Aggregator::Percentile(0.99)), 99.01));
+        assert!(is_close(value(Aggregator::Percentile(0.5)), 50.5));
+    }
+
+    // --- map -------------------------------------------------------------
+
+    #[test]
+    fn map_rolls_a_window_over_consecutive_points() {
+        let snap = snapshot(
+            &[("v", &[(0, 1.0), (1_000, 5.0), (2_000, 3.0), (3_000, 9.0)])],
+            3_000,
+        );
+        let rows = MetricQuery::select("v")
+            .map(2, Max)
+            .named("rolling_max")
+            .evaluate(&snap, 1, 1);
+
+        assert_eq!(rows.len(), 3, "one per full window");
+        assert!(is_close(rows[0].value, 5.0));
+        assert!(is_close(rows[1].value, 5.0));
+        assert!(is_close(rows[2].value, 9.0));
+        assert_eq!(
+            (rows[0].bucket_start_ms, rows[0].bucket_end_ms),
+            (0, 1_000),
+            "the window spans its first point to its last"
+        );
+    }
+
+    #[test]
+    fn map_over_buckets_keeps_bucket_boundaries() {
+        let snap = snapshot(
+            &[("v", &[(0, 1.0), (60_000, 2.0), (120_000, 30.0)])],
+            180_000,
+        );
+        let rows = MetricQuery::select("v")
+            .bucketize(Duration::from_mins(1), Mean)
+            .map(2, Mean)
+            .named("smoothed")
+            .evaluate(&snap, 1, 1);
+
+        assert_eq!(rows.len(), 2);
+        assert_eq!(
+            (rows[0].bucket_start_ms, rows[0].bucket_end_ms),
+            (0, 120_000)
+        );
+        assert!(is_close(rows[0].value, 1.5));
+        assert!(is_close(rows[1].value, 16.0));
+    }
+
+    #[test]
+    fn a_window_longer_than_the_series_produces_nothing() {
+        let snap = snapshot(&[("v", &[(0, 1.0)])], 0);
+        let rows = MetricQuery::select("v")
+            .map(5, Mean)
+            .named("q")
+            .evaluate(&snap, 1, 1);
+        assert!(rows.is_empty());
+    }
+
+    // --- reduce ----------------------------------------------------------
+
+    #[test]
+    fn reduce_combines_aligned_series_bucket_by_bucket() {
+        let snap = snapshot(
+            &[
+                (r#"v{instance="a"}"#, &[(0, 10.0), (60_000, 100.0)]),
+                (r#"v{instance="b"}"#, &[(0, 20.0), (60_000, 200.0)]),
+            ],
+            120_000,
+        );
+        let rows = MetricQuery::select("v")
+            .bucketize(Duration::from_mins(1), Mean)
+            .reduce(Max)
+            .named("worst_node")
+            .evaluate(&snap, 1, 1);
+
+        assert_eq!(rows.len(), 2, "buckets survive the reduce");
+        assert!(rows.iter().all(|r| r.group.is_none()));
+        assert!(is_close(rows[0].value, 20.0));
+        assert!(is_close(rows[1].value, 200.0));
+    }
+
+    #[test]
+    fn reduce_without_buckets_pools_every_observation() {
+        // No shared time grid, so a global percentile over the raw
+        // observations of both nodes.
+        let snap = snapshot(
+            &[
+                (r#"latency{instance="a"}"#, &[(1, 1.0), (2, 2.0)]),
+                (r#"latency{instance="b"}"#, &[(3, 3.0), (4, 4.0)]),
+            ],
+            10,
+        );
+        let rows = MetricQuery::select("latency")
+            .reduce(Percentile(0.5))
+            .named("global_p50")
+            .evaluate(&snap, 1, 1);
+
+        assert_eq!(rows.len(), 1);
+        assert!(is_close(rows[0].value, 2.5), "median of 1,2,3,4");
+        assert_eq!(
+            (rows[0].bucket_start_ms, rows[0].bucket_end_ms),
+            (WHOLE_RUN_MS, WHOLE_RUN_MS),
+            "a pooled reduce covers the run, not the span its points occupied"
+        );
+    }
+
+    #[test]
+    fn a_pooled_reduce_groups_across_seeds_rather_than_per_seed() {
+        // Two seeds whose observations occupy different simulated spans. The
+        // summary must still see one window with two runs in it.
+        let plan = MetricQuery::select("latency")
+            .reduce(Percentile(0.99))
+            .named("global_p99");
+        let rows: Vec<MetricQueryRow> = [(1u64, 5u64), (2, 900)]
+            .iter()
+            .flat_map(|(seed, last_ms)| {
+                let snap = snapshot(&[("latency", &[(1, 1.0), (*last_ms, 2.0)])], 1_000);
+                plan.evaluate(&snap, 7, *seed)
+            })
+            .collect();
+        let report = MetricQueryReport::from_rows(&plan, rows);
+
+        assert_eq!(report.windows.len(), 1, "one window, not one per seed");
+        assert_eq!(report.windows[0].runs, 2);
+    }
+
+    #[test]
+    fn reduce_by_groups_on_one_label() {
+        let snap = snapshot(
+            &[
+                (r#"v{instance="a",zone="eu"}"#, &[(0, 1.0)]),
+                (r#"v{instance="b",zone="eu"}"#, &[(0, 3.0)]),
+                (r#"v{instance="c",zone="us"}"#, &[(0, 10.0)]),
+                (r#"v{instance="d"}"#, &[(0, 99.0)]),
+            ],
+            60_000,
+        );
+        let rows = MetricQuery::select("v")
+            .bucketize(Duration::from_mins(1), Mean)
+            .reduce_by("zone", Mean)
+            .named("per_zone")
+            .evaluate(&snap, 1, 1);
+
+        assert_eq!(rows.len(), 2, "the unlabelled series is dropped");
+        assert_eq!(rows[0].group.as_deref(), Some("eu"));
+        assert!(is_close(rows[0].value, 2.0));
+        assert_eq!(rows[1].group.as_deref(), Some("us"));
+        assert!(is_close(rows[1].value, 10.0));
+    }
+
+    // --- metadata --------------------------------------------------------
+
+    #[test]
+    fn every_row_carries_its_run_id_and_seed() {
+        let snap = snapshot(&[("v", &[(0, 1.0), (60_000, 2.0)])], 120_000);
+        let rows = MetricQuery::select("v")
+            .bucketize(Duration::from_mins(1), Mean)
+            .named("q")
+            .evaluate(&snap, 0xDEAD_BEEF, 9182);
+
+        assert_eq!(rows.len(), 2);
+        assert!(rows.iter().all(|r| r.run_id == 0xDEAD_BEEF));
+        assert!(rows.iter().all(|r| r.seed == 9182));
+        assert!(rows.iter().all(|r| r.query == "q"));
+    }
+
+    #[test]
+    fn provenance_records_the_last_collapse() {
+        let raw = MetricQuery::select("v").rate().named("q");
+        assert_eq!(raw.provenance(), Provenance::Observations);
+
+        let scalar = MetricQuery::select("v")
+            .bucketize(Duration::from_secs(1), Mean)
+            .named("q");
+        assert_eq!(scalar.provenance(), Provenance::Scalar);
+
+        let quantile = MetricQuery::select("v")
+            .bucketize(Duration::from_secs(1), Percentile(0.99))
+            .named("q");
+        assert_eq!(quantile.provenance(), Provenance::Quantile);
+
+        // A percentile followed by an honest mean is still not a percentile.
+        let mixed = MetricQuery::select("v")
+            .bucketize(Duration::from_secs(1), Percentile(0.99))
+            .reduce(Mean)
+            .named("q");
+        assert_eq!(mixed.provenance(), Provenance::Scalar);
+    }
+
+    #[test]
+    fn description_renders_the_pipeline() {
+        let plan = MetricQuery::select("requests_total")
+            .label("operation", "write")
+            .rate()
+            .bucketize(Duration::from_mins(1), Mean)
+            .reduce(Max)
+            .named("write_throughput");
+        assert_eq!(
+            plan.description(),
+            r#"requests_total{operation="write"} → rate → 60s buckets (mean) → reduce (max)"#
+        );
+    }
+
+    // --- cross-run summary -----------------------------------------------
+
+    fn multi_seed_rows(values: &[(u64, f64)]) -> (MetricQueryPlan, Vec<MetricQueryRow>) {
+        let plan = MetricQuery::select("v")
+            .bucketize(Duration::from_mins(1), Mean)
+            .reduce(Mean)
+            .named("throughput");
+        let rows = values
+            .iter()
+            .flat_map(|(seed, value)| {
+                let snap = snapshot(&[("v", &[(0, *value)])], 60_000);
+                plan.evaluate(&snap, 7, *seed)
+            })
+            .collect();
+        (plan, rows)
+    }
+
+    #[test]
+    fn multi_seed_summary_names_the_extreme_seeds() {
+        let (plan, rows) =
+            multi_seed_rows(&[(9182, 5_421.0), (224, 6_102.0), (3, 5_900.0), (4, 5_950.0)]);
+        let report = MetricQueryReport::from_rows(&plan, rows);
+
+        assert_eq!(report.runs, 4);
+        assert_eq!(report.windows.len(), 1, "one window, so a flat summary");
+        let w = &report.windows[0];
+        assert!(is_close(w.min, 5_421.0));
+        assert_eq!(w.min_seed, 9182, "replay this one");
+        assert!(is_close(w.max, 6_102.0));
+        assert_eq!(w.max_seed, 224);
+        assert!(is_close(w.mean, 5_843.25));
+        assert!(is_close(w.p50, 5_925.0));
+    }
+
+    #[test]
+    fn extreme_seed_ties_break_on_the_smallest_seed() {
+        let (plan, rows) = multi_seed_rows(&[(99, 1.0), (7, 1.0), (55, 1.0)]);
+        let report = MetricQueryReport::from_rows(&plan, rows);
+        assert_eq!(report.windows[0].min_seed, 7);
+        assert_eq!(report.windows[0].max_seed, 7);
+    }
+
+    #[test]
+    fn summary_windows_are_deterministically_ordered() {
+        let plan = MetricQuery::select("v")
+            .bucketize(Duration::from_mins(1), Mean)
+            .reduce_by("zone", Mean)
+            .named("per_zone");
+
+        let build = |seeds: &[u64]| {
+            let rows: Vec<MetricQueryRow> = seeds
+                .iter()
+                .flat_map(|seed| {
+                    let snap = snapshot(
+                        &[
+                            (r#"v{zone="us"}"#, &[(0, 2.0), (60_000, 4.0)]),
+                            (r#"v{zone="eu"}"#, &[(0, 1.0), (60_000, 3.0)]),
+                        ],
+                        120_000,
+                    );
+                    plan.evaluate(&snap, 7, *seed)
+                })
+                .collect();
+            MetricQueryReport::from_rows(&plan, rows)
+                .windows
+                .iter()
+                .map(|w| (w.group.clone(), w.bucket_start_ms))
+                .collect::<Vec<_>>()
+        };
+
+        let forward = build(&[1, 2, 3]);
+        let backward = build(&[3, 2, 1]);
+        assert_eq!(forward, backward, "seed order must not reorder the report");
+        assert_eq!(
+            forward,
+            vec![
+                (Some("eu".to_owned()), 0),
+                (Some("eu".to_owned()), 60_000),
+                (Some("us".to_owned()), 0),
+                (Some("us".to_owned()), 60_000),
+            ]
+        );
+    }
+
+    #[test]
+    fn a_bucketed_query_summarizes_each_bucket_separately() {
+        let plan = MetricQuery::select("v")
+            .bucketize(Duration::from_mins(1), Mean)
+            .named("bucketed");
+        let rows: Vec<MetricQueryRow> = [(1u64, 1.0), (2, 3.0)]
+            .iter()
+            .flat_map(|(seed, base)| {
+                let snap = snapshot(&[("v", &[(0, *base), (60_000, base * 10.0)])], 120_000);
+                plan.evaluate(&snap, 7, *seed)
+            })
+            .collect();
+        let report = MetricQueryReport::from_rows(&plan, rows);
+
+        assert_eq!(report.windows.len(), 2);
+        assert_eq!(report.runs, 2);
+        assert!(is_close(report.windows[0].mean, 2.0));
+        assert!(is_close(report.windows[1].mean, 20.0));
+        assert_eq!(report.windows[1].max_seed, 2);
+    }
+
+    #[test]
+    fn percentile_helpers_handle_degenerate_input() {
+        assert!(Aggregator::Mean.apply(&[]).is_none());
+        assert!(is_close(percentile_of_sorted(&[4.0], 0.99), 4.0));
+        assert!(is_close(percentile_of_sorted(&[1.0, 2.0], 0.0), 1.0));
+        assert!(is_close(percentile_of_sorted(&[1.0, 2.0], 1.0), 2.0));
+        assert!(is_close(percentile_of_sorted(&[1.0, 2.0], f64::NAN), 1.0));
+        assert!(is_close(percentile_of_sorted(&[1.0, 2.0], 5.0), 2.0));
+    }
+
+    #[test]
+    fn aggregator_labels_read_as_percentiles() {
+        assert_eq!(Aggregator::Percentile(0.99).label(), "p99");
+        assert_eq!(Aggregator::Percentile(0.5).label(), "p50");
+        assert_eq!(Aggregator::Percentile(0.999).label(), "p99.9");
+        assert_eq!(Aggregator::Mean.label(), "mean");
+    }
+}

--- a/crates/moonpool-prometheus/tests/simulation.rs
+++ b/crates/moonpool-prometheus/tests/simulation.rs
@@ -5,7 +5,10 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use moonpool_prometheus::PrometheusSource;
-use moonpool_sim::{SimContext, SimulationBuilder, SimulationResult, TimeProvider, Workload};
+use moonpool_sim::{
+    Mean, MetricQuery, Percentile, SimContext, SimulationBuilder, SimulationResult, TimeProvider,
+    Workload,
+};
 
 /// Drives a fixed number of "requests", recording each one the way production
 /// code would: a counter, a gauge, and a latency histogram.
@@ -166,4 +169,67 @@ fn series_is_identical_across_replays_of_a_seed() {
             "series {key} must replay bit-for-bit from the same seed"
         );
     }
+}
+
+/// The same workload, plus two metric queries declared on the runner: a
+/// counter read as a throughput and the latency histogram's tail.
+fn run_queried(requests: u64, seeds: &[u64]) -> moonpool_sim::SimulationReport {
+    SimulationBuilder::new()
+        .set_debug_seeds(seeds.to_vec())
+        .set_iterations(seeds.len())
+        .metrics_factory(|_ip| Arc::new(PrometheusSource::default()))
+        .metric(
+            MetricQuery::select("requests_total")
+                .rate()
+                .bucketize(Duration::from_mins(1), Mean)
+                .reduce(Mean)
+                .named("write_throughput"),
+        )
+        .metric(
+            MetricQuery::select("request_latency_seconds")
+                .reduce(Percentile(0.99))
+                .named("write_p99"),
+        )
+        .workload(MeteredWorkload { requests })
+        .run()
+}
+
+#[test]
+fn queries_select_the_series_a_prometheus_source_recorded() {
+    let report = run_queried(5, &[1, 2, 3]);
+    assert_eq!(report.failed_runs, 0);
+
+    let by_name = |name: &str| {
+        report
+            .metric_queries
+            .iter()
+            .find(|q| q.name == name)
+            .unwrap_or_else(|| panic!("{name} missing: {:?}", report.metric_queries))
+    };
+
+    // The instrumented handle records `requests_total`; the runner splices in
+    // the `instance` label, and selection by bare metric name still finds it.
+    let throughput = by_name("write_throughput");
+    assert_eq!(throughput.runs, 3);
+    assert_eq!(throughput.windows.len(), 1);
+    // 5 requests, 10ms of simulated sleep each: 100 per simulated second.
+    assert!(
+        (throughput.windows[0].mean - 100.0).abs() < 1e-6,
+        "expected 100 req/s, got {}",
+        throughput.windows[0].mean
+    );
+
+    // A histogram records one point per observation, so the p99 is taken over
+    // the real distribution rather than interpolated from bucket counts.
+    let tail = by_name("write_p99");
+    assert_eq!(tail.provenance, moonpool_sim::Provenance::Quantile);
+    assert!(
+        (tail.windows[0].mean - 0.010).abs() < 1e-9,
+        "every request took 10ms of simulated time, got {}",
+        tail.windows[0].mean
+    );
+    assert!(
+        tail.rows.iter().all(|row| row.run_id == report.run_id),
+        "rows carry the run id"
+    );
 }

--- a/crates/moonpool-sim-examples/src/bin/sim/metrics_service.rs
+++ b/crates/moonpool-sim-examples/src/bin/sim/metrics_service.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use moonpool_prometheus::PrometheusSource;
-use moonpool_sim::{Chaos, ChaosMode, Mean, MetricQuery, Percentile, SimulationBuilder};
+use moonpool_sim::{Chaos, ChaosMode, Fill, Mean, MetricQuery, Percentile, SimulationBuilder};
 use moonpool_sim_examples::metrics_service::{MeteredKvNode, MeteredKvWorkload};
 
 fn main() {
@@ -31,6 +31,10 @@ fn main() {
                 // average the cumulative total, not the throughput.
                 .rate()
                 .bucketize(Duration::from_secs(1), Mean)
+                // A second in which chaos stalled every node served zero
+                // requests; without this it would read as missing data and
+                // drop out of the summary for that seed.
+                .fill(Fill::Value(0.0))
                 .reduce(Mean)
                 .named("served_throughput"),
         )

--- a/crates/moonpool-sim-examples/src/bin/sim/metrics_service.rs
+++ b/crates/moonpool-sim-examples/src/bin/sim/metrics_service.rs
@@ -1,14 +1,17 @@
 //! Binary target for the metered key/value simulation.
 //!
 //! Three nodes, each with its own `prometheus::Registry`, running under
-//! network chaos. The report's Metrics section shows what they recorded.
+//! network chaos. The report's Metrics section shows what they recorded, and
+//! the Metric Queries section answers the two questions this simulation is
+//! actually about: what throughput did it sustain, and how bad did the tail
+//! latency get.
 
 use std::process;
 use std::sync::Arc;
 use std::time::Duration;
 
 use moonpool_prometheus::PrometheusSource;
-use moonpool_sim::{Chaos, ChaosMode, SimulationBuilder};
+use moonpool_sim::{Chaos, ChaosMode, Mean, MetricQuery, Percentile, SimulationBuilder};
 use moonpool_sim_examples::metrics_service::{MeteredKvNode, MeteredKvWorkload};
 
 fn main() {
@@ -20,6 +23,24 @@ fn main() {
         .metrics_factory(|_ip| Arc::new(PrometheusSource::default()))
         .processes(3, || Box::new(MeteredKvNode::new()))
         .workload(MeteredKvWorkload)
+        // The runner declares what is worth summarizing across seeds. Both
+        // read the series the instrumented handles already record.
+        .metric(
+            MetricQuery::select("kv_requests_served_total")
+                // Counter semantics are explicit: without .rate() this would
+                // average the cumulative total, not the throughput.
+                .rate()
+                .bucketize(Duration::from_secs(1), Mean)
+                .reduce(Mean)
+                .named("served_throughput"),
+        )
+        .metric(
+            // Valid because the histogram handle records every observation, so
+            // the underlying distribution is still there to take a p99 of.
+            MetricQuery::select("kv_request_latency_seconds")
+                .reduce(Percentile(0.99))
+                .named("latency_p99"),
+        )
         .enable_chaos([Chaos::Network(ChaosMode::Swarm)])
         .chaos_duration(Duration::from_secs(3))
         .set_iterations(10)

--- a/crates/moonpool-sim/src/lib.rs
+++ b/crates/moonpool-sim/src/lib.rs
@@ -161,8 +161,8 @@ pub use moonpool_core::metrics::{
 // `Max` and `Percentile` are the aggregator markers the builder accepts;
 // `Percentile` deliberately only applies where the observations survive.
 pub use moonpool_core::metrics::query::{
-    Aggregator, Max, Mean, MetricQuery, MetricQueryPlan, MetricQueryReport, MetricQueryRow,
-    MetricSnapshot, MetricWindowSummary, Min, Percentile, Provenance, SeriesKey,
+    Aggregator, Fill, Max, Mean, MetricQuery, MetricQueryPlan, MetricQueryReport, MetricQueryRow,
+    MetricSnapshot, MetricWindowSummary, Min, Percentile, Provenance, SeriesKey, WHOLE_RUN_MS,
 };
 
 // Buggify macros live in the standalone zero-dependency moonpool-buggify

--- a/crates/moonpool-sim/src/lib.rs
+++ b/crates/moonpool-sim/src/lib.rs
@@ -151,7 +151,19 @@ pub use runner::{
 // simulation using `.metrics_factory()` needs one import path. Adapters over a
 // concrete registry (moonpool-prometheus, and OpenTelemetry later) implement
 // `MetricsSource` against these types.
-pub use moonpool_core::metrics::{HistogramValue, MetricSample, MetricValue, MetricsSource};
+pub use moonpool_core::metrics::{
+    HistogramValue, MetricClock, MetricPoint, MetricSample, MetricValue, MetricsSource,
+    SeriesRecorder,
+};
+
+// The metric query/report vocabulary, so a runner declaring
+// `.metric(MetricQuery::select(...))` imports from one place. `Min`, `Mean`,
+// `Max` and `Percentile` are the aggregator markers the builder accepts;
+// `Percentile` deliberately only applies where the observations survive.
+pub use moonpool_core::metrics::query::{
+    Aggregator, Max, Mean, MetricQuery, MetricQueryPlan, MetricQueryReport, MetricQueryRow,
+    MetricSnapshot, MetricWindowSummary, Min, Percentile, Provenance, SeriesKey,
+};
 
 // Buggify macros live in the standalone zero-dependency moonpool-buggify
 // crate; re-exported here so existing `moonpool_sim::buggify!` call sites keep

--- a/crates/moonpool-sim/src/runner/builder.rs
+++ b/crates/moonpool-sim/src/runner/builder.rs
@@ -25,6 +25,7 @@ use super::iteration::IterationManager;
 use super::metrics::{GenerateReportInputs, MetricsCollector};
 use super::orchestrator::{OrchestrateInputs, OrchestrateOutput, WorkloadOrchestrator};
 use moonpool_core::metrics::MetricsSource;
+use moonpool_core::metrics::query::MetricQueryPlan;
 
 /// Client identity information for a single workload instance.
 #[derive(Debug, Clone, Copy)]
@@ -103,9 +104,10 @@ impl RunState {
         let progress_milestone = iteration_manager
             .max_iterations()
             .map(|max| std::cmp::max(max / 10, 1));
+        let run_id = iteration_manager.run_id();
         Self {
             iteration_manager,
-            metrics_collector: MetricsCollector::new(),
+            metrics_collector: MetricsCollector::new(run_id, builder.metric_queries.clone()),
             progress_milestone,
             pending_return_map: Vec::new(),
             pending_instance_injector_count: 0,
@@ -240,6 +242,8 @@ pub struct SimulationBuilder {
     /// Builds one application-metrics source per node IP, rebuilt each
     /// iteration so counters start from zero on every seed.
     metrics_factory: Option<SourceFactory>,
+    /// Metric queries the runner evaluates against every successful seed.
+    metric_queries: Vec<MetricQueryPlan>,
     chaos_duration: Option<Duration>,
     exploration_config: Option<crate::chaos::exploration_glue::ExplorationConfig>,
     /// Replay breakpoints staged for the next orchestration run. Installed
@@ -283,6 +287,7 @@ impl SimulationBuilder {
             fault_injectors: Vec::new(),
             fault_factories: Vec::new(),
             metrics_factory: None,
+            metric_queries: Vec::new(),
             chaos_duration: None,
             exploration_config: None,
             pending_replay: None,
@@ -600,6 +605,47 @@ impl SimulationBuilder {
                 source as std::sync::Arc<dyn std::any::Any + Send + Sync>,
             )
         }));
+        self
+    }
+
+    /// Declare a metric query the runner evaluates after every successful
+    /// seed.
+    ///
+    /// The runner — not the report, not the CLI — decides what is worth
+    /// watching. Queries are declared once, before `run()`, and their results
+    /// travel with the report in
+    /// [`SimulationReport::metric_queries`](super::report::SimulationReport::metric_queries),
+    /// each row stamped with the seed that produced it so a bad number is
+    /// immediately replayable.
+    ///
+    /// ```ignore
+    /// use std::time::Duration;
+    /// use moonpool_core::metrics::query::{Mean, MetricQuery, Percentile};
+    ///
+    /// SimulationBuilder::new()
+    ///     .metrics_factory(|_ip| Arc::new(PrometheusSource::default()))
+    ///     .metric(
+    ///         MetricQuery::select("requests_total")
+    ///             .label("operation", "write")
+    ///             .rate()
+    ///             .bucketize(Duration::from_secs(60), Mean)
+    ///             .named("write_throughput"),
+    ///     )
+    ///     .metric(
+    ///         MetricQuery::select("request_latency_seconds")
+    ///             .bucketize(Duration::from_secs(60), Percentile(0.99))
+    ///             .named("write_p99"),
+    ///     )
+    ///     .workload(MyWorkload::default())
+    ///     .run();
+    /// ```
+    ///
+    /// Queries read the same data the report already collects, so this needs a
+    /// [`metrics_factory`](Self::metrics_factory); without one there are no
+    /// series to select and every query reports zero runs.
+    #[must_use]
+    pub fn metric(mut self, query: MetricQueryPlan) -> Self {
+        self.metric_queries.push(query);
         self
     }
 
@@ -1406,6 +1452,8 @@ impl SimulationBuilder {
             convergence_timeout: false,
             saturation: None,
             app_metrics: Vec::new(),
+            run_id: 0,
+            metric_queries: Vec::new(),
         }
     }
 
@@ -1779,8 +1827,10 @@ impl SimulationBuilder {
                     .metrics_collector
                     .add_faulty_seeds(faulty_seeds_from_deadlock);
                 state.metrics_collector.add_failed_runs(failed_count);
-                let metrics_collector =
-                    std::mem::replace(&mut state.metrics_collector, MetricsCollector::new());
+                let metrics_collector = std::mem::replace(
+                    &mut state.metrics_collector,
+                    MetricsCollector::new(0, Vec::new()),
+                );
                 Err(Box::new(Self::build_early_exit_report(
                     metrics_collector,
                     iteration_count,

--- a/crates/moonpool-sim/src/runner/display.rs
+++ b/crates/moonpool-sim/src/runner/display.rs
@@ -7,11 +7,12 @@ use std::io::{IsTerminal, Write};
 
 use moonpool_assertions::AssertKind;
 use moonpool_core::metrics::HistogramValue;
+use moonpool_core::metrics::query::{MetricQueryReport, MetricWindowSummary};
 
 use super::report::{
     AssertionDetail, AssertionStatus, BucketSiteSummary, ExplorationReport, SaturationSignal,
-    SimulationReport, f64_to_u64_saturating, fmt_duration, fmt_num, format_recipe, kind_label,
-    kind_sort_order,
+    SimulationReport, f64_to_u64_saturating, fmt_duration, fmt_num, fmt_sim_ms, format_recipe,
+    kind_label, kind_sort_order,
 };
 
 // ---------------------------------------------------------------------------
@@ -295,6 +296,11 @@ fn write_report(w: &mut impl Write, report: &SimulationReport, color: bool) {
         write_app_metrics(w, report, color);
     }
 
+    // === Metric Queries ===
+    if !report.metric_queries.is_empty() {
+        write_metric_queries(w, &report.metric_queries, color);
+    }
+
     // === Per-Seed Metrics ===
     if report.seeds_used.len() > 1 {
         write_seeds(w, report, color);
@@ -545,6 +551,120 @@ fn write_app_metrics(w: &mut impl Write, report: &SimulationReport, color: bool)
             metrics.len() - MAX_METRIC_ROWS,
         );
     }
+}
+
+/// Largest number of per-bucket rows printed for one query before the rest
+/// are elided. A long run bucketized at 60s produces a lot of them; the full
+/// set is always on the report.
+const MAX_QUERY_WINDOWS: usize = 12;
+
+/// Render every registered metric query's across-run summary.
+///
+/// A query that collapsed to a single window per run gets the flat form — one
+/// distribution over runs. One that kept its buckets gets a row per bucket, so
+/// a throughput that decays over simulated time is visible as a shape rather
+/// than as one averaged-away number.
+fn write_metric_queries(w: &mut impl Write, queries: &[MetricQueryReport], color: bool) {
+    section_header(
+        w,
+        &format!("Metric Queries ({})", queries.len()),
+        color,
+        ansi::BOLD_CYAN,
+    );
+
+    let dim = if color { ansi::DIM } else { "" };
+    let bold = if color { ansi::BOLD } else { "" };
+    let reset = if color { ansi::RESET } else { "" };
+
+    for (i, query) in queries.iter().enumerate() {
+        if i > 0 {
+            let _ = writeln!(w);
+        }
+        let _ = writeln!(w, "  {bold}{}{reset}", query.name);
+        let _ = writeln!(
+            w,
+            "    {dim}{}  ·  {} per run  ·  runs: {}{reset}",
+            query.description,
+            query.provenance.label(),
+            fmt_num(u64::try_from(query.runs).unwrap_or(u64::MAX)),
+        );
+
+        if query.windows.is_empty() {
+            let _ = writeln!(w, "    {dim}no series matched{reset}");
+            continue;
+        }
+
+        // One window per run: the whole query is a single distribution over
+        // runs, so print it as one block rather than as a table of one row.
+        if query.windows.len() == 1 {
+            write_query_stats(w, &query.windows[0], "    ", color);
+            continue;
+        }
+
+        for window in query.windows.iter().take(MAX_QUERY_WINDOWS) {
+            let _ = writeln!(w, "    {}", window_label(window));
+            write_query_stats(w, window, "      ", color);
+        }
+        if query.windows.len() > MAX_QUERY_WINDOWS {
+            let _ = writeln!(
+                w,
+                "    {dim}... {} more windows (see SimulationReport::metric_queries){reset}",
+                query.windows.len() - MAX_QUERY_WINDOWS,
+            );
+        }
+    }
+}
+
+/// `[0s,60s)` for a bucket, `eu [0s,60s)` when the query kept groups.
+///
+/// A whole-run value has no meaningful span (both bounds are
+/// `WHOLE_RUN_MS`), so it is labelled by its group alone.
+fn window_label(window: &MetricWindowSummary) -> String {
+    if window.bucket_start_ms == window.bucket_end_ms {
+        return window
+            .group
+            .clone()
+            .unwrap_or_else(|| "whole run".to_owned());
+    }
+    let span = format!(
+        "[{},{})",
+        fmt_sim_ms(window.bucket_start_ms),
+        fmt_sim_ms(window.bucket_end_ms),
+    );
+    match &window.group {
+        Some(group) => format!("{group} {span}"),
+        None => span,
+    }
+}
+
+/// One window's distribution across runs, with the seed behind each extremum.
+///
+/// The percentiles are over runs — each seed contributes one value — which is
+/// why they are printed for a percentile-derived query too: `p95` here names
+/// the 95th-percentile *run*, not a percentile of the observations beneath it.
+fn write_query_stats(w: &mut impl Write, window: &MetricWindowSummary, indent: &str, color: bool) {
+    let dim = if color { ansi::DIM } else { "" };
+    let reset = if color { ansi::RESET } else { "" };
+    let _ = writeln!(
+        w,
+        "{indent}min   {:>14}   {dim}seed={}{reset}",
+        fmt_metric(window.min),
+        window.min_seed,
+    );
+    let _ = writeln!(w, "{indent}mean  {:>14}", fmt_metric(window.mean));
+    let _ = writeln!(
+        w,
+        "{indent}max   {:>14}   {dim}seed={}{reset}",
+        fmt_metric(window.max),
+        window.max_seed,
+    );
+    let _ = writeln!(
+        w,
+        "{indent}{dim}across runs:{reset}  p50 {}  p95 {}  p99 {}",
+        fmt_metric(window.p50),
+        fmt_metric(window.p95),
+        fmt_metric(window.p99),
+    );
 }
 
 /// Format a metric scalar: integral values print without a decimal tail, so a

--- a/crates/moonpool-sim/src/runner/iteration.rs
+++ b/crates/moonpool-sim/src/runner/iteration.rs
@@ -64,6 +64,18 @@ impl IterationManager {
         seed
     }
 
+    /// Identity of this whole `run()` invocation.
+    ///
+    /// The base seed every generated iteration seed is derived from — fresh
+    /// per invocation (wall-clock entropy) even when the caller pins explicit
+    /// debug seeds, which is exactly what distinguishes one execution from
+    /// another. Metric query results carry it alongside the per-iteration
+    /// seed: the seed says *what* to replay, the run id says *which run* the
+    /// number came from.
+    pub(crate) fn run_id(&self) -> u64 {
+        self.base_seed
+    }
+
     /// Return the number of iterations started so far.
     pub(crate) fn current_iteration(&self) -> usize {
         self.iteration_count

--- a/crates/moonpool-sim/src/runner/metrics.rs
+++ b/crates/moonpool-sim/src/runner/metrics.rs
@@ -3,6 +3,10 @@
 use std::collections::BTreeMap;
 use std::time::Duration;
 
+use moonpool_core::metrics::query::{
+    MetricQueryPlan, MetricQueryReport, MetricQueryRow, MetricSnapshot,
+};
+
 use crate::chaos::AssertionStats;
 use crate::{SimulationError, SimulationResult};
 
@@ -20,11 +24,19 @@ pub(crate) struct MetricsCollector {
     faulty_seeds: Vec<u64>,
     /// Application-metric series folded across seeds, keyed by series identity.
     app_metrics: BTreeMap<String, MetricAggregate>,
+    /// Identity of this `run()` invocation, stamped onto every query row.
+    run_id: u64,
+    /// Queries registered on the builder, evaluated once per successful seed.
+    metric_queries: Vec<MetricQueryPlan>,
+    /// Rows produced so far, parallel to `metric_queries`.
+    metric_query_rows: Vec<Vec<MetricQueryRow>>,
 }
 
 impl MetricsCollector {
-    /// Create an empty metrics collector.
-    pub(crate) fn new() -> Self {
+    /// Create an empty metrics collector for run `run_id`, evaluating
+    /// `metric_queries` against every successful iteration.
+    pub(crate) fn new(run_id: u64, metric_queries: Vec<MetricQueryPlan>) -> Self {
+        let metric_query_rows = vec![Vec::new(); metric_queries.len()];
         Self {
             successful_runs: 0,
             failed_runs: 0,
@@ -32,6 +44,9 @@ impl MetricsCollector {
             individual_metrics: Vec::new(),
             faulty_seeds: Vec::new(),
             app_metrics: BTreeMap::new(),
+            run_id,
+            metric_queries,
+            metric_query_rows,
         }
     }
 
@@ -66,10 +81,33 @@ impl MetricsCollector {
             &metrics.app_metrics,
             &metrics.app_series,
         );
+        self.evaluate_queries(seed, &metrics);
 
         let mut individual = metrics;
         individual.wall_time = wall_time;
         self.individual_metrics.push(Ok(individual));
+    }
+
+    /// Evaluate every registered query against one iteration's metrics.
+    ///
+    /// Done here rather than in the orchestrator because this is where the
+    /// seed and the iteration's metrics meet, and because only successful
+    /// iterations should contribute: a run that deadlocked describes a system
+    /// that never reached steady state.
+    fn evaluate_queries(&mut self, seed: u64, metrics: &SimulationMetrics) {
+        if self.metric_queries.is_empty() {
+            return;
+        }
+        let end_time_ms = u64::try_from(metrics.simulated_time.as_millis()).unwrap_or(u64::MAX);
+        let snapshot =
+            MetricSnapshot::from_run(&metrics.app_metrics, &metrics.app_series, end_time_ms);
+        for (plan, rows) in self
+            .metric_queries
+            .iter()
+            .zip(self.metric_query_rows.iter_mut())
+        {
+            rows.extend(plan.evaluate(&snapshot, self.run_id, seed));
+        }
     }
 
     fn record_failure(&mut self, seed: u64) {
@@ -134,6 +172,14 @@ impl MetricsCollector {
         let app_metrics = std::mem::take(&mut self.app_metrics)
             .into_values()
             .collect::<Vec<_>>();
+        // Registration order, so the report reads the way the runner declared
+        // its queries rather than in some incidental map order.
+        let metric_queries = self
+            .metric_queries
+            .iter()
+            .zip(std::mem::take(&mut self.metric_query_rows))
+            .map(|(plan, rows)| MetricQueryReport::from_rows(plan, rows))
+            .collect();
         SimulationReport {
             iterations: inputs.iteration_count,
             successful_runs: self.successful_runs,
@@ -152,6 +198,8 @@ impl MetricsCollector {
             convergence_timeout: inputs.convergence_timeout,
             saturation: inputs.saturation,
             app_metrics,
+            run_id: self.run_id,
+            metric_queries,
         }
     }
 }

--- a/crates/moonpool-sim/src/runner/report.rs
+++ b/crates/moonpool-sim/src/runner/report.rs
@@ -7,6 +7,7 @@ use std::fmt;
 use std::time::Duration;
 
 use moonpool_assertions::AssertKind;
+use moonpool_core::metrics::query::MetricQueryReport;
 use moonpool_core::metrics::{HistogramValue, MetricPoint, MetricSample, MetricValue};
 
 use crate::SimulationResult;
@@ -346,6 +347,22 @@ pub struct SimulationReport {
     /// series key. Empty unless the simulation registered a
     /// [`metrics_factory`](super::builder::SimulationBuilder::metrics_factory).
     pub app_metrics: Vec<MetricAggregate>,
+    /// Identity of this `run()` invocation, carried on every
+    /// [`MetricQueryRow`](moonpool_core::metrics::query::MetricQueryRow) so a
+    /// value can be traced back to the execution that produced it.
+    ///
+    /// Distinct from a seed: the seed identifies one replayable iteration,
+    /// the run id identifies the whole exploration invocation those
+    /// iterations belonged to.
+    pub run_id: u64,
+    /// Evaluated metric queries, one per query registered with
+    /// [`metric`](super::builder::SimulationBuilder::metric), in registration
+    /// order.
+    ///
+    /// Each carries every per-seed row it produced plus the across-run
+    /// summary the report prints. Empty unless the simulation registered
+    /// queries.
+    pub metric_queries: Vec<MetricQueryReport>,
 }
 
 impl SimulationReport {
@@ -453,6 +470,47 @@ pub(crate) fn fmt_duration(d: Duration) -> String {
         let mins = d.as_secs() / 60;
         let secs = d.as_secs() % 60;
         format!("{mins}m {secs:02}s")
+    }
+}
+
+/// One metric-query window as a single line, for the plain `Display` path.
+///
+/// `min`/`max` carry the seed that produced them; the percentiles are across
+/// runs, not across the observations beneath each run's value.
+fn fmt_query_window(window: &moonpool_core::metrics::query::MetricWindowSummary) -> String {
+    // A whole-run value has no meaningful span; both bounds are WHOLE_RUN_MS.
+    let bounds = if window.bucket_start_ms == window.bucket_end_ms {
+        "whole run".to_owned()
+    } else {
+        format!(
+            "[{},{})",
+            fmt_sim_ms(window.bucket_start_ms),
+            fmt_sim_ms(window.bucket_end_ms)
+        )
+    };
+    let span = match &window.group {
+        Some(group) => format!("{group} {bounds}"),
+        None => bounds,
+    };
+    format!(
+        "{span}  min={:.2} (seed={})  mean={:.2}  max={:.2} (seed={})  p50={:.2}  p95={:.2}  p99={:.2}",
+        window.min,
+        window.min_seed,
+        window.mean,
+        window.max,
+        window.max_seed,
+        window.p50,
+        window.p95,
+        window.p99,
+    )
+}
+
+/// Simulated milliseconds as the shortest exact label, e.g. `60s` or `1500ms`.
+pub(crate) fn fmt_sim_ms(ms: u64) -> String {
+    if ms.is_multiple_of(1000) {
+        format!("{}s", ms / 1000)
+    } else {
+        format!("{ms}ms")
     }
 }
 
@@ -755,6 +813,25 @@ impl fmt::Display for SimulationReport {
                 f,
                 "  UntilCoverageStable hit the iteration cap without saturating."
             )?;
+        }
+
+        // === Metric Queries ===
+        if !self.metric_queries.is_empty() {
+            writeln!(f)?;
+            writeln!(f, "--- Metric Queries ({}) ---", self.metric_queries.len())?;
+            for query in &self.metric_queries {
+                writeln!(
+                    f,
+                    "  {}  [{}]  {} per run  runs: {}",
+                    query.name,
+                    query.description,
+                    query.provenance.label(),
+                    query.runs
+                )?;
+                for window in &query.windows {
+                    writeln!(f, "    {}", fmt_query_window(window))?;
+                }
+            }
         }
 
         // === Per-Seed Metrics ===

--- a/crates/moonpool-sim/tests/metric_queries.rs
+++ b/crates/moonpool-sim/tests/metric_queries.rs
@@ -1,0 +1,278 @@
+//! End-to-end: a runner declares metric queries, and their per-seed results
+//! reach the report with the seed and run id that produced them.
+//!
+//! The metrics source here is hand-rolled rather than a `prometheus::Registry`
+//! so the test exercises the runner wiring, not an adapter: what matters is
+//! that `SeriesRecorder` points recorded on the simulated clock flow into
+//! `SimulationReport::metric_queries`.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use moonpool_sim::{
+    Max, Mean, MetricPoint, MetricQuery, MetricSample, MetricValue, MetricsSource, Percentile,
+    Provenance, SeriesRecorder, SimContext, SimulationBuilder, SimulationReport, SimulationResult,
+    TimeProvider, Workload,
+};
+
+/// A minimal [`MetricsSource`]: one counter and one latency series, recorded
+/// through a [`SeriesRecorder`] so both carry simulated timestamps.
+struct Counters {
+    recorder: SeriesRecorder,
+    total: std::sync::atomic::AtomicU64,
+}
+
+impl Counters {
+    fn new() -> Self {
+        Self {
+            recorder: SeriesRecorder::new(),
+            total: std::sync::atomic::AtomicU64::new(0),
+        }
+    }
+
+    /// Increment `requests_total{operation="write"}`, recording the new
+    /// cumulative value the way an instrumented counter handle would.
+    fn request(&self) {
+        let next = self
+            .total
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            + 1;
+        let value = u32::try_from(next).map_or(f64::INFINITY, f64::from);
+        self.recorder
+            .record(r#"requests_total{operation="write"}"#, value);
+    }
+
+    /// Observe one latency, as a histogram handle would: the observation
+    /// itself, not a running total.
+    fn latency(&self, seconds: f64) {
+        self.recorder.record("request_latency_seconds", seconds);
+    }
+}
+
+impl MetricsSource for Counters {
+    fn collect(&self) -> Vec<MetricSample> {
+        let total = self.total.load(std::sync::atomic::Ordering::Relaxed);
+        vec![MetricSample::new(
+            "requests_total",
+            vec![("operation".to_owned(), "write".to_owned())],
+            MetricValue::Counter(u32::try_from(total).map_or(f64::INFINITY, f64::from)),
+        )]
+    }
+
+    fn set_clock(&self, clock: Arc<dyn moonpool_sim::MetricClock>) {
+        self.recorder.set_clock(clock);
+    }
+
+    fn series(&self) -> BTreeMap<String, Vec<MetricPoint>> {
+        self.recorder.series()
+    }
+}
+
+/// Issues `requests` requests, one every 100 simulated milliseconds, with a
+/// latency that grows with the request index so percentiles have a shape.
+struct MeteredWorkload {
+    requests: u64,
+}
+
+#[async_trait]
+impl Workload for MeteredWorkload {
+    fn name(&self) -> &'static str {
+        "metered"
+    }
+
+    async fn run(&mut self, ctx: &SimContext) -> SimulationResult<()> {
+        let metrics = ctx.metrics::<Counters>().expect("metrics factory set");
+        for i in 0..self.requests {
+            ctx.time().sleep(Duration::from_millis(100)).await.ok();
+            metrics.request();
+            let index = u32::try_from(i).map_or(f64::INFINITY, f64::from);
+            metrics.latency(0.001 * (index + 1.0));
+        }
+        Ok(())
+    }
+}
+
+/// Run `seeds` iterations with two queries registered: a bucketized throughput
+/// and a bucketized p99 latency.
+fn run_with_queries(seeds: &[u64], requests: u64) -> SimulationReport {
+    SimulationBuilder::new()
+        .set_debug_seeds(seeds.to_vec())
+        .set_iterations(seeds.len())
+        .metrics_factory(|_ip| Arc::new(Counters::new()))
+        .metric(
+            MetricQuery::select("requests_total")
+                .label("operation", "write")
+                .rate()
+                .bucketize(Duration::from_mins(1), Mean)
+                .reduce(Mean)
+                .named("write_throughput"),
+        )
+        .metric(
+            MetricQuery::select("request_latency_seconds")
+                .bucketize(Duration::from_mins(1), Percentile(0.99))
+                .named("write_p99"),
+        )
+        .workload(MeteredWorkload { requests })
+        .run()
+}
+
+fn query<'a>(report: &'a SimulationReport, name: &str) -> &'a moonpool_sim::MetricQueryReport {
+    report
+        .metric_queries
+        .iter()
+        .find(|q| q.name == name)
+        .unwrap_or_else(|| panic!("{name} missing from {:?}", report.metric_queries))
+}
+
+#[test]
+fn declared_queries_reach_the_report_with_seed_and_run_id() {
+    let seeds = vec![11, 22, 33];
+    let report = run_with_queries(&seeds, 20);
+    assert_eq!(report.failed_runs, 0, "workload should succeed");
+    assert_eq!(
+        report.metric_queries.len(),
+        2,
+        "one report per registered query, in registration order"
+    );
+    assert_eq!(report.metric_queries[0].name, "write_throughput");
+    assert_eq!(report.metric_queries[1].name, "write_p99");
+
+    let throughput = query(&report, "write_throughput");
+    assert_eq!(throughput.runs, seeds.len());
+    assert!(!throughput.rows.is_empty(), "queries produced rows");
+
+    // run_id identifies the invocation; the seed identifies the replay.
+    assert_ne!(report.run_id, 0, "a run id was assigned");
+    assert!(
+        throughput.rows.iter().all(|r| r.run_id == report.run_id),
+        "every row carries the report's run id"
+    );
+    let seeds_seen: std::collections::BTreeSet<u64> =
+        throughput.rows.iter().map(|r| r.seed).collect();
+    assert_eq!(
+        seeds_seen,
+        seeds.iter().copied().collect(),
+        "every seed contributed, and is identifiable"
+    );
+}
+
+#[test]
+fn rate_reads_the_workloads_real_throughput() {
+    // 20 requests, one per 100ms: 10 per simulated second, and the counter
+    // starts at zero, so the whole run averages 10/s.
+    let report = run_with_queries(&[7], 20);
+    let throughput = query(&report, "write_throughput");
+    assert_eq!(throughput.windows.len(), 1, "one 60s bucket");
+    let window = &throughput.windows[0];
+    assert!(
+        (window.mean - 10.0).abs() < 0.01,
+        "expected ~10 req/s, got {}",
+        window.mean
+    );
+    assert_eq!(window.min_seed, 7);
+    assert_eq!(window.max_seed, 7);
+}
+
+#[test]
+fn provenance_distinguishes_a_percentile_from_a_mean() {
+    let report = run_with_queries(&[1], 10);
+    assert_eq!(
+        query(&report, "write_throughput").provenance,
+        Provenance::Scalar,
+        "mean-then-mean is not a percentile"
+    );
+    assert_eq!(
+        query(&report, "write_p99").provenance,
+        Provenance::Quantile,
+        "collapsed by a percentile over the raw observations"
+    );
+}
+
+#[test]
+fn the_worst_seed_is_named_and_replayable() {
+    // Different request counts per seed would need different workloads, so
+    // instead vary the seed set and check the extremes are attributed to a
+    // real seed that can be fed back into set_debug_seeds.
+    let report = run_with_queries(&[101, 202, 303], 15);
+    let latency = query(&report, "write_p99");
+    let window = &latency.windows[0];
+    assert!(
+        [101, 202, 303].contains(&window.max_seed),
+        "max is attributed to a seed that ran"
+    );
+
+    // Replaying that seed alone reproduces the same value.
+    let replay = run_with_queries(&[window.max_seed], 15);
+    let replayed = &query(&replay, "write_p99").windows[0];
+    assert!(
+        (replayed.max - window.max).abs() < 1e-9,
+        "replaying the named seed reproduces the value: {} vs {}",
+        replayed.max,
+        window.max
+    );
+}
+
+#[test]
+fn report_ordering_does_not_depend_on_seed_order() {
+    let forward = run_with_queries(&[5, 6, 7], 12);
+    let backward = run_with_queries(&[7, 6, 5], 12);
+
+    let shape = |report: &SimulationReport| {
+        report
+            .metric_queries
+            .iter()
+            .map(|q| {
+                (
+                    q.name.clone(),
+                    q.windows
+                        .iter()
+                        .map(|w| (w.group.clone(), w.bucket_start_ms, w.bucket_end_ms))
+                        .collect::<Vec<_>>(),
+                )
+            })
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(shape(&forward), shape(&backward));
+
+    // And the printed report is byte-identical for the same seed set.
+    let repeat = run_with_queries(&[5, 6, 7], 12);
+    let rendered = |report: &SimulationReport| {
+        report
+            .metric_queries
+            .iter()
+            .map(|q| format!("{}|{:?}", q.name, summary_of(q)))
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(rendered(&forward), rendered(&repeat));
+}
+
+/// The numbers a report prints for one query, as a comparable tuple list.
+fn summary_of(query: &moonpool_sim::MetricQueryReport) -> Vec<(u64, u64, u64, u64)> {
+    query
+        .windows
+        .iter()
+        .map(|w| (w.bucket_start_ms, w.bucket_end_ms, w.min_seed, w.max_seed))
+        .collect()
+}
+
+#[test]
+fn a_query_matching_nothing_reports_no_runs() {
+    let report = SimulationBuilder::new()
+        .set_debug_seeds(vec![1])
+        .set_iterations(1)
+        .metrics_factory(|_ip| Arc::new(Counters::new()))
+        .metric(
+            MetricQuery::select("no_such_metric")
+                .reduce(Max)
+                .named("nope"),
+        )
+        .workload(MeteredWorkload { requests: 3 })
+        .run();
+
+    let nope = query(&report, "nope");
+    assert_eq!(nope.runs, 0);
+    assert!(nope.rows.is_empty());
+    assert!(nope.windows.is_empty());
+}


### PR DESCRIPTION
Builds on #190. A recorded series is exact but raw — after hundreds of seeds the question is "what throughput did this hold, and which seed was worst?". This adds a small Warp 10-shaped query model so the **workload runner declares what it wants summarized**, and the report answers it.

```rust
SimulationBuilder::new()
    .metrics_factory(|_ip| Arc::new(PrometheusSource::default()))
    .metric(
        MetricQuery::select("requests_total")
            .label("operation", "write")
            .rate()
            .bucketize(Duration::from_secs(60), Mean)
            .fill(Fill::Value(0.0))
            .reduce(Mean)
            .named("write_throughput"),
    )
    .metric(
        MetricQuery::select("request_latency_seconds")
            .bucketize(Duration::from_secs(60), Percentile(0.99))
            .named("write_p99"),
    )
    .set_iterations(500)
    .run();
```

```
━━━ Metric Queries (2) ━━━━━━━━━━━━━━━━━━━━━━━━━━
  write_throughput
    requests_total{operation="write"} → rate → 60s buckets (mean) → fill (0) → reduce (mean)  ·  scalar per run  ·  runs: 500
    min            5,421   seed=9182
    mean           5,973
    max            6,102   seed=224
    across runs:  p50 5,991  p95 6,071  p99 6,094
```

`min`/`max` name the seed that produced them, so the worst run goes straight into `set_debug_seeds(vec[9182])`.

## What's reused

Everything sits on the paths #190 already built rather than beside them:

| Reused | How |
|---|---|
| `MetricSample` / `MetricPoint` / `sort_key()` | the query input and the canonical series identity |
| `SeriesRecorder` | already records raw observations per `observe()` and cumulative values per `inc()` — nothing new was needed for exact percentiles |
| `SimulationMetrics.app_metrics` + `.app_series` | the per-run snapshot a query evaluates against |
| `MetricsCollector::record_success(seed, …)` | already where seed and metrics meet; queries evaluate there |
| `IterationManager::base_seed` | exposed as `run_id()` rather than inventing a new identity |
| `SimulationReport` / `display.rs` | extended with one new section |

## Query model

`moonpool_core::metrics::query` (pure std, wasm-clean) holds the whole thing: `SeriesKey` for canonical name+label identity, `MetricSnapshot` for one run's series, and a typed builder over SELECT / RATE / BUCKETIZE / FILL / INTERPOLATE / MAP / REDUCE with `Min`, `Mean`, `Max` and `Percentile(p)` as the only aggregators. No parser, no expression language, no storage engine.

**Counter semantics are explicit.** Only `.rate()` reads a series as a counter — handling resets Prometheus-style and prepending the implicit zero origin a per-iteration source guarantees. `bucketize(_, Mean)` on a raw counter honestly averages cumulative values rather than silently inferring a throughput.

**Empty buckets.** `bucketize` omits a bucket nothing landed in, because a gap and a zero are different facts. Two ops say which one a metric means, split the way Warp 10 splits them — `.fill(policy)` repeats a value the series already has, `.interpolate()` computes one it never had:

```
bucket                     0 |    1 |    2 |    3 |    4
no fill                   10 |    - |    - |   40 |    -
.fill(Fill::Previous)     10 |   10 |   10 |   40 |   40
.fill(Fill::Next)         10 |   40 |   40 |   40 |    -
.fill(Fill::Value(0.0))   10 |    0 |    0 |   40 |    0
.interpolate()            10 |   20 |   30 |   40 |    -
```

They compose in call order: `.interpolate().fill(Fill::Value(0.0))` draws the line through interior gaps and zeroes the ends interpolation cannot reach. Both read only the *recorded* buckets, never their own output, so a carried value is the last real observation and a run of interpolated gaps is one straight line rather than a drifting curve.

This matters beyond tidiness: without a fill, a seed's bucket set depends on when *that* seed happened to be busy, so the across-run summary splits one window into several with a fraction of the runs in each, and min/max stop comparing like with like. The grid spans bucket zero to the run's end, putting every seed on the same windows.

## Percentile correctness, at compile time

`mean(p99(a), p99(b))` is not a p99, and `p99(p99(a), p99(b))` is not one either. Each stage tracks whether its values are observations, min/mean/max-collapsed scalars, or percentile-derived, and `Percentile` only implements `ValidOn<Observations>`:

```rust
// Compiles: the raw histogram observations are still there.
.bucketize(Duration::from_secs(60), Percentile(0.99))

// Does NOT compile: p99 of per-bucket p99s (or of per-bucket means).
.bucketize(Duration::from_secs(60), Percentile(0.99)).reduce(Percentile(0.99))
```

Two `compile_fail` doctests pin this. `Min`/`Mean`/`Max` still apply anywhere — "the mean of each node's p99" is useful as long as nobody calls it a p99, which is why the report prints each query's provenance (`observations` / `scalar` / `percentile-derived`).

The percentiles in the summary block are a different dimension — taken *across runs*, where every seed contributes one equally-weighted value — so they stay valid whatever a query's own provenance is, and the report labels them `across runs`.

## Seed and run_id

Every `MetricQueryRow` carries `seed` (the replayable identity of one iteration) and `run_id` (the identity of the whole `run()` invocation), as moonpool-side fields — never injected into the application's Prometheus labels. Rows are flat on purpose: that's the shape a CSV export writes, so it can be added later without redesigning anything.

## Testing

35 unit tests in `moonpool-core` covering label canonicalization, selection and subset matching, rate/resets/coalescing, bucket boundaries, each aggregator, the fill and interpolate policies including their edges, rolling MAP, REDUCE alignment, run_id/seed preservation, deterministic report ordering, extreme-seed attribution and multi-seed aggregation; plus integration tests in `moonpool-sim` (runner wiring, replayability of the named worst seed) and `moonpool-prometheus` (queries against a real registry's recorded series).

Book chapter and `sim-metrics-service` example updated.

## Deliberately out of scope

CSV export and metastability detection — this PR is the substrate both will sit on.

---

Validated with `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo nextest run --workspace` (672 passed), doctests, `cargo clippy -p moonpool-sim --no-default-features` and `cargo check --target wasm32-unknown-unknown -p moonpool-sim --no-default-features`, and `mdbook build book/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYZbn4UBExL3HoWoKe9HNS

---
_Generated by [Claude Code](https://claude.ai/code/session_01CYZbn4UBExL3HoWoKe9HNS)_