### PR TITLE
feat(moonpool-sim): bound every fault source with chaos_duration

### DIFF
--- a/book/src/appendix/03-configuration.md
+++ b/book/src/appendix/03-configuration.md
@@ -24,7 +24,7 @@ The builder pattern for configuring and running simulation experiments. Created 
 | `invariant_fn(name, f)` | `String`, closure | Add a closure-based invariant |
 | `fault(f)` | `impl FaultInjector` | Add a custom fault injector instance for the chaos phase (reused across iterations; rejected by exploration) |
 | `fault_factory(f)` | `Fn() -> Box<dyn FaultInjector>` | Add a fault injector rebuilt fresh for every root and explored timeline (exploration-compatible) |
-| `chaos_duration(dur)` | `Duration` | Set the chaos phase duration (faults run concurrently with workloads) |
+| `chaos_duration(dur)` | `Duration` | Bound the window in which new faults may be injected (see [Chaos duration and recovery mode](#chaos-duration-and-recovery-mode)) |
 | `set_iterations(n)` | `usize` | Run exactly N iterations (default: 1) |
 | `set_iteration_control(ctrl)` | `IterationControl` | Set the iteration control strategy |
 | `set_time_limit(dur)` | `Duration` | Run for a wall-clock time duration |
@@ -88,6 +88,34 @@ Strategy for assigning client IDs to workload instances.
 | `RandomRange(range)` | `Range<usize>` | Random ID drawn from `[start..end)` per instance (not guaranteed unique) |
 
 **Default**: `Fixed(0)` (sequential starting from 0, matching FoundationDB's `WorkloadContext.clientId`).
+
+## Chaos duration and recovery mode
+
+`.chaos_duration(dur)` bounds the period during which Moonpool may inject **new**
+faults. When it expires the runner crosses the chaos → recovery boundary in one
+step: `ctx.chaos_shutdown()` is cancelled so fault injectors wind down, and
+`SimWorld::enter_recovery_mode()` switches off every configuration-driven fault
+family and heals the partitions the simulator is holding.
+
+| At the cutoff | |
+|---|---|
+| Stopped | Network: partitions, clogs, bit flips, spontaneous closes, connect failures, clock drift, buggified sleep delays, new per-pair latency degradation |
+| Stopped | Storage: read/write/sync/crash faults, misdirected and phantom writes, new disk stall and throttle episodes |
+| Stopped | Block devices: EIO, read corruption, misdirected and phantom writes, persist failures, barrier violations |
+| Stopped | Fault injectors, including built-in attrition |
+| Healed | Every partition in force — directed pair cuts and asymmetric send-side / receive-side blocks alike |
+| Preserved | Corrupted sectors, lost/misdirected/phantom writes already applied, connections already closed, processes already killed, application state, the fixed extra latency a slow link already sampled |
+| Left to expire | Finite effects already started: disk stall and throttle episodes, clogs, packets already scheduled with a delay |
+
+The persistent consequences of faults already injected remain part of the
+simulated state. **The cluster is not healthy at the cutoff** — only the
+environment stops generating new faults. Recovering from the damage is the
+simulated system's job.
+
+The recovery window is the quiet tail between the cutoff and workload
+completion, while the processes are still alive. The settle phase that follows
+is *not* a recovery window: processes are aborted before it, so it only drains
+the events left in the scheduler.
 
 ## Attrition
 
@@ -287,8 +315,10 @@ Each ordered IP pair samples one fixed latency from this range at first contact 
 
 Builder campaigns apply this fault only to sleeps scheduled inside
 `.chaos_duration()`. Setup and the post-chaos quiet tail do not consume its RNG
-draws or receive extra delay. A directly constructed `SimWorld` has no campaign
-window and applies the configured fault for its whole lifetime.
+draws or receive extra delay (recovery mode also clears the flag outright at the
+cutoff). A directly constructed `SimWorld` has no campaign window and applies the
+configured fault for its whole lifetime, unless you call
+`SimWorld::enter_recovery_mode()` yourself.
 
 ### Connection Failures
 

--- a/book/src/llms.md
+++ b/book/src/llms.md
@@ -726,10 +726,23 @@ when the model permits losing that process's durable state. Failure-domain
 attrition needs `.cluster(...)` and a budget large enough to remove the chosen
 machine, zone, or datacenter.
 
-`.chaos_duration(...)` controls the phase in which attrition and custom fault
-injectors run. Network/storage configuration faults are part of their provider
-models. Leave a recovery segment inside `Workload::run` for final live queries,
-then use `check` for retained state and timeline assertions.
+`.chaos_duration(...)` bounds the window in which Moonpool may inject **new**
+faults of any kind. At the cutoff the runner stops attrition and custom fault
+injectors *and* calls `SimWorld::enter_recovery_mode()`, which switches off every
+configuration-driven network, storage, and block-device fault family and heals
+the partitions in force.
+
+It stops fault generation, it does not repair anything: corrupted sectors, lost
+or misdirected writes, connections already closed, and processes already killed
+all survive the cutoff, and finite effects already started (disk stall/throttle
+episodes, clogs, delayed packets) expire on their own schedule. The cluster is
+not healthy at the cutoff — the environment merely stops making it worse.
+
+Leave a recovery segment inside `Workload::run` after the cutoff for
+reconvergence and final live queries: that quiet tail, with the processes still
+alive, is the only window where protocol recovery can happen (settle runs after
+the processes are aborted). Then use `check` for retained state and timeline
+assertions.
 
 ### Swarm the operation alphabet
 

--- a/book/src/part3-building/04-simulation-builder.md
+++ b/book/src/part3-building/04-simulation-builder.md
@@ -156,13 +156,19 @@ SimulationBuilder::new()
 
 The simulation lifecycle:
 
-1. **Chaos phase** (30 simulated seconds): Workloads run concurrently with fault injectors. Attrition randomly kills and restarts processes, respecting `max_dead` to avoid killing everything at once.
+1. **Chaos phase** (30 simulated seconds): Workloads run concurrently with fault injectors. Attrition randomly kills and restarts processes, respecting `max_dead` to avoid killing everything at once. Configuration-driven network and storage faults fire in this window too.
 
-2. **Workload completion**: After chaos ends, faults stop and the system continues until all workloads finish. Workloads should be finite (do N operations, or sleep for a sim-time duration, then return).
+2. **Chaos cutoff**: `chaos_duration` expires and the simulation enters *recovery mode*. Fault injectors are told to stop, every configuration-driven fault family (network, storage, block device) is switched off, and the partitions the simulator is holding are healed.
 
-3. **Settle**: The orchestrator drains remaining events. If the system does not settle within 30 seconds (sim time), the test fails with diagnostics, surfacing cleanup bugs like leaked tasks or unclosed connections.
+   The cutoff bounds *fault generation only*. It does not repair anything: corrupted sectors stay corrupted, lost writes stay lost, connections the application already saw close stay closed, and a disk stall or clog already running is waited out rather than erased. The cluster is not healthy at the cutoff — the environment has merely stopped making it worse.
 
-4. **Check**: The `check()` methods run inside the event loop, so network RPCs work normally.
+3. **Recovery tail**: The processes are still running, so this is the window where the system under test re-elects, re-replicates, and re-syncs. Give your workloads enough simulated time after the cutoff to converge, and assert on convergence from them.
+
+4. **Workload completion**: Workloads should be finite (do N operations, or sleep for a sim-time duration, then return).
+
+5. **Settle**: Processes are aborted, then the orchestrator drains remaining events. If the system does not settle within the timeout (sim time), the test fails with diagnostics, surfacing cleanup bugs like leaked tasks or unclosed connections. Because the processes are already gone, settle is *not* a recovery window — no protocol work can happen there.
+
+6. **Check**: The `check()` methods run inside the event loop, so network RPCs work normally.
 
 `max_dead: 1` means at most one process is down at any time. The probability weights control the mix of graceful shutdowns (shutdown token fired, grace period) versus instant crashes (no warning, connections abort).
 

--- a/book/src/part3-building/09-attrition.md
+++ b/book/src/part3-building/09-attrition.md
@@ -83,7 +83,7 @@ SimulationBuilder::new()
     .await;
 ```
 
-The `.chaos_duration()` call is required because attrition runs only during the chaos phase. After the chaos duration elapses, fault injectors stop and the system continues until all workloads complete. A settle phase then drains remaining events before checks run, surfacing cleanup bugs rather than hiding them behind an arbitrary timer.
+The `.chaos_duration()` call is required because attrition runs only during the chaos phase. After the chaos duration elapses the simulation enters recovery mode: fault injectors stop, every configuration-driven network and storage fault family is switched off, and partitions are healed, while the system continues until all workloads complete. That quiet tail is where a rebooted process rejoins and the cluster reconverges — the damage from the chaos phase is still there to recover from, since recovery mode stops new faults rather than repairing old ones. A settle phase then drains remaining events before checks run, surfacing cleanup bugs rather than hiding them behind an arbitrary timer.
 
 `ChaosMode::Random` uses your configured weights, recovery window, and scope as
 written every seed. Switch to `ChaosMode::Swarm` to swarm the reboot *regime*

--- a/book/src/part3-building/10-network-faults.md
+++ b/book/src/part3-building/10-network-faults.md
@@ -85,7 +85,18 @@ The gate is checked before either buggified-delay RNG draw. A configuration that
 disables the fault, a `NetworkFaultMask` without `BuggifiedDelay`, and sleeps
 outside the chaos window therefore leave the counted simulation RNG untouched.
 Direct low-level `SimWorld` construction has no campaign phases and retains the
-historical whole-run behavior.
+historical whole-run behavior, unless you call `SimWorld::enter_recovery_mode()`
+yourself.
+
+The same quiet-tail guarantee holds for every other network fault family, not
+just this one: at the `chaos_duration` cutoff the runner calls
+`SimWorld::enter_recovery_mode()`, which zeroes the whole
+`ChaosConfiguration` fault surface and heals any partition in force. What it
+does **not** do is repair damage: bytes already corrupted stay corrupted, a
+connection the application already saw close stays closed, and a link that has
+already sampled its permanent extra latency stays slow. See the
+[configuration appendix](../appendix/03-configuration.md#chaos-duration-and-recovery-mode)
+for the full boundary contract.
 
 ### Network Partitions
 

--- a/crates/moonpool-sim/src/chaos/fault_events.rs
+++ b/crates/moonpool-sim/src/chaos/fault_events.rs
@@ -90,6 +90,16 @@ pub enum SimFaultEvent {
         /// The partitioned IP.
         ip: String,
     },
+    /// Send partition healed (outgoing traffic from an IP flows again).
+    SendPartitionHealed {
+        /// The restored IP.
+        ip: String,
+    },
+    /// Receive partition healed (incoming traffic to an IP flows again).
+    RecvPartitionHealed {
+        /// The restored IP.
+        ip: String,
+    },
     /// Connection randomly closed by chaos.
     RandomClose {
         /// The connection that was closed.
@@ -165,6 +175,8 @@ impl SimFaultEvent {
             Self::PartitionHealed { .. } => "partition_healed",
             Self::SendPartitionCreated { .. } => "send_partition_created",
             Self::RecvPartitionCreated { .. } => "recv_partition_created",
+            Self::SendPartitionHealed { .. } => "send_partition_healed",
+            Self::RecvPartitionHealed { .. } => "recv_partition_healed",
             Self::RandomClose { .. } => "random_close",
             Self::BitFlip { .. } => "bit_flip",
             Self::StorageReadFault { .. } => "storage_read_fault",

--- a/crates/moonpool-sim/src/chaos/mod.rs
+++ b/crates/moonpool-sim/src/chaos/mod.rs
@@ -127,6 +127,22 @@
 //! // Randomized per seed
 //! let chaos = ChaosConfiguration::random_for_seed();
 //! ```
+//!
+//! # The Chaos → Recovery Boundary
+//!
+//! Every mechanism above is bounded by
+//! [`SimulationBuilder::chaos_duration`](crate::SimulationBuilder::chaos_duration).
+//! When it expires the runner calls
+//! [`SimWorld::enter_recovery_mode`](crate::SimWorld::enter_recovery_mode),
+//! which stops all fault injectors, switches off every configuration-driven
+//! network, storage, and block-device fault family, and heals the partitions in
+//! force — giving the system under test a quiet tail to recover in.
+//!
+//! The boundary bounds *fault generation only*. It repairs nothing: corrupted
+//! sectors, lost writes, closed connections, and killed processes all survive
+//! it, and finite effects already running expire on their own schedule. The
+//! cluster is not healthy at the cutoff; the environment has merely stopped
+//! making it worse.
 
 pub mod assertions;
 pub mod buggify;

--- a/crates/moonpool-sim/src/network/config.rs
+++ b/crates/moonpool-sim/src/network/config.rs
@@ -574,6 +574,28 @@ impl ChaosConfiguration {
         self.random_close_probability =
             crate::buggify_knob!(self.random_close_probability, 0.01..0.1);
     }
+
+    /// Turn every network fault family off, leaving performance shaping alone.
+    ///
+    /// This is the chaos half of the recovery-mode transition
+    /// ([`SimWorld::enter_recovery_mode`](crate::SimWorld::enter_recovery_mode)):
+    /// after this call the engine samples no new partitions, clogs, bit flips,
+    /// spontaneous closes, connect failures, clock drift, sleep delays, or
+    /// per-pair latency degradations. It is exactly
+    /// [`NetworkFaultMask::none()`](crate::NetworkFaultMask::none) applied to
+    /// this configuration and consumes no randomness.
+    ///
+    /// It only stops *new* faults. Everything already produced stays: a
+    /// partition still in force, a clog still ticking down, corrupted bytes
+    /// already delivered, a connection the application already saw close, and
+    /// the fixed extra latency a slow pair already sampled.
+    ///
+    /// Latencies (`bind`/`accept`/`connect`/`write`, `link_latency`) and the
+    /// TCP-realistic partial read/write sizes are untouched: they are the
+    /// deployment's normal characteristics, not injected damage.
+    pub fn disable_fault_injection(&mut self) {
+        NetworkFaultMask::none().apply_to(self);
+    }
 }
 
 /// Distance-based latency, one [`LatencyDistribution`] per locality class.
@@ -675,6 +697,17 @@ impl Default for NetworkConfiguration {
             link_latency: None,
             chaos: ChaosConfiguration::default(),
         }
+    }
+}
+
+impl NetworkConfiguration {
+    /// Turn every network fault family off while keeping latency, link, and
+    /// other performance characteristics intact.
+    ///
+    /// See [`ChaosConfiguration::disable_fault_injection`] for the precise
+    /// contract.
+    pub fn disable_fault_injection(&mut self) {
+        self.chaos.disable_fault_injection();
     }
 }
 

