### PR TITLE
feat(moonpool-sim): floor the simulation subscriber at INFO, configurable via `trace_level`

### DIFF
--- a/book/src/llms.md
+++ b/book/src/llms.md
@@ -349,6 +349,10 @@ tracing::info!(
 ```
 
 The event message must be a non-empty constant name. Use `%` for string values.
+The run's subscriber is floored at `INFO` by default, so `DEBUG`/`TRACE` spans
+and events (`#[tracing::instrument(level = "trace")]` on hot paths) cost one
+level compare and are never allocated; `.trace_level(LevelFilter::DEBUG)` on
+the builder lowers the floor to debug one seed, capturing those events too.
 Do not add simulated time manually; the observability layer stamps it. Actor
 spans provide source attribution automatically.
 

--- a/book/src/part3-building/17-events-and-invariants.md
+++ b/book/src/part3-building/17-events-and-invariants.md
@@ -48,7 +48,9 @@ The `seq` field gives total ordering across all event names. If `leader_elected`
 
 **One emission, two audiences.** In simulation, `SimulationLayer` captures the event into the timeline and invariants cross-validate it. In production, where no `SimulationLayer` is installed, the same event flows to whatever subscriber is configured: `fmt`, OpenTelemetry, structured JSON. Nothing in the emission is moonpool-specific.
 
-**Below `INFO` is free in simulation.** `SimulationLayer::install` (what `SimulationBuilder::run` calls) registers the layer behind a `LevelFilter::INFO`, so a `DEBUG` or `TRACE` span or event is disabled at the subscriber and never reaches the registry. Instrument hot paths freely with `#[tracing::instrument(level = "trace")]`: in a simulation each call costs one level compare, and the timeline captures exactly the `INFO`-and-above events it always did.
+**Below the floor is free in simulation.** `SimulationLayer::install` (what `SimulationBuilder::run` calls) stacks the layer on a `LevelFilter` at the run's trace floor, `INFO` by default, so a `DEBUG` or `TRACE` span or event is disabled at the subscriber and never reaches the registry. Instrument hot paths freely with `#[tracing::instrument(level = "trace")]`: in a sweep each call costs one level compare, and the timeline captures exactly the `INFO`-and-above events it always did.
+
+**Lowering the floor to debug one seed.** `SimulationBuilder::trace_level(LevelFilter::DEBUG)` (or `TRACE`) turns those spans on and captures their events into the timeline for the whole run; `SimulationLayer::new().with_level(..)` does the same for a hand-built layer. The floor never touches scheduling or randomness, so the seed replays identically at any level — only the run is slower and the capture larger, which is why it is a per-investigation setting rather than a sweep default.
 
 ## The Invariant Trait
 

--- a/book/src/part3-building/17-events-and-invariants.md
+++ b/book/src/part3-building/17-events-and-invariants.md
@@ -48,6 +48,8 @@ The `seq` field gives total ordering across all event names. If `leader_elected`
 
 **One emission, two audiences.** In simulation, `SimulationLayer` captures the event into the timeline and invariants cross-validate it. In production, where no `SimulationLayer` is installed, the same event flows to whatever subscriber is configured: `fmt`, OpenTelemetry, structured JSON. Nothing in the emission is moonpool-specific.
 
+**Below `INFO` is free in simulation.** `SimulationLayer::install` (what `SimulationBuilder::run` calls) registers the layer behind a `LevelFilter::INFO`, so a `DEBUG` or `TRACE` span or event is disabled at the subscriber and never reaches the registry. Instrument hot paths freely with `#[tracing::instrument(level = "trace")]`: in a simulation each call costs one level compare, and the timeline captures exactly the `INFO`-and-above events it always did.
+
 ## The Invariant Trait
 
 An invariant is a check the orchestrator runs **after every simulation step**. If the invariant records a failure, the simulation reports the failing seed.

--- a/crates/moonpool-sim/src/observability/layer.rs
+++ b/crates/moonpool-sim/src/observability/layer.rs
@@ -12,6 +12,15 @@
 //! drains them from the simulation engine and records them via
 //! [`SimulationLayerHandle::record_sim_fault`] with `source = "sim"`.
 //!
+//! [`SimulationLayer::install`] applies that first rule at the subscriber,
+//! not just at capture: the layer is registered behind a
+//! `LevelFilter::INFO`, so every span and event below `INFO` is disabled
+//! before the registry allocates anything for it. A process may therefore
+//! carry `#[tracing::instrument(level = "debug")]` / `level = "trace"` spans
+//! on its hot paths (a consensus state machine's per-message handlers, a
+//! storage engine's per-record writes) at the cost of one level compare per
+//! call in simulation, and the timeline captures exactly what it did before.
+//!
 //! Simulation time is stamped from the layer's internal clock, advanced by
 //! the orchestrator via [`SimulationLayerHandle::set_sim_time_ms`] after each
 //! step. Invariants are run by the orchestrator through
@@ -110,7 +119,16 @@ impl SimulationLayer {
     }
 
     /// Install this layer as the per-thread default subscriber without any
-    /// additional layers.
+    /// additional layers, filtered at `INFO`.
+    ///
+    /// The filter is the capture rule applied early: the layer only ever
+    /// records `INFO`-or-more-severe events, so anything below that level is
+    /// disabled at the subscriber and never reaches the registry. Spans and
+    /// events at `DEBUG`/`TRACE` in process or workload code cost a level
+    /// compare and nothing else while a simulation runs; the timeline is
+    /// unchanged. The floor belongs to the subscriber `install` builds, so a
+    /// caller composing its own (`registry().with(SimulationLayer::new())`)
+    /// decides its own.
     #[must_use]
     pub fn install(self) -> (SimulationLayerHandle, InstallGuard) {
         let handle = self.handle();
@@ -125,7 +143,14 @@ impl SimulationLayer {
         // callsite guarantees the cache can never collapse to `never` while a
         // layer is installed. See issue #112.
         let interest_anchor = tracing::Dispatch::new(tracing_subscriber::registry());
-        let subscriber = tracing_subscriber::registry().with(self);
+        // A global floor, not a per-layer filter: `LevelFilter` as a layer in
+        // the stack makes the whole subscriber's `enabled` false below INFO, so
+        // the registry never allocates the span. (A `Filtered` wrapper around
+        // this layer alone would only hide the span from it; the registry
+        // would still create it.)
+        let subscriber = tracing_subscriber::registry()
+            .with(tracing_subscriber::filter::LevelFilter::INFO)
+            .with(self);
         let guard = tracing::subscriber::set_default(subscriber);
         // `set_default` is thread-local and does not rebuild the interest cache,
         // so re-evaluate every callsite now against this capturing subscriber to

--- a/crates/moonpool-sim/src/observability/layer.rs
+++ b/crates/moonpool-sim/src/observability/layer.rs
@@ -12,14 +12,20 @@
 //! drains them from the simulation engine and records them via
 //! [`SimulationLayerHandle::record_sim_fault`] with `source = "sim"`.
 //!
-//! [`SimulationLayer::install`] applies that first rule at the subscriber,
-//! not just at capture: the layer is registered behind a
-//! `LevelFilter::INFO`, so every span and event below `INFO` is disabled
-//! before the registry allocates anything for it. A process may therefore
-//! carry `#[tracing::instrument(level = "debug")]` / `level = "trace"` spans
-//! on its hot paths (a consensus state machine's per-message handlers, a
-//! storage engine's per-record writes) at the cost of one level compare per
-//! call in simulation, and the timeline captures exactly what it did before.
+//! The first rule is a configurable floor, `INFO` by default
+//! ([`SimulationLayer::with_level`], [`SimulationBuilder::trace_level`]), and
+//! [`SimulationLayer::install`] applies it at the subscriber, not just at
+//! capture: the layer is stacked on a `LevelFilter` at that level, so every
+//! span and event below it is disabled before the registry allocates anything
+//! for it. A process may therefore carry `#[tracing::instrument(level =
+//! "debug")]` / `level = "trace"` spans on its hot paths (a consensus state
+//! machine's per-message handlers, a storage engine's per-record writes) at
+//! the cost of one level compare per call in simulation, and the timeline
+//! captures exactly what it did before. Lowering the floor to `DEBUG` or
+//! `TRACE` while debugging one seed turns those spans and events on and
+//! captures the events into the timeline.
+//!
+//! [`SimulationBuilder::trace_level`]: crate::SimulationBuilder::trace_level
 //!
 //! Simulation time is stamped from the layer's internal clock, advanced by
 //! the orchestrator via [`SimulationLayerHandle::set_sim_time_ms`] after each
@@ -38,6 +44,7 @@ use std::sync::Arc;
 use parking_lot::Mutex;
 use tracing::Subscriber;
 use tracing::field::{Field, Visit};
+use tracing::level_filters::LevelFilter;
 use tracing_subscriber::Layer;
 use tracing_subscriber::layer::{Context, SubscriberExt};
 use tracing_subscriber::registry::LookupSpan;
@@ -97,16 +104,48 @@ impl EventStore {
 pub struct SimulationLayer {
     events: Arc<Mutex<EventStore>>,
     invariants: Arc<Mutex<Vec<Box<dyn Invariant + Send>>>>,
+    /// The capture floor: events below it are dropped, and [`install`] makes it
+    /// the subscriber's global floor too. `INFO` by default.
+    ///
+    /// [`install`]: SimulationLayer::install
+    level: LevelFilter,
 }
 
 impl SimulationLayer {
-    /// Create a fresh layer with no events and no invariants.
+    /// Create a fresh layer with no events, no invariants, and an `INFO` floor.
     #[must_use]
     pub fn new() -> Self {
         Self {
             events: Arc::new(Mutex::new(EventStore::new())),
             invariants: Arc::new(Mutex::new(Vec::new())),
+            level: LevelFilter::INFO,
         }
+    }
+
+    /// Set the trace floor: the most verbose level this layer captures, and
+    /// the level [`install`] floors the whole subscriber at.
+    ///
+    /// `INFO` (the default) keeps the timeline to the events invariants read
+    /// and makes every `DEBUG`/`TRACE` span or event in process code free.
+    /// `LevelFilter::DEBUG` or `LevelFilter::TRACE` is the seed-debugging
+    /// setting: hot-path spans are then live and their events land in the
+    /// timeline, so expect a slower run and a much larger capture.
+    /// [`SimulationBuilder::trace_level`] sets this for a whole run.
+    ///
+    /// [`install`]: SimulationLayer::install
+    /// [`SimulationBuilder::trace_level`]: crate::SimulationBuilder::trace_level
+    #[must_use]
+    pub fn with_level(mut self, level: LevelFilter) -> Self {
+        self.level = level;
+        self
+    }
+
+    /// The trace floor this layer captures at (see [`with_level`]).
+    ///
+    /// [`with_level`]: SimulationLayer::with_level
+    #[must_use]
+    pub fn level(&self) -> LevelFilter {
+        self.level
     }
 
     /// Get a clonable handle for registering invariants and reading captured events.
@@ -119,16 +158,19 @@ impl SimulationLayer {
     }
 
     /// Install this layer as the per-thread default subscriber without any
-    /// additional layers, filtered at `INFO`.
+    /// additional layers, floored at the layer's [`level`] (`INFO` unless
+    /// [`with_level`] changed it).
     ///
-    /// The filter is the capture rule applied early: the layer only ever
-    /// records `INFO`-or-more-severe events, so anything below that level is
-    /// disabled at the subscriber and never reaches the registry. Spans and
-    /// events at `DEBUG`/`TRACE` in process or workload code cost a level
-    /// compare and nothing else while a simulation runs; the timeline is
-    /// unchanged. The floor belongs to the subscriber `install` builds, so a
-    /// caller composing its own (`registry().with(SimulationLayer::new())`)
-    /// decides its own.
+    /// The floor is the capture rule applied early: the layer only records
+    /// events at its level or more severe, so anything below is disabled at
+    /// the subscriber and never reaches the registry. At the default `INFO`,
+    /// spans and events at `DEBUG`/`TRACE` in process or workload code cost a
+    /// level compare and nothing else while a simulation runs. The floor
+    /// belongs to the subscriber `install` builds, so a caller composing its
+    /// own (`registry().with(SimulationLayer::new())`) decides its own.
+    ///
+    /// [`level`]: SimulationLayer::level
+    /// [`with_level`]: SimulationLayer::with_level
     #[must_use]
     pub fn install(self) -> (SimulationLayerHandle, InstallGuard) {
         let handle = self.handle();
@@ -144,13 +186,11 @@ impl SimulationLayer {
         // layer is installed. See issue #112.
         let interest_anchor = tracing::Dispatch::new(tracing_subscriber::registry());
         // A global floor, not a per-layer filter: `LevelFilter` as a layer in
-        // the stack makes the whole subscriber's `enabled` false below INFO, so
-        // the registry never allocates the span. (A `Filtered` wrapper around
-        // this layer alone would only hide the span from it; the registry
-        // would still create it.)
-        let subscriber = tracing_subscriber::registry()
-            .with(tracing_subscriber::filter::LevelFilter::INFO)
-            .with(self);
+        // the stack makes the whole subscriber's `enabled` false below the
+        // floor, so the registry never allocates the span. (A `Filtered`
+        // wrapper around this layer alone would only hide the span from it;
+        // the registry would still create it.)
+        let subscriber = tracing_subscriber::registry().with(self.level).with(self);
         let guard = tracing::subscriber::set_default(subscriber);
         // `set_default` is thread-local and does not rebuild the interest cache,
         // so re-evaluate every callsite now against this capturing subscriber to
@@ -416,9 +456,9 @@ where
     }
 
     fn on_event(&self, event: &tracing::Event<'_>, ctx: Context<'_, S>) {
-        // 1. INFO or more severe only (Level::TRACE > Level::INFO in tracing's
-        //    ordering).
-        if *event.metadata().level() > tracing::Level::INFO {
+        // 1. At the floor or more severe only (Level::TRACE > Level::INFO in
+        //    tracing's ordering; a `LevelFilter` compares the same way).
+        if *event.metadata().level() > self.level {
             return;
         }
         // 2. Only events attributable to an actor span carrying an `ip`.

--- a/crates/moonpool-sim/src/observability/mod.rs
+++ b/crates/moonpool-sim/src/observability/mod.rs
@@ -140,6 +140,35 @@ mod tests {
     }
 
     #[test]
+    fn with_level_lowers_the_floor_for_spans_and_capture() {
+        // The seed-debugging setting: at DEBUG the debug span is live, the
+        // debug event is captured, and trace stays off.
+        let (handle, _guard) = SimulationLayer::new()
+            .with_level(tracing::level_filters::LevelFilter::DEBUG)
+            .install();
+
+        in_actor_span("10.0.1.2", || {
+            let trace_span = tracing::trace_span!("handler");
+            let debug_span = tracing::debug_span!("handler");
+            assert!(trace_span.is_disabled());
+            assert!(!debug_span.is_disabled());
+            assert!(tracing::enabled!(tracing::Level::DEBUG));
+            assert!(!tracing::enabled!(tracing::Level::TRACE));
+
+            let _enter = debug_span.enter();
+            tracing::debug!(slot = 3_u64, "accept_seen");
+            tracing::trace!("trace_only");
+        });
+
+        let entries = handle.snapshot("accept_seen");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].level, tracing::Level::DEBUG);
+        assert_eq!(entries[0].source, "10.0.1.2");
+        assert_eq!(entries[0].u64("slot"), Some(3));
+        assert!(handle.snapshot("trace_only").is_empty());
+    }
+
+    #[test]
     fn event_outside_actor_span_is_dropped() {
         let (handle, _guard) = SimulationLayer::new().install();
 

--- a/crates/moonpool-sim/src/observability/mod.rs
+++ b/crates/moonpool-sim/src/observability/mod.rs
@@ -109,6 +109,37 @@ mod tests {
     }
 
     #[test]
+    fn install_disables_spans_and_events_below_info() {
+        // `install` filters at INFO, so a hot-path `#[instrument(level =
+        // "trace")]` span in a process costs a level compare and no registry
+        // allocation. `is_disabled` is the observable: an enabled span gets an
+        // id from the registry, a filtered one does not.
+        let (handle, _guard) = SimulationLayer::new().install();
+
+        in_actor_span("10.0.1.1", || {
+            let trace_span = tracing::trace_span!("handler");
+            let debug_span = tracing::debug_span!("handler");
+            let info_span = tracing::info_span!("stage");
+            assert!(trace_span.is_disabled());
+            assert!(debug_span.is_disabled());
+            assert!(!info_span.is_disabled());
+            assert!(!tracing::enabled!(tracing::Level::DEBUG));
+            assert!(tracing::enabled!(tracing::Level::INFO));
+
+            // An INFO event nested under a filtered span is still captured,
+            // with the source resolved through the surviving actor span.
+            let _enter = debug_span.enter();
+            tracing::debug!("debug_only");
+            tracing::info!(term = 1_u64, "leader_elected");
+        });
+
+        assert!(handle.snapshot("debug_only").is_empty());
+        let entries = handle.snapshot("leader_elected");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].source, "10.0.1.1");
+    }
+
+    #[test]
     fn event_outside_actor_span_is_dropped() {
         let (handle, _guard) = SimulationLayer::new().install();
 

--- a/crates/moonpool-sim/src/runner/builder.rs
+++ b/crates/moonpool-sim/src/runner/builder.rs
@@ -234,6 +234,9 @@ pub struct SimulationBuilder {
     /// `enable_chaos`/`Chaos` model.
     buggify_knobs: bool,
     swarm_operations: bool,
+    /// The trace floor for the run's subscriber and timeline (see
+    /// [`SimulationBuilder::trace_level`]). `INFO` by default.
+    trace_level: tracing::level_filters::LevelFilter,
     invariants: Vec<Box<dyn Invariant + Send>>,
     fault_injectors: Vec<Box<dyn FaultInjector>>,
     /// Factories that build a fresh fault injector for every root and explored
@@ -283,6 +286,7 @@ impl SimulationBuilder {
             link_latency: None,
             buggify_knobs: false,
             swarm_operations: false,
+            trace_level: tracing::level_filters::LevelFilter::INFO,
             invariants: Vec::new(),
             fault_injectors: Vec::new(),
             fault_factories: Vec::new(),
@@ -538,6 +542,24 @@ impl SimulationBuilder {
             client_id: ClientId::default(),
             factory: Box::new(factory),
         });
+        self
+    }
+
+    /// Set the trace floor for the run: the most verbose `tracing` level the
+    /// simulation subscriber enables and the timeline captures.
+    ///
+    /// `INFO` (the default) is the sweep setting: invariants read `INFO`+
+    /// events, and every `DEBUG`/`TRACE` span or event in process and workload
+    /// code is disabled before the registry allocates it, so hot-path
+    /// `#[tracing::instrument(level = "trace")]` costs one level compare.
+    /// Lower it to `LevelFilter::DEBUG` or `LevelFilter::TRACE` when debugging
+    /// one seed: those spans come alive and their events join the timeline,
+    /// at the price of a slower run and a much larger capture. The floor
+    /// never changes scheduling or randomness, so a seed replays identically
+    /// at any level.
+    #[must_use]
+    pub fn trace_level(mut self, level: tracing::level_filters::LevelFilter) -> Self {
+        self.trace_level = level;
         self
     }
 
@@ -1523,7 +1545,7 @@ impl SimulationBuilder {
         // Install the observability layer once for the entire run. The guard
         // is dropped when run() returns, restoring the previous subscriber.
         // All registered invariants live on the layer handle.
-        let layer = SimulationLayer::new();
+        let layer = SimulationLayer::new().with_level(self.trace_level);
         let (obs_handle, _obs_guard) = layer.install();
         for inv in self.invariants.drain(..) {
             obs_handle.register(inv);


### PR DESCRIPTION
## Summary

`SimulationLayer::install` built its subscriber with no level filter, so every `DEBUG`/`TRACE` span or event a process emitted was enabled, allocated in the registry, and visited — even though the layer only ever captures `INFO` and above. A process instrumenting its hot paths (`#[tracing::instrument(level = "trace")]` on a consensus state machine's per-message handlers, say) paid a registry allocation per call for spans nothing would read.

Two commits:

1. **The floor.** The layer is now stacked on a `LevelFilter` layer, a global floor for the whole subscriber: below it, `enabled` is false and the registry never allocates. This is deliberately **not** a per-layer `Filtered` wrapper — that would only hide the span from this layer while the registry still created it (the first draft used one, and its own test caught it).
2. **The knob.** The floor is `INFO` by default and configurable: `SimulationLayer::with_level(LevelFilter)` for a hand-built layer, `SimulationBuilder::trace_level(LevelFilter)` for a run. The layer's capture rule follows the same level, so at `DEBUG` the hot-path spans come alive and their events join the timeline — the seed-debugging setting. The floor never touches scheduling or randomness, so a seed replays identically at any level.

## Downstream evidence

paros (PierreZ/paros#130) adds `#[instrument]` spans to every important method, including the core's per-message handlers at `trace`. Without this floor each of those spans was a live registry span for the whole sweep.

## What stays the same

- The timeline at the default floor: the capture rule was already `INFO`+.
- Source attribution: it still walks the surviving actor spans outward.
- A caller composing its own subscriber (`registry().with(SimulationLayer::new())`) decides its own floor.

## Tests / docs

- `install_disables_spans_and_events_below_info`: a `trace`/`debug` span under `install` is disabled, an `info` span is not, `enabled!(DEBUG)` is false, and an `INFO` event nested under a filtered span is still captured with its source.
- `with_level_lowers_the_floor_for_spans_and_capture`: at `DEBUG` the debug span is live and its event captured with level and source, trace stays off.
- The events-and-invariants chapter and `llms.md` document the floor and the knob.
- `cargo fmt`, `cargo clippy --all-targets -D warnings`, `clippy -p moonpool-sim --no-default-features`, and `cargo nextest run` (724 passed) are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017QAX6zveJzgdUcVXeMwo2h