--- a/crates/moonpool-sim/src/network/sim/engine.rs
+++ b/crates/moonpool-sim/src/network/sim/engine.rs
@@ -943,9 +943,6 @@ impl NetworkSimulation {
     pub(crate) fn connection_base_latency(&mut self, id: ConnectionId) -> Duration {
         let range = self.state.config.chaos.max_pair_latency.clone();
         let link = self.state.config.link_latency.clone();
-        if range.end.is_zero() && link.is_none() {
-            return Duration::ZERO;
-        }
         let Some((local, remote)) = self
             .state
             .connections
@@ -954,8 +951,15 @@ impl NetworkSimulation {
         else {
             return Duration::ZERO;
         };
+        // A pair samples its fixed extra latency once and keeps it for the rest
+        // of the run. Checking the cache *before* the configuration means
+        // recovery mode (which zeroes `max_pair_latency`) stops new pairs from
+        // degrading without healing a link that is already slow.
         if let Some(latency) = self.pair_latency(local, remote) {
             return latency;
+        }
+        if range.end.is_zero() && link.is_none() {
+            return Duration::ZERO;
         }
         let mut latency = if range.end.is_zero() {
             Duration::ZERO
@@ -1332,6 +1336,39 @@ impl NetworkSimulation {
         });
         self.resume_stalled_sends(now, &mut actions);
         actions
+    }
+
+    /// Heal every environmental partition currently in force: directed pair
+    /// cuts plus the send-side and receive-side blocks that
+    /// [`restore_partition`](Self::restore_partition) cannot reach.
+    ///
+    /// Connections held back by a partition are re-driven, so a stalled send
+    /// resumes instead of waiting out a deadline that no longer applies.
+    pub(crate) fn heal_all_partitions(&mut self, now: Duration) -> NetworkActions {
+        let mut actions = NetworkActions::default();
+        for (from, to) in std::mem::take(&mut self.state.ip_partitions).into_keys() {
+            actions.record(SimFaultEvent::PartitionHealed {
+                from: from.to_string(),
+                to: to.to_string(),
+            });
+        }
+        for ip in std::mem::take(&mut self.state.send_partitions).into_keys() {
+            actions.record(SimFaultEvent::SendPartitionHealed { ip: ip.to_string() });
+        }
+        for ip in std::mem::take(&mut self.state.recv_partitions).into_keys() {
+            actions.record(SimFaultEvent::RecvPartitionHealed { ip: ip.to_string() });
+        }
+        self.resume_stalled_sends(now, &mut actions);
+        actions
+    }
+
+    /// Stop sampling new network faults (see
+    /// [`ChaosConfiguration::disable_fault_injection`](crate::network::ChaosConfiguration::disable_fault_injection)).
+    ///
+    /// Consumes no randomness and leaves every already-produced effect in
+    /// place, including the per-pair latencies sampled so far.
+    pub(crate) fn disable_fault_injection(&mut self) {
+        self.state.config.disable_fault_injection();
     }
 
     pub(crate) fn is_partitioned(&self, from: IpAddr, to: IpAddr, now: Duration) -> bool {

--- a/crates/moonpool-sim/src/network/sim/facade.rs
+++ b/crates/moonpool-sim/src/network/sim/facade.rs
@@ -32,8 +32,16 @@ impl SimWorld {
     }
 
     /// Replaces the network configuration without discarding live connections.
-    pub fn set_network_config(&mut self, config: NetworkConfiguration) {
+    ///
+    /// After [`enter_recovery_mode`](Self::enter_recovery_mode) the chaos
+    /// families in `config` are stripped before it is installed, so the
+    /// no-new-faults promise survives a later reconfiguration. Latency
+    /// distributions and link shaping are installed as given.
+    pub fn set_network_config(&mut self, mut config: NetworkConfiguration) {
         let mut inner = self.inner.write();
+        if inner.recovery_mode() {
+            config.disable_fault_injection();
+        }
         let now = inner.now();
         let actions = inner.network.set_config(config, now);
         inner.apply_network(actions);

--- a/crates/moonpool-sim/src/runner/builder.rs
+++ b/crates/moonpool-sim/src/runner/builder.rs
@@ -674,12 +674,43 @@ impl SimulationBuilder {
         self
     }
 
-    /// Set the chaos phase duration.
+    /// Set the chaos phase duration: the window in which Moonpool may inject
+    /// *new* faults.
     ///
-    /// When set, fault injectors run concurrently with workloads for this
-    /// duration. After it elapses, faults stop and the system continues
-    /// until all workloads complete. A settle phase then drains remaining
-    /// events before checks run.
+    /// Fault injectors run concurrently with the workloads for this long. When
+    /// it elapses the runner ends chaos in one step: it cancels
+    /// [`ctx.chaos_shutdown()`](crate::FaultContext::chaos_shutdown), so
+    /// injector loops wind down, and calls
+    /// [`SimWorld::enter_recovery_mode`](crate::SimWorld::enter_recovery_mode),
+    /// which turns off every configuration-driven network, storage, and
+    /// block-device fault family and heals the partitions the simulator is
+    /// holding.
+    ///
+    /// # The contract
+    ///
+    /// The cutoff bounds *fault generation*, nothing else. The persistent
+    /// consequences of faults already injected stay part of the simulated
+    /// state: corrupted sectors, lost or misdirected writes, connections the
+    /// application already saw close, processes already killed, and whatever
+    /// state the system was left in. Finite effects already started — a disk
+    /// stall or throttle episode, a clog, a delayed packet — keep their
+    /// deadlines and expire naturally.
+    ///
+    /// So the cutoff does **not** mean the cluster is healthy. It means the
+    /// environment stopped making it worse, and recovering is now the system
+    /// under test's job.
+    ///
+    /// # Where recovery actually happens
+    ///
+    /// Between the cutoff and workload completion — the quiet tail — because
+    /// that is the only window where the processes are still running and can
+    /// re-elect, re-replicate, or re-sync. Give the workloads enough simulated
+    /// time after the cutoff to converge, then assert on convergence from
+    /// them.
+    ///
+    /// The settle phase that follows is *not* a recovery window: processes are
+    /// aborted before it, so it only drains the events left in the scheduler
+    /// before `check()` runs.
     #[must_use]
     pub fn chaos_duration(mut self, duration: Duration) -> Self {
         self.chaos_duration = Some(duration);

--- a/crates/moonpool-sim/src/runner/orchestrator.rs
+++ b/crates/moonpool-sim/src/runner/orchestrator.rs
@@ -88,7 +88,6 @@ struct RunPhaseInputs<'a, 'pm> {
     shutdown_signal: &'a tokio_util::sync::CancellationToken,
     chaos_shutdown: &'a tokio_util::sync::CancellationToken,
     chaos_duration: Option<Duration>,
-    all_ips: &'a [String],
     workload_handles: &'a mut WorkloadHandleSlots,
     workload_collected: &'a mut [Option<WorkloadResult>],
     injector_handles: &'a mut InjectorHandleSlots,
@@ -248,7 +247,6 @@ struct ChaosAndRunInputs<'a, 'pm> {
     contexts: Vec<SimContext>,
     fault_injectors: Vec<Box<dyn FaultInjector>>,
     chaos_duration: Option<Duration>,
-    all_entities: &'a [(String, String)],
     state: &'a StateHandle,
     obs: &'a SimulationLayerHandle,
     shutdown_signal: &'a tokio_util::sync::CancellationToken,
@@ -353,7 +351,6 @@ impl WorkloadOrchestrator {
             contexts,
             fault_injectors,
             chaos_duration,
-            all_entities: &all_entities,
             state: &state,
             obs: &obs,
             shutdown_signal: &shutdown_signal,
@@ -504,7 +501,6 @@ impl WorkloadOrchestrator {
             contexts,
             fault_injectors,
             chaos_duration,
-            all_entities,
             state,
             obs,
             shutdown_signal,
@@ -515,7 +511,6 @@ impl WorkloadOrchestrator {
 
         let chaos_shutdown = tokio_util::sync::CancellationToken::new();
         sim.start_buggified_delay_window(chaos_duration);
-        let all_ips: Vec<String> = all_entities.iter().map(|(_, ip)| ip.clone()).collect();
         let (mut injector_handles, parked_injectors) = Self::start_fault_injectors(
             fault_injectors,
             chaos_duration,
@@ -540,7 +535,6 @@ impl WorkloadOrchestrator {
             shutdown_signal,
             chaos_shutdown: &chaos_shutdown,
             chaos_duration,
-            all_ips: &all_ips,
             workload_handles: &mut workload_handles,
             workload_collected: &mut workload_collected,
             injector_handles: &mut injector_handles,
@@ -746,7 +740,6 @@ impl WorkloadOrchestrator {
             shutdown_signal,
             chaos_shutdown,
             chaos_duration,
-            all_ips,
             workload_handles,
             workload_collected,
             injector_handles,
@@ -787,8 +780,15 @@ impl WorkloadOrchestrator {
 
             if !chaos_ended && Self::should_end_chaos(sim, chaos_start, chaos_duration) {
                 tracing::debug!("Chaos phase ended");
+                // Stop the two sources of new faults together: the explicit
+                // injector loops (token) and the configuration-driven network,
+                // storage, and block-device families (recovery mode, which
+                // also heals the partitions the simulator is holding). Damage
+                // already done stays done — the quiet tail that follows is
+                // where the system under test has to recover from it, while
+                // its processes are still alive.
                 chaos_shutdown.cancel();
-                Self::heal_all_partitions(sim, all_ips);
+                sim.enter_recovery_mode();
                 chaos_ended = true;
                 assert_reachable!("phase: chaos ended");
             }
@@ -1283,6 +1283,13 @@ impl WorkloadOrchestrator {
     /// Drain remaining simulation events synchronously after all workloads
     /// have completed.
     ///
+    /// This is **not** a recovery window. `abort_all()` has already killed
+    /// every process by the time settle runs, so no protocol work can happen
+    /// here — it only surfaces cleanup bugs in what the run left behind. The
+    /// window in which the system under test can actually recover from chaos
+    /// is the quiet tail between the `chaos_duration` cutoff and workload
+    /// completion, while the processes are still alive.
+    ///
     /// Returns `Some(SettleTimeout)` if the queue does not converge within
     /// the timeout, otherwise `None` on a clean drain.
     fn settle_phase(sim: &mut crate::sim::SimWorld) -> Option<crate::SimulationError> {
@@ -1451,19 +1458,5 @@ impl WorkloadOrchestrator {
         shutdown_signal.cancel();
 
         sim.schedule_event(crate::sim::Event::Shutdown, Duration::from_nanos(1));
-    }
-
-    /// Heal all network partitions between all IP pairs.
-    fn heal_all_partitions(sim: &mut crate::sim::SimWorld, all_ips: &[String]) {
-        for i in 0..all_ips.len() {
-            for j in (i + 1)..all_ips.len() {
-                if let (Ok(a_ip), Ok(b_ip)) = (
-                    all_ips[i].parse::<std::net::IpAddr>(),
-                    all_ips[j].parse::<std::net::IpAddr>(),
-                ) {
-                    sim.restore_partition(a_ip, b_ip);
-                }
-            }
-        }
     }
 }

--- a/crates/moonpool-sim/src/sim/storage_ops.rs
+++ b/crates/moonpool-sim/src/sim/storage_ops.rs
@@ -303,20 +303,36 @@ impl SimWorld {
     /// call. The builder applies the per-seed chaos configuration here before
     /// any process runs.
     ///
+    /// After [`enter_recovery_mode`](Self::enter_recovery_mode) the fault
+    /// probabilities in `config` are stripped before it is installed, so a
+    /// store created in the quiet tail is born fault-free. The crash-shape
+    /// parameters are installed as given.
+    ///
     /// # Panics
     ///
     /// Panics if the simulation lock is poisoned by a prior task panic.
-    pub fn set_block_fault_config(&self, config: crate::storage::block::BlockFaultConfig) {
-        self.inner.write().block.set_config(config);
+    pub fn set_block_fault_config(&self, mut config: crate::storage::block::BlockFaultConfig) {
+        let mut inner = self.inner.write();
+        if inner.recovery_mode() {
+            config.disable_fault_injection();
+        }
+        inner.block.set_config(config);
     }
 
     /// Set storage configuration for a specific process.
+    ///
+    /// Recovery-aware in the same way as
+    /// [`set_storage_config`](Self::set_storage_config).
     ///
     /// # Panics
     ///
     /// Panics if the simulation lock is poisoned by a prior task panic.
     #[instrument(skip(self, config))]
-    pub fn set_process_storage_config(&self, ip: IpAddr, config: StorageConfiguration) {
-        self.inner.write().storage.set_config_for(ip, config);
+    pub fn set_process_storage_config(&self, ip: IpAddr, mut config: StorageConfiguration) {
+        let mut inner = self.inner.write();
+        if inner.recovery_mode() {
+            config.disable_fault_injection();
+        }
+        inner.storage.set_config_for(ip, config);
     }
 }

--- a/crates/moonpool-sim/src/sim/world.rs
+++ b/crates/moonpool-sim/src/sim/world.rs
@@ -67,6 +67,9 @@ pub(crate) struct SimInner {
     pub(crate) last_processed_event: Option<Event>,
     pub(crate) pending_faults: Vec<SimFaultRecord>,
     buggified_delay_window: BuggifiedDelayWindow,
+    /// Set once [`SimWorld::enter_recovery_mode`] has run. The simulator
+    /// injects no new faults from that point on.
+    recovery_mode: bool,
 }
 
 /// Campaign lifetime for the global sleep-delay fault.
@@ -98,6 +101,7 @@ impl SimInner {
             last_processed_event: None,
             pending_faults: Vec::new(),
             buggified_delay_window: BuggifiedDelayWindow::Unbounded,
+            recovery_mode: false,
         }
     }
 
@@ -290,7 +294,12 @@ impl SimWorld {
         let mut inner = self.inner.write();
         let chaos = &inner.network.config().chaos;
         if !chaos.clock_drift_enabled {
-            return inner.now();
+            // Never hand back a reading below one already given out. Drift that
+            // accumulated before it was switched off (recovery mode) is a real
+            // skew the node still has to live with; rewinding the clock instead
+            // would be a *new* fault, and a nastier one than the drift.
+            inner.timer_time = inner.timer_time.max(inner.now());
+            return inner.timer_time;
         }
         let max_timer = inner.now().saturating_add(chaos.clock_drift_max);
         if inner.timer_time < max_timer {
@@ -470,6 +479,77 @@ impl SimWorld {
             .map_or(BuggifiedDelayWindow::Inactive, |duration| {
                 BuggifiedDelayWindow::ActiveUntil(inner.now().saturating_add(duration))
             });
+    }
+
+    /// End fault injection for the rest of the run: the simulator stops
+    /// generating new faults and heals the environmental partitions it is
+    /// holding, so the system under test gets a quiet tail to recover in.
+    ///
+    /// The runner calls this once, at the [`chaos_duration`] cutoff, together
+    /// with cancelling the fault-injector shutdown token. Calling it directly
+    /// is the raw-`SimWorld` equivalent.
+    ///
+    /// # What stops
+    ///
+    /// - network: partitions, clogs, bit flips, spontaneous closes, connect
+    ///   failures, clock drift, buggified sleep delays, and new per-pair
+    ///   latency degradation;
+    /// - storage: read/write/sync/crash faults, misdirected and phantom
+    ///   writes, and new disk stall or throttle episodes;
+    /// - block devices: EIO, read corruption, misdirected and phantom writes,
+    ///   persist failures, and barrier violations.
+    ///
+    /// # What is healed
+    ///
+    /// Every partition currently in force — directed pair cuts and the
+    /// asymmetric send-side and receive-side blocks alike. A partition is
+    /// environmental: nothing in the system under test can clear it, so
+    /// leaving one up would make the quiet tail untestable rather than quiet.
+    ///
+    /// # What survives
+    ///
+    /// Everything already done. Corrupted sectors stay corrupted, lost writes
+    /// stay lost, misdirected and phantom writes are not undone, a connection
+    /// the application already saw close stays closed, a process already
+    /// killed is not resurrected, and application state is left exactly as the
+    /// chaos phase left it. Finite effects already started — a disk stall or
+    /// throttle episode, a clog, a packet already scheduled with delay — keep
+    /// their deadlines and expire on their own rather than being rewritten.
+    ///
+    /// This is emphatically **not** "the cluster is now healthy": it is only
+    /// "the environment stops making it worse". Recovering from the damage is
+    /// the simulated system's job.
+    ///
+    /// Idempotent, and consumes no randomness.
+    ///
+    /// [`chaos_duration`]: crate::SimulationBuilder::chaos_duration
+    ///
+    /// # Panics
+    ///
+    /// Panics if the simulation lock is poisoned by a prior task panic.
+    pub fn enter_recovery_mode(&mut self) {
+        let mut inner = self.inner.write();
+        if inner.recovery_mode {
+            return;
+        }
+        inner.recovery_mode = true;
+        inner.buggified_delay_window = BuggifiedDelayWindow::Inactive;
+        inner.network.disable_fault_injection();
+        inner.storage.disable_fault_injection();
+        inner.block.disable_fault_injection();
+        let now = inner.now();
+        let actions = inner.network.heal_all_partitions(now);
+        inner.apply_network(actions);
+    }
+
+    /// Whether [`enter_recovery_mode`](Self::enter_recovery_mode) has run.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the simulation lock is poisoned by a prior task panic.
+    #[must_use]
+    pub fn is_in_recovery_mode(&self) -> bool {
+        self.inner.read().recovery_mode
     }
 
     pub(crate) fn poll_sleep(&self, task_id: u64, waker: &Waker) -> bool {

--- a/crates/moonpool-sim/src/sim/world.rs
+++ b/crates/moonpool-sim/src/sim/world.rs
@@ -109,6 +109,16 @@ impl SimInner {
         self.scheduler.now()
     }
 
+    /// Whether [`SimWorld::enter_recovery_mode`] has run.
+    ///
+    /// Every setter that installs a caller-supplied fault configuration has to
+    /// consult this: the recovery boundary promises no new simulator faults for
+    /// the rest of the run, and a configuration installed after it must not be
+    /// able to re-arm one.
+    pub(crate) fn recovery_mode(&self) -> bool {
+        self.recovery_mode
+    }
+
     pub(crate) fn schedule_after(&mut self, event: Event, delay: Duration) {
         if let Err(error) = self.scheduler.schedule_after(delay, event) {
             tracing::error!(%error, "failed to schedule simulation event");
@@ -393,17 +403,34 @@ impl SimWorld {
     }
 
     /// Replaces the default storage configuration.
-    pub fn set_storage_config(&mut self, config: crate::storage::StorageConfiguration) {
-        self.inner.write().storage.set_config(config);
+    ///
+    /// After [`enter_recovery_mode`](Self::enter_recovery_mode) the fault
+    /// probabilities in `config` are stripped before it is installed, so the
+    /// no-new-faults promise survives a later reconfiguration. Performance
+    /// knobs (IOPS, bandwidth, latencies, throttle multipliers) are installed
+    /// as given.
+    pub fn set_storage_config(&mut self, mut config: crate::storage::StorageConfiguration) {
+        let mut inner = self.inner.write();
+        if inner.recovery_mode() {
+            config.disable_fault_injection();
+        }
+        inner.storage.set_config(config);
     }
 
     /// Replaces storage configuration for one IP.
+    ///
+    /// Recovery-aware in the same way as
+    /// [`set_storage_config`](Self::set_storage_config).
     pub fn set_storage_config_for(
         &mut self,
         ip: IpAddr,
-        config: crate::storage::StorageConfiguration,
+        mut config: crate::storage::StorageConfiguration,
     ) {
-        self.inner.write().storage.set_config_for(ip, config);
+        let mut inner = self.inner.write();
+        if inner.recovery_mode() {
+            config.disable_fault_injection();
+        }
+        inner.storage.set_config_for(ip, config);
     }
 
     /// Returns an active disk episode for one IP.
@@ -519,6 +546,26 @@ impl SimWorld {
     /// This is emphatically **not** "the cluster is now healthy": it is only
     /// "the environment stops making it worse". Recovering from the damage is
     /// the simulated system's job.
+    ///
+    /// # It stays entered
+    ///
+    /// The promise holds for the rest of the run, not just for the instant it
+    /// is made. Every setter that installs a caller-supplied fault
+    /// configuration — [`set_network_config`](Self::set_network_config),
+    /// [`set_storage_config`](Self::set_storage_config),
+    /// [`set_storage_config_for`](Self::set_storage_config_for),
+    /// [`set_process_storage_config`](Self::set_process_storage_config),
+    /// [`set_block_fault_config`](Self::set_block_fault_config) — strips the
+    /// fault knobs out of what it is handed once recovery mode is on, while
+    /// installing the performance half unchanged. Reconfiguring a disk or link
+    /// in the quiet tail therefore cannot re-arm chaos.
+    ///
+    /// Directed fault APIs are deliberately left alone: a caller that reaches
+    /// for [`partition_pair`](Self::partition_pair),
+    /// [`simulate_crash_for_process`](Self::simulate_crash_for_process), or the
+    /// [`SimBlockStore`](crate::SimBlockStore) targeted-fault methods is
+    /// scripting a specific fault by hand rather than asking the simulator to
+    /// generate one, and red tests depend on that still working.
     ///
     /// Idempotent, and consumes no randomness.
     ///

--- a/crates/moonpool-sim/src/storage/block/config.rs
+++ b/crates/moonpool-sim/src/storage/block/config.rs
@@ -127,6 +127,35 @@ impl BlockFaultConfig {
         self
     }
 
+    /// Turn off every fault family that fires during normal device I/O.
+    ///
+    /// This is the block-device half of the recovery-mode transition
+    /// ([`SimWorld::enter_recovery_mode`](crate::SimWorld::enter_recovery_mode)):
+    /// reads stop returning EIO or planting latent faults, writes stop being
+    /// misdirected or turned into phantoms, `persist()` stops failing, and it
+    /// stops lying about barriers.
+    ///
+    /// The **crash-shape** parameters (`clean_crash_probability`,
+    /// `crash_lost_probability`, `crash_latent_fault_probability`,
+    /// `shorn_write_probability`, `correlated_rollback_*`,
+    /// `grow_survives_crash_probability`, `garbage_fill_probability`) are left
+    /// alone on purpose: they describe what a crash *does* to buffered data,
+    /// not an environment that generates crashes. Recovery mode stops the
+    /// simulator from generating crashes; if one still happens it must resolve
+    /// with the same physics it would have had before the cutoff.
+    ///
+    /// Damage already on the device — corrupted sectors, lost or misdirected
+    /// writes, sectors a lying `persist()` left volatile — is untouched.
+    pub fn disable_fault_injection(&mut self) {
+        self.eio_read_probability = 0.0;
+        self.eio_write_probability = 0.0;
+        self.read_corruption_probability = 0.0;
+        self.misdirected_write_probability = 0.0;
+        self.phantom_write_probability = 0.0;
+        self.persist_failure_probability = 0.0;
+        self.barrier_violation_probability = 0.0;
+    }
+
     /// Apply a per-seed swarm subset: each enabled fault family is
     /// independently kept or zeroed with probability 0.5, drawn from the
     /// configuration RNG stream (never the counted sim RNG). The barrier

--- a/crates/moonpool-sim/src/storage/block/registry.rs
+++ b/crates/moonpool-sim/src/storage/block/registry.rs
@@ -32,6 +32,18 @@ impl BlockDeviceRegistry {
         self.config = config;
     }
 
+    /// Stop injecting new faults on every block store: the configuration
+    /// future stores are born with, and every store already created.
+    ///
+    /// Damage already written to a device stays (see
+    /// [`BlockFaultConfig::disable_fault_injection`]).
+    pub(crate) fn disable_fault_injection(&mut self) {
+        self.config.disable_fault_injection();
+        for store in self.stores.values() {
+            store.disable_fault_injection();
+        }
+    }
+
     /// The store for `ip`, created on first access.
     pub(crate) fn store_for(&mut self, ip: IpAddr) -> SimBlockStore {
         self.stores

--- a/crates/moonpool-sim/src/storage/block/store.rs
+++ b/crates/moonpool-sim/src/storage/block/store.rs
@@ -297,6 +297,13 @@ struct DeviceState {
 struct StoreState {
     rng: ChaCha8Rng,
     config: BlockFaultConfig,
+    /// Whether the barrier-violation family was ever armed on this store.
+    ///
+    /// Latched at construction rather than read back off `config`, so
+    /// [`SimBlockStore::disable_fault_injection`] can stop *new* lies without
+    /// retroactively turning a sector a pre-cutoff `persist()` already lied
+    /// about into an impossible-state panic in the crash oracle.
+    barrier_violation_armed: bool,
     devices: BTreeMap<String, DeviceState>,
     eligibility: Option<BlockEligibilityMask>,
     fault_records: Vec<BlockFaultRecord>,
@@ -356,6 +363,7 @@ impl SimBlockStore {
         Self {
             inner: Arc::new(Mutex::new(StoreState {
                 rng: ChaCha8Rng::seed_from_u64(seed),
+                barrier_violation_armed: config.barrier_violation_probability > 0.0,
                 config,
                 devices: BTreeMap::new(),
                 eligibility: None,
@@ -372,6 +380,15 @@ impl SimBlockStore {
     /// Remove the fault eligibility mask: every sector becomes eligible.
     pub fn clear_eligibility_mask(&self) {
         self.inner.lock().eligibility = None;
+    }
+
+    /// Stop injecting new device faults (see
+    /// [`BlockFaultConfig::disable_fault_injection`]).
+    ///
+    /// Damage already on the device is untouched, and the crash model keeps
+    /// the shape it was built with.
+    pub fn disable_fault_injection(&self) {
+        self.inner.lock().config.disable_fault_injection();
     }
 
     /// Drain the fault records accumulated so far.
@@ -1038,7 +1055,7 @@ impl SimBlockStore {
             }
         }
 
-        let armed = inner.config.barrier_violation_probability > 0.0;
+        let armed = inner.barrier_violation_armed;
         for (index, state) in device.regions.iter_mut().enumerate() {
             let region = RegionId(u32::try_from(index).expect("region count fits in u32"));
             oracle_sweep(

--- a/crates/moonpool-sim/src/storage/config.rs
+++ b/crates/moonpool-sim/src/storage/config.rs
@@ -375,6 +375,35 @@ impl StorageConfiguration {
         );
     }
 
+    /// Turn every storage fault family off, leaving disk performance alone.
+    ///
+    /// This is the storage half of the recovery-mode transition
+    /// ([`SimWorld::enter_recovery_mode`](crate::SimWorld::enter_recovery_mode)):
+    /// after this call no operation samples a read/write/sync/crash fault, no
+    /// write is misdirected or turned into a phantom, and no new disk stall or
+    /// throttle episode is entered. It consumes no randomness.
+    ///
+    /// It only stops *new* faults. Sectors already corrupted stay corrupted,
+    /// bytes already lost stay lost, misdirected and phantom writes already
+    /// applied are not undone, and an episode already in force runs to its
+    /// expiry.
+    ///
+    /// IOPS, bandwidth, and the read/write/sync latency distributions are
+    /// untouched — they are the disk's normal characteristics. So are the
+    /// throttle multipliers, which an episode still ticking down needs in order
+    /// to keep behaving the way it did before the cutoff.
+    pub fn disable_fault_injection(&mut self) {
+        self.read_fault_probability = 0.0;
+        self.write_fault_probability = 0.0;
+        self.crash_fault_probability = 0.0;
+        self.misdirect_write_probability = 0.0;
+        self.misdirect_read_probability = 0.0;
+        self.phantom_write_probability = 0.0;
+        self.sync_failure_probability = 0.0;
+        self.disk_stall_probability = 0.0;
+        self.disk_throttle_probability = 0.0;
+    }
+
     /// Create a configuration optimized for fast local testing.
     ///
     /// Minimal latencies and no fault injection for predictable,

--- a/crates/moonpool-sim/src/storage/sim/engine.rs
+++ b/crates/moonpool-sim/src/storage/sim/engine.rs
@@ -96,6 +96,21 @@ impl StorageEngine {
         self.state.per_process_configs.insert(ip, config);
     }
 
+    /// Stop sampling new storage faults on every disk, default and per-process
+    /// alike (see
+    /// [`StorageConfiguration::disable_fault_injection`](crate::storage::StorageConfiguration::disable_fault_injection)).
+    ///
+    /// Disk-degradation episodes already in force are deliberately left in
+    /// `disk_episodes`: they carry an expiry and clear themselves on the next
+    /// operation past it, so a stall that started under chaos still has to be
+    /// waited out.
+    pub(crate) fn disable_fault_injection(&mut self) {
+        self.state.config.disable_fault_injection();
+        for config in self.state.per_process_configs.values_mut() {
+            config.disable_fault_injection();
+        }
+    }
+
     pub(crate) fn disk_episode_for(&self, ip: IpAddr) -> Option<DiskDegradationState> {
         self.state.disk_episodes.get(&ip).copied()
     }

--- a/crates/moonpool-sim/tests/recovery_mode.rs
+++ b/crates/moonpool-sim/tests/recovery_mode.rs
@@ -665,7 +665,230 @@ fn disabling_clock_drift_never_rewinds_the_clock() {
 }
 
 // ===========================================================================
-// 5. The runner crosses the boundary for real
+// 5. The boundary cannot be reconfigured away
+// ===========================================================================
+
+/// Reconfiguring a disk after the boundary must install the performance half
+/// and drop the fault half. Otherwise `enter_recovery_mode` would only hold
+/// until the next `set_storage_config` call, and its promise is for the rest of
+/// the run.
+#[test]
+fn set_storage_config_cannot_rearm_faults_after_recovery() {
+    let mut sim = SimWorld::new_with_seed(20_260_901);
+    sim.set_storage_config(StorageConfiguration::fast_local());
+    sim.enter_recovery_mode();
+
+    let mut rearmed = StorageConfiguration::fast_local();
+    rearmed.write_fault_probability = 1.0;
+    rearmed.read_fault_probability = 1.0;
+    rearmed.phantom_write_probability = 1.0;
+    rearmed.disk_stall_probability = 1.0;
+    rearmed.iops = 4321;
+    sim.set_storage_config(rearmed);
+
+    sim.with_storage_config(|config| {
+        assert_zero(
+            config.write_fault_probability,
+            "write faults must not be re-armable after the boundary",
+        );
+        assert_zero(
+            config.read_fault_probability,
+            "read faults must not be re-armable after the boundary",
+        );
+        assert_zero(
+            config.phantom_write_probability,
+            "phantom writes must not be re-armable after the boundary",
+        );
+        assert_zero(
+            config.disk_stall_probability,
+            "stall episodes must not be re-armable after the boundary",
+        );
+        assert_eq!(
+            config.iops, 4321,
+            "the performance half of the new configuration is installed as given"
+        );
+    });
+
+    // And behaviorally: a write/read round trip takes no damage.
+    let provider = sim.storage_provider(ip(1));
+    let payload = vec![0x77_u8; SECTOR_SIZE];
+    let read_back = drive(&mut sim, async {
+        let mut file = provider
+            .open(
+                "rearmed.bin",
+                OpenOptions::new().read(true).write(true).create(true),
+            )
+            .await
+            .expect("open");
+        file.write_all(&payload).await.expect("write");
+        file.sync_all().await.expect("sync");
+        file.seek(SeekFrom::Start(0)).await.expect("seek");
+        let mut buf = vec![0_u8; SECTOR_SIZE];
+        file.read_exact(&mut buf).await.expect("read");
+        buf
+    });
+    assert_eq!(
+        read_back, payload,
+        "a re-armed configuration must not corrupt anything after the boundary"
+    );
+    assert!(
+        sim.disk_episode_for(ip(1)).is_none(),
+        "no degradation episode may be entered after the boundary"
+    );
+}
+
+/// The per-IP setters are the same hole with a narrower blast radius. Both
+/// spellings — `set_storage_config_for` and `set_process_storage_config` —
+/// reach the same per-process map, so both are checked.
+#[test]
+fn per_process_storage_setters_cannot_rearm_faults_after_recovery() {
+    let mut sim = SimWorld::new_with_seed(20_260_901);
+    sim.set_storage_config(StorageConfiguration::fast_local());
+    sim.enter_recovery_mode();
+
+    let mut rearmed = StorageConfiguration::fast_local();
+    rearmed.write_fault_probability = 1.0;
+    rearmed.disk_stall_probability = 1.0;
+    rearmed.iops = 8765;
+    sim.set_storage_config_for(ip(1), rearmed.clone());
+    sim.set_process_storage_config(ip(2), rearmed);
+
+    let payload = vec![0x33_u8; SECTOR_SIZE];
+    for host in [ip(1), ip(2)] {
+        let provider = sim.storage_provider(host);
+        let path = format!("rearmed-{host}.bin");
+        let read_back = drive(&mut sim, async {
+            let mut file = provider
+                .open(
+                    &path,
+                    OpenOptions::new().read(true).write(true).create(true),
+                )
+                .await
+                .expect("open");
+            file.write_all(&payload).await.expect("write");
+            file.sync_all().await.expect("sync");
+            file.seek(SeekFrom::Start(0)).await.expect("seek");
+            let mut buf = vec![0_u8; SECTOR_SIZE];
+            file.read_exact(&mut buf).await.expect("read");
+            buf
+        });
+        assert_eq!(
+            read_back, payload,
+            "a per-process configuration installed after the boundary must not corrupt {host}"
+        );
+        assert!(
+            sim.disk_episode_for(host).is_none(),
+            "no degradation episode may be entered for {host} after the boundary"
+        );
+    }
+}
+
+/// The network configuration has the same shape of hole, and the same fix.
+#[test]
+fn set_network_config_cannot_rearm_faults_after_recovery() {
+    const CONNECT: Duration = Duration::from_millis(3);
+
+    let mut sim =
+        SimWorld::new_with_network_config_and_seed(NetworkConfiguration::fast_local(), 20_260_901);
+    let server = sim.network_provider(ip(2));
+    let listener = drive(&mut sim, server.bind("10.0.1.2:8080")).expect("bind");
+    let client = sim.network_provider(ip(1));
+    let _client_stream = drive(&mut sim, client.connect("10.0.1.2:8080")).expect("connect");
+    let (_server_stream, _) = drive(&mut sim, listener.accept()).expect("accept");
+
+    sim.enter_recovery_mode();
+
+    let mut rearmed = NetworkConfiguration::fast_local();
+    rearmed.chaos.partition_probability = 1.0;
+    rearmed.chaos.partition_strategy = PartitionStrategy::IsolateSingle;
+    rearmed.chaos.clog_probability = 1.0;
+    rearmed.chaos.clock_drift_enabled = true;
+    rearmed.connect_latency = LatencyDistribution::Uniform {
+        start: CONNECT,
+        end: CONNECT,
+    };
+    sim.set_network_config(rearmed);
+
+    sim.with_network_config(|config| {
+        assert_zero(
+            config.chaos.partition_probability,
+            "partitioning must not be re-armable after the boundary",
+        );
+        assert_zero(
+            config.chaos.clog_probability,
+            "clogging must not be re-armable after the boundary",
+        );
+        assert!(
+            !config.chaos.clock_drift_enabled,
+            "clock drift must not be re-armable after the boundary"
+        );
+        assert_eq!(
+            config.connect_latency,
+            LatencyDistribution::Uniform {
+                start: CONNECT,
+                end: CONNECT
+            },
+            "the performance half of the new configuration is installed as given"
+        );
+    });
+
+    tick_maintenance(&mut sim, 200);
+    assert!(
+        !sim.is_partitioned(ip(1), ip(2)) && !sim.is_partitioned(ip(2), ip(1)),
+        "a re-armed configuration must not partition after the boundary"
+    );
+}
+
+/// Block stores are created lazily, so the registry's default configuration is
+/// what a process touching a device in the quiet tail inherits.
+#[test]
+fn set_block_fault_config_cannot_rearm_faults_after_recovery() {
+    let mut sim = SimWorld::new_with_seed(20_260_901);
+    sim.enter_recovery_mode();
+    // Pinned to 1.0 rather than `BlockFaultConfig::chaos()`: at that profile's
+    // 0.5% the fault would usually miss, and the test would pass whether or not
+    // the guard exists.
+    sim.set_block_fault_config(BlockFaultConfig {
+        read_corruption_probability: 1.0,
+        ..BlockFaultConfig::default()
+    });
+
+    // A store this process has never touched is created from the registry
+    // default *after* the boundary — the exact path the guard protects.
+    let provider = sim.block_device_provider(ip(5));
+    let spec = [RegionSpec {
+        name: "data",
+        size: 8 * BLOCK_SECTOR_SIZE as u64,
+    }];
+    let written = vec![0x6E_u8; BLOCK_SECTOR_SIZE];
+
+    let read_back = Executor::new(20_260_901).block_on({
+        let written = written.clone();
+        async move {
+            let device = provider.create("db", &spec).await.expect("create");
+            device.persist().await.expect("persist");
+            device
+                .write(RegionId(0), 0, &written)
+                .await
+                .expect("write sector 0");
+            device.persist().await.expect("persist");
+            let mut buf = vec![0_u8; BLOCK_SECTOR_SIZE];
+            device
+                .read(RegionId(0), 0, &mut buf)
+                .await
+                .expect("read sector 0");
+            buf
+        }
+    });
+
+    assert_eq!(
+        read_back, written,
+        "a store born after the boundary must inherit a fault-free configuration"
+    );
+}
+
+// ===========================================================================
+// 6. The runner crosses the boundary for real
 // ===========================================================================
 
 struct EchoProcess;

--- a/crates/moonpool-sim/tests/recovery_mode.rs
+++ b/crates/moonpool-sim/tests/recovery_mode.rs
@@ -1,0 +1,783 @@
+//! Lifecycle tests for the chaos → recovery transition.
+//!
+//! [`SimWorld::enter_recovery_mode`] is the boundary the runner crosses when
+//! `chaos_duration` expires. Its contract has two halves, and both need
+//! guarding:
+//!
+//! 1. **No new faults.** Every configuration-driven fault family — network,
+//!    stream storage, block device — stops sampling, and the environmental
+//!    partitions the simulator is holding are healed so the system under test
+//!    gets a quiet tail it can actually recover in.
+//! 2. **Damage already done stays done.** Corrupted sectors stay corrupted,
+//!    closed connections stay closed, a degraded link stays slow, and a finite
+//!    episode already running expires on its own schedule instead of being
+//!    rewritten out of history.
+//!
+//! Every test here pins probabilities to 0.0 or 1.0 so the interesting path is
+//! taken deterministically rather than sampled.
+
+use std::{
+    future::Future,
+    io::SeekFrom,
+    net::IpAddr,
+    pin::pin,
+    task::{Context, Poll},
+    time::Duration,
+};
+
+use async_trait::async_trait;
+use futures::{
+    io::{AsyncRead, AsyncReadExt, AsyncSeekExt, AsyncWrite, AsyncWriteExt},
+    task::noop_waker,
+};
+use moonpool_core::block::SECTOR_SIZE as BLOCK_SECTOR_SIZE;
+use moonpool_core::{
+    BlockDevice, BlockDeviceProvider, OpenOptions, RegionId, RegionSpec, StorageFile,
+    StorageProvider,
+};
+use moonpool_sim::{
+    BlockFaultConfig, Event, FaultContext, FaultInjector, LatencyDistribution,
+    NetworkConfiguration, NetworkEvent, NetworkFaultMask, NetworkProvider, PartitionStrategy,
+    Process, SECTOR_SIZE, SimContext, SimWorld, SimulationBuilder, SimulationError,
+    SimulationResult, StorageConfiguration, TcpListenerTrait, TimeProvider, Workload,
+    executor::Executor,
+};
+
+/// How many events a driven future may consume before it is declared stuck.
+const MAX_DRIVER_STEPS: usize = 10_000;
+
+fn ip(last_octet: u8) -> IpAddr {
+    format!("10.0.1.{last_octet}")
+        .parse()
+        .expect("valid test IP")
+}
+
+/// Poll a simulation-backed future, advancing virtual time whenever it parks.
+fn drive<F: Future>(sim: &mut SimWorld, future: F) -> F::Output {
+    let mut future = pin!(future);
+    let waker = noop_waker();
+    let mut context = Context::from_waker(&waker);
+
+    for _ in 0..MAX_DRIVER_STEPS {
+        if let Poll::Ready(output) = future.as_mut().poll(&mut context) {
+            return output;
+        }
+        assert!(
+            sim.has_pending_events(),
+            "simulation-backed future stalled without a pending event"
+        );
+        sim.step();
+    }
+
+    panic!("simulation-backed future exceeded {MAX_DRIVER_STEPS} events")
+}
+
+fn poll_write_once(
+    stream: &mut (impl AsyncWrite + Unpin),
+    data: &[u8],
+) -> Poll<std::io::Result<usize>> {
+    let waker = noop_waker();
+    let mut context = Context::from_waker(&waker);
+    std::pin::Pin::new(stream).poll_write(&mut context, data)
+}
+
+fn poll_read_once(
+    stream: &mut (impl AsyncRead + Unpin),
+    data: &mut [u8],
+) -> Poll<std::io::Result<usize>> {
+    let waker = noop_waker();
+    let mut context = Context::from_waker(&waker);
+    std::pin::Pin::new(stream).poll_read(&mut context, data)
+}
+
+/// Pump the scheduler by feeding it network maintenance ticks, which is where
+/// the engine rolls for a new random partition.
+fn tick_maintenance(sim: &mut SimWorld, ticks: usize) {
+    for _ in 0..ticks {
+        sim.schedule_event(Event::Network(NetworkEvent::Maintenance), Duration::ZERO);
+        sim.step();
+    }
+}
+
+// ===========================================================================
+// 1. New configuration-driven faults stop at the boundary
+// ===========================================================================
+
+/// Random partitioning is rolled on every event, straight from the network
+/// configuration — it never went through the fault-injector token, which is
+/// exactly why the cutoff used to leak new cuts into the quiet tail.
+#[test]
+fn recovery_mode_stops_new_random_partitions() {
+    let mut config = NetworkConfiguration::fast_local();
+    config.chaos.partition_probability = 1.0;
+    config.chaos.partition_duration = Duration::from_millis(50)..Duration::from_millis(51);
+    config.chaos.partition_strategy = PartitionStrategy::IsolateSingle;
+    let mut sim = SimWorld::new_with_network_config_and_seed(config, 20_260_901);
+
+    // Two connected endpoints give the partition roller something to cut.
+    let server = sim.network_provider(ip(2));
+    let listener = drive(&mut sim, server.bind("10.0.1.2:8080")).expect("bind");
+    let client = sim.network_provider(ip(1));
+    let _client_stream = drive(&mut sim, client.connect("10.0.1.2:8080")).expect("connect");
+    let (_server_stream, _) = drive(&mut sim, listener.accept()).expect("accept");
+
+    tick_maintenance(&mut sim, 4);
+    assert!(
+        sim.is_partitioned(ip(1), ip(2)) || sim.is_partitioned(ip(2), ip(1)),
+        "the chaos phase must actually partition, or the test proves nothing"
+    );
+
+    sim.enter_recovery_mode();
+    assert!(sim.is_in_recovery_mode());
+    assert!(
+        !sim.is_partitioned(ip(1), ip(2)) && !sim.is_partitioned(ip(2), ip(1)),
+        "recovery mode heals the partitions in force at the boundary"
+    );
+
+    // A partition would be rolled on *every* one of these ticks before.
+    tick_maintenance(&mut sim, 200);
+    assert!(
+        !sim.is_partitioned(ip(1), ip(2)) && !sim.is_partitioned(ip(2), ip(1)),
+        "no new partition may be created after the recovery boundary"
+    );
+}
+
+/// The asymmetric cuts: `send_partitions` and `recv_partitions` are keyed by a
+/// single IP, so the old pairwise `restore_partition` sweep could not reach
+/// them and a one-way cut outlived the cutoff.
+#[test]
+fn recovery_mode_heals_asymmetric_partitions() {
+    let sim = SimWorld::new_with_network_config(NetworkConfiguration::fast_local());
+    let mut sim = sim;
+
+    sim.partition_pair(ip(1), ip(2), Duration::from_hours(1));
+    sim.partition_send_from(ip(3), Duration::from_hours(1));
+    sim.partition_recv_to(ip(4), Duration::from_hours(1));
+    assert!(sim.is_partitioned(ip(1), ip(2)));
+    assert!(
+        sim.is_partitioned(ip(3), ip(9)),
+        "send-side cut is in force"
+    );
+    assert!(
+        sim.is_partitioned(ip(9), ip(4)),
+        "recv-side cut is in force"
+    );
+
+    sim.enter_recovery_mode();
+
+    assert!(!sim.is_partitioned(ip(1), ip(2)));
+    assert!(!sim.is_partitioned(ip(3), ip(9)), "send-side cut healed");
+    assert!(!sim.is_partitioned(ip(9), ip(4)), "recv-side cut healed");
+
+    let kinds: Vec<&str> = sim
+        .take_faults()
+        .iter()
+        .map(|record| record.event.kind())
+        .collect();
+    assert!(
+        kinds.contains(&"partition_healed")
+            && kinds.contains(&"send_partition_healed")
+            && kinds.contains(&"recv_partition_healed"),
+        "every heal is recorded on the fault timeline, got {kinds:?}"
+    );
+}
+
+/// Healing at the boundary must let the endpoints talk again *now*, not when
+/// the (possibly hour-long) partition deadline it stalled under expires.
+#[test]
+fn endpoints_communicate_again_after_the_recovery_boundary() {
+    const PAYLOAD: &[u8] = b"held-back-by-the-cut";
+
+    let mut sim =
+        SimWorld::new_with_network_config_and_seed(NetworkConfiguration::fast_local(), 20_260_901);
+    let server_provider = sim.network_provider(ip(2));
+    let listener = drive(&mut sim, server_provider.bind("10.0.1.2:8080")).expect("bind");
+    let client_provider = sim.network_provider(ip(1));
+    let mut client = drive(&mut sim, client_provider.connect("10.0.1.2:8080")).expect("connect");
+    let (mut server, _) = drive(&mut sim, listener.accept()).expect("accept");
+    sim.run_until_empty();
+
+    sim.partition_pair(ip(1), ip(2), Duration::from_hours(1));
+    assert_eq!(
+        poll_write_once(&mut client, PAYLOAD).map(|result| result.expect("payload is accepted")),
+        Poll::Ready(PAYLOAD.len())
+    );
+    assert!(sim.step(), "the engine drains the queued send");
+    let mut byte = [0_u8; 1];
+    assert!(
+        poll_read_once(&mut server, &mut byte).is_pending(),
+        "no byte crosses an active partition"
+    );
+
+    sim.enter_recovery_mode();
+
+    let mut received = vec![0_u8; PAYLOAD.len()];
+    drive(&mut sim, server.read_exact(&mut received)).expect("the stalled bytes are released");
+    assert_eq!(received, PAYLOAD);
+    assert!(
+        sim.current_time() < Duration::from_hours(1),
+        "the bytes were released by the heal, not by the partition deadline"
+    );
+}
+
+/// Recovery mode stops the environment from breaking connections. It does not
+/// mend one the application has already seen close.
+#[test]
+fn a_connection_already_closed_stays_closed_through_recovery_mode() {
+    let mut sim =
+        SimWorld::new_with_network_config_and_seed(NetworkConfiguration::fast_local(), 20_260_901);
+    let server_provider = sim.network_provider(ip(2));
+    let listener = drive(&mut sim, server_provider.bind("10.0.1.2:8080")).expect("bind");
+    let client_provider = sim.network_provider(ip(1));
+    let client = drive(&mut sim, client_provider.connect("10.0.1.2:8080")).expect("connect");
+    let (_server, _) = drive(&mut sim, listener.accept()).expect("accept");
+    sim.run_until_empty();
+
+    let connection = client.connection_id();
+    sim.close_connection_abort(connection);
+    assert!(sim.is_connection_closed(connection));
+
+    sim.enter_recovery_mode();
+
+    assert!(
+        sim.is_connection_closed(connection),
+        "recovery mode must not resurrect a connection the application already saw close"
+    );
+}
+
+// ===========================================================================
+// 2. Persistent storage damage survives
+// ===========================================================================
+
+/// A write fault marks the written sectors as faulted, so every later read of
+/// them comes back corrupted. After the boundary: no *new* sector is faulted,
+/// and the sector already faulted is still faulted, byte for byte.
+#[test]
+fn storage_damage_survives_recovery_mode_while_new_faults_stop() {
+    let mut config = StorageConfiguration::fast_local();
+    config.write_fault_probability = 1.0;
+    let mut sim = SimWorld::new_with_seed(20_260_901);
+    sim.set_storage_config(config);
+    let provider = sim.storage_provider(ip(1));
+
+    let damaged = vec![0xAA_u8; SECTOR_SIZE];
+    let clean = vec![0xBB_u8; SECTOR_SIZE];
+    let mut file = drive(
+        &mut sim,
+        provider.open(
+            "damaged.bin",
+            OpenOptions::new().read(true).write(true).create(true),
+        ),
+    )
+    .expect("open");
+
+    // --- chaos phase: the write lands but its sectors are faulted ---
+    let corrupted = drive(&mut sim, async {
+        file.write_all(&damaged).await.expect("write sector 0");
+        file.sync_all().await.expect("sync");
+        file.seek(SeekFrom::Start(0)).await.expect("seek");
+        let mut buf = vec![0_u8; SECTOR_SIZE];
+        file.read_exact(&mut buf).await.expect("read sector 0");
+        buf
+    });
+    assert_ne!(
+        corrupted, damaged,
+        "the chaos phase must actually corrupt, or the test proves nothing"
+    );
+
+    sim.enter_recovery_mode();
+
+    // --- quiet tail: a fresh sector takes no new damage ---
+    let fresh = drive(&mut sim, async {
+        file.seek(SeekFrom::Start(SECTOR_SIZE as u64))
+            .await
+            .expect("seek");
+        file.write_all(&clean).await.expect("write sector 1");
+        file.sync_all().await.expect("sync");
+        file.seek(SeekFrom::Start(SECTOR_SIZE as u64))
+            .await
+            .expect("seek");
+        let mut buf = vec![0_u8; SECTOR_SIZE];
+        file.read_exact(&mut buf).await.expect("read sector 1");
+        buf
+    });
+    assert_eq!(
+        fresh, clean,
+        "no new storage fault may be injected after the recovery boundary"
+    );
+
+    // --- and the damage from before the boundary is still there ---
+    let reread = drive(&mut sim, async {
+        file.seek(SeekFrom::Start(0)).await.expect("seek");
+        let mut buf = vec![0_u8; SECTOR_SIZE];
+        file.read_exact(&mut buf).await.expect("re-read sector 0");
+        buf
+    });
+    assert_eq!(
+        reread, corrupted,
+        "recovery mode must not repair a sector that was already corrupted"
+    );
+}
+
+/// The block-device surface has its own fault configuration, held per process
+/// store, so it needs its own half of the transition.
+#[test]
+fn block_device_faults_stop_but_planted_corruption_stays() {
+    let config = BlockFaultConfig {
+        read_corruption_probability: 1.0,
+        ..BlockFaultConfig::default()
+    };
+    let mut sim = SimWorld::new_with_seed(20_260_901);
+    sim.set_block_fault_config(config);
+
+    let provider = sim.block_device_provider(ip(1));
+    let spec = [RegionSpec {
+        name: "data",
+        size: 8 * BLOCK_SECTOR_SIZE as u64,
+    }];
+    let written = vec![0x5A_u8; BLOCK_SECTOR_SIZE];
+
+    let device = Executor::new(20_260_901).block_on(async move {
+        let device = provider.create("db", &spec).await.expect("create");
+        device.persist().await.expect("persist");
+        device
+            .write(RegionId(0), 0, &written)
+            .await
+            .expect("write sector 0");
+        device.persist().await.expect("persist");
+        device
+    });
+
+    let corrupted = Executor::new(20_260_901).block_on({
+        let device = device.clone();
+        async move {
+            let mut buf = vec![0_u8; BLOCK_SECTOR_SIZE];
+            device
+                .read(RegionId(0), 0, &mut buf)
+                .await
+                .expect("read sector 0");
+            buf
+        }
+    });
+    assert_ne!(
+        corrupted,
+        vec![0x5A_u8; BLOCK_SECTOR_SIZE],
+        "the chaos phase must actually plant a latent fault"
+    );
+
+    sim.enter_recovery_mode();
+
+    let (after_recovery, fresh_sector) = Executor::new(20_260_901).block_on({
+        let device = device.clone();
+        async move {
+            let mut old = vec![0_u8; BLOCK_SECTOR_SIZE];
+            device
+                .read(RegionId(0), 0, &mut old)
+                .await
+                .expect("re-read sector 0");
+
+            let fresh = vec![0xC3_u8; BLOCK_SECTOR_SIZE];
+            device
+                .write(RegionId(0), BLOCK_SECTOR_SIZE as u64, &fresh)
+                .await
+                .expect("write sector 1");
+            device.persist().await.expect("persist");
+            let mut read_back = vec![0_u8; BLOCK_SECTOR_SIZE];
+            device
+                .read(RegionId(0), BLOCK_SECTOR_SIZE as u64, &mut read_back)
+                .await
+                .expect("read sector 1");
+            (old, read_back)
+        }
+    });
+
+    assert_eq!(
+        after_recovery, corrupted,
+        "a latent fault already planted stays planted, identically on retry"
+    );
+    assert_eq!(
+        fresh_sector,
+        vec![0xC3_u8; BLOCK_SECTOR_SIZE],
+        "no new block-device corruption may be planted after the boundary"
+    );
+}
+
+// ===========================================================================
+// 3. Finite episodes expire, they are not rewritten
+// ===========================================================================
+
+/// A disk-degradation episode carries an expiry. Recovery mode forbids
+/// *entering* a new one but leaves one already running to be waited out —
+/// rewriting it away would erase timing the system under test has already
+/// committed to.
+#[test]
+fn an_active_disk_throttle_outlives_the_boundary_then_expires() {
+    const THROTTLE: Duration = Duration::from_secs(10);
+
+    let mut config = StorageConfiguration::fast_local();
+    config.disk_throttle_probability = 1.0;
+    config.disk_throttle_duration = THROTTLE;
+    config.disk_throttle_iops_multiplier = 1000.0;
+    config.disk_throttle_bandwidth_multiplier = 1000.0;
+    config.iops = 1_000;
+    let mut sim = SimWorld::new_with_seed(20_260_901);
+    sim.set_storage_config(config);
+    let provider = sim.storage_provider(ip(1));
+
+    let mut file = drive(
+        &mut sim,
+        provider.open(
+            "throttled.bin",
+            OpenOptions::new().read(true).write(true).create(true),
+        ),
+    )
+    .expect("open");
+    drive(&mut sim, file.write_all(b"tick")).expect("write");
+
+    let expires_at = sim
+        .disk_episode_for(ip(1))
+        .expect("a throttle episode must be in force before the boundary")
+        .expires_at;
+    assert!(
+        expires_at > sim.current_time(),
+        "the episode must still be running when the boundary is crossed"
+    );
+
+    sim.enter_recovery_mode();
+
+    assert_eq!(
+        sim.disk_episode_for(ip(1))
+            .expect("the running episode outlives the boundary")
+            .expires_at,
+        expires_at,
+        "recovery mode must not rewrite an episode's deadline"
+    );
+
+    // The episode still bites: a write inside the window pays the throttled
+    // IOPS cost, which is a full second at these knobs.
+    let before = sim.current_time();
+    drive(&mut sim, file.write_all(b"tock")).expect("write");
+    assert!(
+        sim.current_time().saturating_sub(before) >= Duration::from_millis(500),
+        "an episode already in force keeps slowing I/O after the boundary"
+    );
+
+    // Wait it out, then keep working: it clears itself and, with the family
+    // switched off, no replacement is ever entered.
+    let sleep = sim.sleep(THROTTLE * 2);
+    drive(&mut sim, sleep).expect("sleep");
+    for _ in 0..20 {
+        drive(&mut sim, file.write_all(b"tack")).expect("write");
+    }
+    assert!(
+        sim.disk_episode_for(ip(1)).is_none(),
+        "the episode expired and no new one was entered after the boundary"
+    );
+}
+
+// ===========================================================================
+// 4. Non-chaos configuration survives
+// ===========================================================================
+
+/// Assert an `f64` is exactly `+0.0` (bit-exact, avoiding the float-cmp lint).
+fn assert_zero(value: f64, message: &str) {
+    assert_eq!(value.to_bits(), 0.0_f64.to_bits(), "{message}, got {value}");
+}
+
+/// Recovery mode mutates the network and storage configurations, so the
+/// performance characteristics that are *not* chaos have to be shown to
+/// survive it: latency shaping, IOPS, bandwidth, throttle multipliers.
+#[test]
+fn recovery_mode_keeps_non_chaos_configuration() {
+    const CONNECT: Duration = Duration::from_millis(7);
+    const WRITE: Duration = Duration::from_micros(321);
+    const READ: Duration = Duration::from_micros(654);
+
+    let mut network = NetworkConfiguration::fast_local();
+    network.connect_latency = LatencyDistribution::Uniform {
+        start: CONNECT,
+        end: CONNECT,
+    };
+    network.write_latency = LatencyDistribution::Uniform {
+        start: WRITE,
+        end: WRITE,
+    };
+    network.chaos.partition_probability = 1.0;
+    network.chaos.clog_probability = 1.0;
+    let mut sim = SimWorld::new_with_network_config_and_seed(network, 20_260_901);
+
+    let mut storage = StorageConfiguration::fast_local();
+    storage.iops = 1234;
+    storage.bandwidth = 5_678_000;
+    storage.read_latency = LatencyDistribution::Uniform {
+        start: READ,
+        end: READ,
+    };
+    storage.disk_throttle_iops_multiplier = 9.0;
+    storage.disk_throttle_bandwidth_multiplier = 11.0;
+    storage.read_fault_probability = 1.0;
+    sim.set_storage_config(storage);
+
+    sim.enter_recovery_mode();
+
+    sim.with_network_config(|config| {
+        assert_eq!(
+            config.connect_latency,
+            LatencyDistribution::Uniform {
+                start: CONNECT,
+                end: CONNECT
+            },
+            "connect latency is deployment shape, not chaos"
+        );
+        assert_eq!(
+            config.write_latency,
+            LatencyDistribution::Uniform {
+                start: WRITE,
+                end: WRITE
+            },
+            "write latency is deployment shape, not chaos"
+        );
+        assert_zero(
+            config.chaos.partition_probability,
+            "partitioning is chaos and must be off",
+        );
+        assert_zero(
+            config.chaos.clog_probability,
+            "clogging is chaos and must be off",
+        );
+    });
+
+    sim.with_storage_config(|config| {
+        assert_eq!(config.iops, 1234, "IOPS is disk performance, not chaos");
+        assert_eq!(
+            config.bandwidth, 5_678_000,
+            "bandwidth is disk performance, not chaos"
+        );
+        assert_eq!(
+            config.read_latency,
+            LatencyDistribution::Uniform {
+                start: READ,
+                end: READ
+            },
+            "read latency is disk performance, not chaos"
+        );
+        assert_eq!(
+            config.disk_throttle_iops_multiplier.to_bits(),
+            9.0_f64.to_bits(),
+            "an episode still ticking down needs its multipliers"
+        );
+        assert_eq!(
+            config.disk_throttle_bandwidth_multiplier.to_bits(),
+            11.0_f64.to_bits()
+        );
+        assert_zero(
+            config.read_fault_probability,
+            "read faults are chaos and must be off",
+        );
+    });
+}
+
+/// A pair that already sampled its permanent extra latency keeps it. Zeroing
+/// `max_pair_latency` stops *new* pairs from degrading; it does not repair a
+/// link that is already slow.
+#[test]
+fn an_already_degraded_pair_keeps_its_latency() {
+    let mut config = NetworkConfiguration::fast_local();
+    config.chaos.max_pair_latency = Duration::from_millis(80)..Duration::from_millis(81);
+    let mut sim = SimWorld::new_with_network_config_and_seed(config, 20_260_901);
+
+    let server_provider = sim.network_provider(ip(2));
+    let listener = drive(&mut sim, server_provider.bind("10.0.1.2:8080")).expect("bind");
+    let client_provider = sim.network_provider(ip(1));
+    let mut client = drive(&mut sim, client_provider.connect("10.0.1.2:8080")).expect("connect");
+    let (mut server, _) = drive(&mut sim, listener.accept()).expect("accept");
+    drive(&mut sim, client.write_all(b"warm")).expect("write");
+    let mut warm = [0_u8; 4];
+    drive(&mut sim, server.read_exact(&mut warm)).expect("read");
+
+    let degraded = sim
+        .pair_latency(ip(1), ip(2))
+        .expect("the pair sampled its permanent extra latency");
+    assert!(degraded >= Duration::from_millis(80));
+
+    sim.enter_recovery_mode();
+
+    assert_eq!(
+        sim.pair_latency(ip(1), ip(2)),
+        Some(degraded),
+        "an already-degraded link is persistent damage, not a fault to heal"
+    );
+    assert_eq!(
+        sim.connection_base_latency(client.connection_id()),
+        degraded,
+        "the connection still pays the latency its pair already sampled"
+    );
+}
+
+/// The transition is idempotent and draws no randomness, so calling it cannot
+/// shift the RNG stream a replay depends on.
+#[test]
+fn recovery_mode_is_idempotent_and_consumes_no_randomness() {
+    let mut config = NetworkConfiguration::fast_local();
+    config.chaos.partition_probability = 1.0;
+    let mut sim = SimWorld::new_with_network_config_and_seed(config, 20_260_901);
+    sim.partition_pair(ip(1), ip(2), Duration::from_hours(1));
+
+    moonpool_sim::reset_rng_call_count();
+    sim.enter_recovery_mode();
+    sim.enter_recovery_mode();
+    sim.enter_recovery_mode();
+
+    assert_eq!(
+        moonpool_sim::rng_call_count(),
+        0,
+        "the recovery transition must not consume the simulation RNG"
+    );
+    assert!(!sim.is_partitioned(ip(1), ip(2)));
+    assert!(sim.is_in_recovery_mode());
+}
+
+/// Clock drift is switched off at the boundary, but a reading already handed
+/// out must never be walked back — rewinding a clock is a worse fault than the
+/// drift it replaces.
+#[test]
+fn disabling_clock_drift_never_rewinds_the_clock() {
+    let mut config = NetworkConfiguration::fast_local();
+    config.chaos.clock_drift_enabled = true;
+    config.chaos.clock_drift_max = Duration::from_millis(100);
+    let mut sim = SimWorld::new_with_network_config_and_seed(config, 20_260_901);
+
+    let mut drifted = Duration::ZERO;
+    for _ in 0..50 {
+        drifted = sim.timer();
+    }
+    assert!(
+        drifted > sim.now(),
+        "the clock must actually drift ahead, or the test proves nothing"
+    );
+
+    sim.enter_recovery_mode();
+
+    assert!(
+        sim.timer() >= drifted,
+        "the timer must never read below a value already handed out"
+    );
+}
+
+// ===========================================================================
+// 5. The runner crosses the boundary for real
+// ===========================================================================
+
+struct EchoProcess;
+
+#[async_trait]
+impl Process for EchoProcess {
+    fn name(&self) -> &'static str {
+        "echo"
+    }
+
+    async fn run(&mut self, ctx: &SimContext) -> SimulationResult<()> {
+        let listener = ctx.network().bind(ctx.my_ip()).await?;
+        loop {
+            let accepted = moonpool_sim::select! {
+                biased;
+                r = listener.accept() => r,
+                () = ctx.shutdown().cancelled() => return Ok(()),
+            };
+            if let Ok((mut stream, _)) = accepted {
+                let mut buf = [0_u8; 16];
+                if let Ok(n) = stream.read(&mut buf).await
+                    && n > 0
+                {
+                    let _ = stream.write_all(&buf[..n]).await;
+                }
+            }
+        }
+    }
+}
+
+/// Cuts the workload off from the server for the whole chaos phase, using the
+/// hour-long cut `FaultContext::partition` installs, then parks until the
+/// chaos token is cancelled.
+struct CutEverything;
+
+#[async_trait]
+impl FaultInjector for CutEverything {
+    fn name(&self) -> &'static str {
+        "cut-everything"
+    }
+
+    async fn inject(&mut self, ctx: &FaultContext) -> SimulationResult<()> {
+        for process in ctx.process_ips() {
+            ctx.partition("10.0.0.1", process)?;
+        }
+        ctx.chaos_shutdown().cancelled().await;
+        Ok(())
+    }
+}
+
+/// The request is issued during the cut and can only complete once the cutoff
+/// heals it. If the boundary stopped healing partitions, this workload would
+/// hang and the run-time budget would fail the seed.
+struct RequestAcrossTheCut;
+
+#[async_trait]
+impl Workload for RequestAcrossTheCut {
+    fn name(&self) -> &'static str {
+        "request-across-the-cut"
+    }
+
+    async fn run(&mut self, ctx: &SimContext) -> SimulationResult<()> {
+        let target = ctx.topology().all_process_ips()[0].clone();
+        // Retry on a timer, the way a real client would. Every attempt before
+        // the cutoff times out inside the cut; the first attempt after it must
+        // succeed. The retries also keep virtual time moving, so the cutoff is
+        // reached on schedule instead of being jumped over.
+        loop {
+            let attempt = async {
+                let mut stream = ctx.network().connect(&target).await?;
+                stream
+                    .write_all(b"ping")
+                    .await
+                    .map_err(|error| SimulationError::InvalidState(error.to_string()))?;
+                let mut buf = [0_u8; 4];
+                stream
+                    .read_exact(&mut buf)
+                    .await
+                    .map_err(|error| SimulationError::InvalidState(error.to_string()))?;
+                Ok::<[u8; 4], SimulationError>(buf)
+            };
+            if let Ok(Ok(reply)) = ctx
+                .time()
+                .timeout(Duration::from_millis(500), attempt)
+                .await
+            {
+                assert_eq!(&reply, b"ping", "the echo server replies with the request");
+                return Ok(());
+            }
+        }
+    }
+}
+
+#[test]
+fn a_campaign_heals_its_partitions_at_the_chaos_cutoff() {
+    let report = SimulationBuilder::new()
+        .processes(1, || Box::new(EchoProcess))
+        .workload(RequestAcrossTheCut)
+        .fault_factory(|| Box::new(CutEverything))
+        // The cut is the only fault under test: silence the default network
+        // chaos families so a connect failure cannot muddy the result.
+        .network_fault_mask(NetworkFaultMask::none())
+        .chaos_duration(Duration::from_secs(5))
+        // The cut lasts an hour; only the cutoff can release the request in
+        // time, so a stranded request trips this budget instead of hanging.
+        .run_time_budget(Duration::from_mins(2))
+        .set_iterations(3)
+        .set_debug_seeds(vec![1, 2, 3])
+        .run();
+
+    assert_eq!(
+        report.failed_runs, 0,
+        "the request must complete once the cutoff heals the cut:\n{report}"
+    );
+}


### PR DESCRIPTION
## The problem

`chaos_duration` only ever stopped the explicit fault-injector loops and healed pairwise partitions:

```rust
chaos_shutdown.cancel();
Self::heal_all_partitions(sim, all_ips);   // pairwise restore_partition sweep
chaos_ended = true;
```

The configuration-driven fault families are resolved when the world is built and live in `NetworkState::config` / `StorageState::config` / each `SimBlockStore` for the whole run, so after the cutoff the engine kept generating new faults:

- **Network** — `randomly_trigger_partitions` runs from `before_event` on *every* `sim.step()`, straight off `chaos.partition_probability`; plus clogs, bit flips, spontaneous closes, connect failures, clock drift, and `max_pair_latency` sampling for newly-contacted pairs.
- **Storage** — read/write/sync/crash faults, misdirected reads/writes, phantom writes, and new disk stall/throttle episodes.
- **Block devices** — every family in `store.rs` (EIO read/write, read corruption, misdirected/phantom write, persist failure, barrier violation).
- **Asymmetric partitions** — `restore_partition` only clears `ip_partitions`; `send_partitions`/`recv_partitions` are keyed by a single IP, so `AsymmetricSend`/`AsymmetricRecv` cuts survived the "heal all" sweep entirely.

So `chaos_duration` did not actually bound fault injection, and there was no fault-free tail for a workload to assert convergence in.

## The change

One lifecycle transition, `SimWorld::enter_recovery_mode()`, crossed by the runner at the cutoff alongside cancelling the chaos token:

```rust
if !chaos_ended && Self::should_end_chaos(sim, chaos_start, chaos_duration) {
    chaos_shutdown.cancel();
    sim.enter_recovery_mode();
    chaos_ended = true;
}
```

It switches off every fault family through new `disable_fault_injection` methods on `ChaosConfiguration`, `NetworkConfiguration`, `StorageConfiguration` and `BlockFaultConfig`, and heals every partition in force — directed, send-side and receive-side. It touches no performance configuration: latencies, IOPS, bandwidth, link shaping and the throttle multipliers all survive (an episode still ticking down needs its multipliers). It is idempotent and consumes no randomness.

The network half reuses the existing `NetworkFaultMask::none()` rather than adding a parallel mechanism, and the `buggified_delay` window (the one family already bounded) set the precedent for the whole design.

### It stops damage, it does not repair damage

Corrupted sectors, lost/misdirected/phantom writes, wiped data, connections the application already saw close, killed processes and application state all survive the boundary. Finite effects already started — disk stall and throttle episodes, clogs, delayed packets — keep their deadlines and expire on their own rather than being rewritten.

Three cases needed care to keep that true:

- **Pair latency.** `connection_base_latency` early-returned `ZERO` when `max_pair_latency` was zero *before* consulting the per-pair cache, so zeroing the knob would have silently repaired an already-degraded link. The cache is now checked first.
- **Clock drift.** Disabling it made `timer()` jump *backwards* by up to `clock_drift_max`. It now clamps to the max of the last reading and `now`, so accumulated skew is absorbed as time advances — rewinding a clock is a worse fault than the drift.
- **Barrier violations.** `crash_device`'s oracle uses `barrier_violation_probability > 0.0` to decide whether a synced sector changing across a crash is legal. Zeroing it would have turned a pre-cutoff persist lie into a false `"moonpool sim bug"` panic, so the store now latches whether the family was ever armed.

Block **crash-shape** parameters (`clean_crash_probability`, `crash_lost_probability`, …) are deliberately untouched: they describe what a crash *does* to buffered data, and recovery mode already stops crashes from being generated.

## Also in here

- Partition healing moves out of the orchestrator into the transition (which fixes the asymmetric-cut gap and drops the `all_ips` plumbing).
- Two new `SimFaultEvent` variants, `SendPartitionHealed` / `RecvPartitionHealed`, so the timeline records what actually healed.
- `settle_phase` is documented as what it is: `abort_all()` runs before it, so it is **not** a recovery window. The recovery window is the quiet tail between the cutoff and workload completion, while processes are still alive.
- Docs updated: `chaos_duration`'s contract on the builder, the `chaos` module, and five book chapters. `book/src/llms.md` previously stated the old behavior as intentional (*"Network/storage configuration faults are part of their provider models"*) — that contradicted the documented purpose of `chaos_duration` everywhere else, so it is rewritten. No test or example relied on faults continuing past the cutoff.

## Tests

`crates/moonpool-sim/tests/recovery_mode.rs`, 12 deterministic tests (probabilities pinned to 0.0/1.0, no statistical assertions): new random partitions stop; asymmetric partitions heal with heal events recorded; stalled bytes release immediately rather than waiting out an hour-long deadline; closed connections stay closed; storage damage survives while new faults stop; block faults stop but planted corruption stays; an active throttle episode outlives the boundary, keeps biting, then expires with no successor; non-chaos network/storage config survives; a degraded pair keeps its latency; the transition is idempotent and draws no RNG; the clock never rewinds; and a builder campaign whose request can only complete once the cutoff heals the cut.

Each test was checked as a genuine negative control — reverting each half of the change (fault-disable / heal / pair-latency ordering / clock clamp) fails the corresponding tests.

## Validation

`nix develop` was unavailable in this sandbox (the flake's `numtide/flake-utils` input is 403'd by the GitHub proxy), so this ran on the rustup toolchain, which `rust-toolchain.toml` pins to the same 1.95.0 channel. CI on nix should match, but that was not confirmed locally.

- `cargo fmt --all` — clean
- `cargo clippy --workspace --all-targets` — zero warnings
- `cargo clippy -p moonpool-sim --no-default-features --all-targets -- -D warnings` — clean
- `cargo check --target wasm32-unknown-unknown -p moonpool-sim --no-default-features` — clean
- `cargo nextest run --workspace` — **718 passed, 0 failed** (706 before + 12 new)
- `cargo xtask sim run-all` — 7/7 passed
- `mdbook build book/` — clean; `cargo doc` warning count unchanged (22, all pre-existing)

## Known gaps

- **Partial reads/writes are not disabled.** They are gated by bare `buggify!()`, not a chaos probability, and `NetworkFaultMask` already excludes them as TCP-realistic behavior rather than a fault family. Kept that stance and documented it.
- **Buggify itself stays enabled**, so `buggify!()` sites in Process/Workload code keep firing after the cutoff. Disabling it globally would reach into application code, which felt out of scope — happy to add it if you want it.
- **Time can overshoot the cutoff.** The boundary is evaluated at the top of the run loop, so a fully idle executor lets `sim.step()` jump to the next scheduled event and cross it late. Pre-existing; workloads that retry on a timer are unaffected.
- **RNG draw counts after the cutoff change**, since zeroed probabilities skip their draws. Still fully deterministic per seed, and exploration replays from the root through the same code path so recipes stay exact — but traces recorded before this change will not line up byte-for-byte.

## Can a workload rely on `chaos_duration expires → no new faults → quiet tail → convergence assertion`?

Yes, with the two gaps above (partial reads/writes; your own `buggify!()` sites). Beyond those, no Moonpool-generated fault occurs after the cutoff.

Two things to keep in mind: the tail is quiet but the **cluster is not healthy** — it starts the tail carrying all the damage the chaos phase did, which is the point. And the convergence assertion must be made from `Workload::run` before it returns, not from `check()`: processes are aborted before settle, so `check()` sees retained state and the timeline, never a live cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XSCHs6CToWXzjPhvzA3gEf

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSCHs6CToWXzjPhvzA3gEf)_