### PR TITLE
feat(moonpool-sim): faults that never answer — failed disks and black-holed connections

### DIFF
--- a/book/src/appendix/03-configuration.md
+++ b/book/src/appendix/03-configuration.md
@@ -99,12 +99,12 @@ family and heals the partitions the simulator is holding.
 
 | At the cutoff | |
 |---|---|
-| Stopped | Network: partitions, clogs, bit flips, spontaneous closes, connect failures, clock drift, buggified sleep delays, new per-pair latency degradation |
+| Stopped | Network: partitions, clogs, bit flips, spontaneous closes, black holes, connect failures, clock drift, buggified sleep delays, new per-pair latency degradation |
 | Stopped | Storage: read/write/sync/crash faults, misdirected and phantom writes, new disk stall and throttle episodes, new disk failures |
 | Stopped | Block devices: EIO, read corruption, misdirected and phantom writes, persist failures, barrier violations |
 | Stopped | Fault injectors, including built-in attrition |
 | Healed | Every partition in force — directed pair cuts and asymmetric send-side / receive-side blocks alike |
-| Preserved | Corrupted sectors, lost/misdirected/phantom writes already applied, connections already closed, processes already killed, a disk that already failed (and the operations it parked), application state, the fixed extra latency a slow link already sampled |
+| Preserved | Corrupted sectors, lost/misdirected/phantom writes already applied, connections already closed or black-holed, processes already killed, a disk that already failed (and the operations it parked), application state, the fixed extra latency a slow link already sampled |
 | Left to expire | Finite effects already started: disk stall and throttle episodes, clogs, packets already scheduled with a delay |
 
 The persistent consequences of faults already injected remain part of the
@@ -207,7 +207,8 @@ SimulationBuilder::new()
 ```
 
 The mask covers `Clog`, `Partition`, `BitFlip`, `RandomClose`,
-`ConnectFailure`, `ClockDrift`, `BuggifiedDelay`, and `PairLatency`. Removing a
+`ConnectFailure`, `ClockDrift`, `BuggifiedDelay`, `PairLatency`, and
+`BlackHole`. Removing a
 family can only suppress a fault; it cannot enable a family the sampled profile
 turned off. Partial reads and writes are TCP/buggify behavior rather than
 independently sampled fault families and remain active.
@@ -298,6 +299,16 @@ Each ordered IP pair samples one fixed latency from this range at first contact 
 | `random_close_probability` | `f64` | 0.00001 (0.001%) |
 | `random_close_cooldown` | `Duration` | 5s |
 | `random_close_explicit_ratio` | `f64` | 0.3 (30% explicit) |
+
+### Black Hole
+
+A direction that accepts every write and delivers nothing, for the rest of the
+connection's life; see [Black Holes](../part3-building/10-network-faults.md#black-holes).
+
+| Field | Type | Default |
+|-------|------|---------|
+| `black_hole_probability` | `f64` | 0.0 (off) |
+| `black_hole_cooldown` | `Duration` | 5s |
 
 ### Clock Drift
 

--- a/book/src/appendix/03-configuration.md
+++ b/book/src/appendix/03-configuration.md
@@ -100,11 +100,11 @@ family and heals the partitions the simulator is holding.
 | At the cutoff | |
 |---|---|
 | Stopped | Network: partitions, clogs, bit flips, spontaneous closes, connect failures, clock drift, buggified sleep delays, new per-pair latency degradation |
-| Stopped | Storage: read/write/sync/crash faults, misdirected and phantom writes, new disk stall and throttle episodes |
+| Stopped | Storage: read/write/sync/crash faults, misdirected and phantom writes, new disk stall and throttle episodes, new disk failures |
 | Stopped | Block devices: EIO, read corruption, misdirected and phantom writes, persist failures, barrier violations |
 | Stopped | Fault injectors, including built-in attrition |
 | Healed | Every partition in force — directed pair cuts and asymmetric send-side / receive-side blocks alike |
-| Preserved | Corrupted sectors, lost/misdirected/phantom writes already applied, connections already closed, processes already killed, application state, the fixed extra latency a slow link already sampled |
+| Preserved | Corrupted sectors, lost/misdirected/phantom writes already applied, connections already closed, processes already killed, a disk that already failed (and the operations it parked), application state, the fixed extra latency a slow link already sampled |
 | Left to expire | Finite effects already started: disk stall and throttle episodes, clogs, packets already scheduled with a delay |
 
 The persistent consequences of faults already injected remain part of the

--- a/book/src/appendix/04-fault-reference.md
+++ b/book/src/appendix/04-fault-reference.md
@@ -122,6 +122,14 @@ Episodic degradation layered on top of steady-state timing (FoundationDB's `Disk
 | Throttle | `disk_throttle_probability` / `disk_throttle_duration` | 0%, 0ms | Effective IOPS/bandwidth divided by the multipliers |
 | Throttle factor | `disk_throttle_iops_multiplier` / `disk_throttle_bandwidth_multiplier` | 1.0 | Divisor applied to IOPS / bandwidth during a throttle |
 
+### Disk Failure
+
+A disk that never answers (FoundationDB's `failedDisk`, where `waitUntilDiskReady()` returns `Never()`). Off by default and scoped per process: every read, write, sync, or `set_len` issued to a failed disk is accepted and stays `Pending` for the rest of the run, with no error and no scheduled completion. At most one disk is failed at a time; a crash or wipe of the owning process replaces it and fails the parked operations with `OperationInterrupted`. Recovery mode stops new failures but keeps one already in force. `SimWorld::fail_disk_for_process(ip)` is the scripted form.
+
+| Fault | Config Field | Default | Effect |
+|-------|-------------|---------|--------|
+| Disk failure | `disk_failure_probability` | 0% | Every later I/O on that process's disk parks forever; only the caller's timeout or a process kill unblocks it |
+
 ## Process Lifecycle Faults
 
 Configured via [`Attrition`](../part3-building/09-attrition.md) (built-in) or

--- a/book/src/appendix/04-fault-reference.md
+++ b/book/src/appendix/04-fault-reference.md
@@ -26,6 +26,8 @@ Configured via `ChaosConfiguration` (nested under `NetworkConfiguration::chaos`)
 | Random connection close | `random_close_probability` | 0.001% | Reconnection logic, message redelivery, connection pooling |
 | Close error surfacing | `random_close_explicit_ratio` | 30% immediate error, 70% silent close | Explicit-error and timeout-based detection |
 | Close cooldown | `random_close_cooldown` | 5s | Prevents cascading failures after a close event |
+| Black hole | `black_hole_probability` | 0% (off) | A direction that accepts every write and delivers nothing, forever: missing request timeouts, keep-alive and heartbeat detection, half-open connections |
+| Black hole cooldown | `black_hole_cooldown` | 5s | Spaces out black holes across connections |
 | Connect failure | `connect_failure_mode` | `Probabilistic` (50% refused, 50% hang) | Connection establishment retries, timeout handling |
 | Connect failure probability | `connect_failure_probability` | 50% | Ratio of failed vs hanging connections |
 | Stable connection exemption | `mark_connection_stable()` | Manual | Exempt supervision channels from random-close chaos |

--- a/book/src/part3-building/10-network-faults.md
+++ b/book/src/part3-building/10-network-faults.md
@@ -50,6 +50,18 @@ Fault decisions are sampled only when an operation can make progress. Re-polling
 
 A cooldown period prevents cascading closes from overwhelming the system. The goal is to test recovery, not to make the system completely inoperable.
 
+### Black Holes
+
+A silent close still ends: the peer eventually reads EOF and learns something. A **black hole** never ends. When `black_hole_probability` fires, one direction of a connection (this side's sends, the peer's, or both, the same three-way draw random close makes) starts accepting every write and delivering nothing. The bytes are acknowledged into the sender's buffer and vanish, the peer's reads stay `Pending` with no data and no EOF, and a graceful close from the holed side never arrives either. Both ends see a connection that looks perfectly alive. That is what a peer whose kernel keeps acknowledging into a frozen application looks like, or a middlebox that dropped its connection state, and it is the fault that finds a request without a timeout: nothing errors, nothing closes, and only the caller's own deadline can notice. An application-level timeout, an HTTP/2 keep-alive ping, a heartbeat: whatever detects it in production is what has to detect it here.
+
+```rust
+let mut config = NetworkConfiguration::fast_local();
+config.chaos.black_hole_probability = 0.0001; // per I/O, like random close
+config.chaos.black_hole_cooldown = Duration::from_secs(5);
+```
+
+The coin is rolled on the same operations as random close, under the same progress rule, with its own cooldown, and it is recorded once as a `black_hole` fault event. Three properties keep it honest. A black hole is **permanent for the connection**: it never recovers, and the only way out is the one production has, a new connection. An **abort still crosses**: a process kill resets its connections and the peer finds out, as a kernel `RST` would once the host is back, so a hung peer is never mistaken for a dead one at the wrong time. And **recovery mode stops new black holes but keeps the ones in force**, like a closed connection; the quiet tail is where the reconnect has to happen. `SimWorld::black_hole_connection(id, hole_send, hole_recv)` is the scripted form for fault injectors, and the family is off by default, masked as `NetworkFault::BlackHole`.
+
 ### Clogging
 
 Write clogging stalls data delivery on a connection for a random duration (100-300ms by default). This simulates network congestion, TCP backpressure, and flow control contention. Code that assumes writes complete promptly will fail under clogging.

--- a/book/src/part3-building/11-storage-faults.md
+++ b/book/src/part3-building/11-storage-faults.md
@@ -94,6 +94,27 @@ let stalling = StorageConfiguration {
 
 The key property is that **a disabled disk never touches the random number stream**. When both probabilities are zero, the state machine returns before drawing any randomness, so steady-state runs stay byte-for-byte deterministic. Chaos runs enable low-rate episodes through `random_for_seed()`, swarm masking, and buggify knob spikes, the same machinery every other storage fault family uses.
 
+## Disk Failure: I/O That Never Completes
+
+A stall is a disk that answers late. A **failed disk** is a disk that never answers. Every read, write, sync, or `set_len` issued to it after the failure is accepted and stays `Pending` for the rest of the run. Nothing returns an error, nothing times out on the disk's behalf, and the world's event queue is empty while the caller waits. FoundationDB models this with `failedDisk`, where `waitUntilDiskReady()` returns `Never()`; moonpool does the same through `disk_failure_probability`, a per-operation coin that is off by default.
+
+This is the storage fault that finds a missing timeout. Code that awaits an `fsync` inline, with no deadline and no way for the rest of the process to notice, hangs. The runner's stall detector then sees a world with no events and no progress, requests a graceful shutdown, and reports a **deadlock**. That verdict is the point: a disk that stops answering is something a real machine does, and a process that cannot survive it has a bug.
+
+```rust
+// A disk that fails on its first operation
+let failing = StorageConfiguration {
+    disk_failure_probability: 1.0,
+    ..StorageConfiguration::fast_local()
+};
+```
+
+The failure is keyed by the owning process, like an episode: one failure hangs every file the machine owns. Two rules keep it a fault a system can be expected to survive rather than a way to make a run unwinnable:
+
+- **At most one disk is failed at a time.** The coin is not drawn while another disk is failed, so a quorum system never loses more than one member to a hung disk. This is the family's floor.
+- **A crash or wipe of the owning process replaces the disk.** The operations it parked fail with `OperationInterrupted` along with the rest of the process's in-flight I/O, the failure is cleared, and the budget is free for the next disk to draw the coin. Until then the failure has no expiry: recovery mode stops new failures but keeps one already in force, exactly as it keeps a killed process.
+
+A scripted fault injector can fail a disk directly with `SimWorld::fail_disk_for_process(ip)`. That path consumes no randomness and ignores the one-at-a-time budget, because the injector owns its own budget. A parked operation samples no latency and enters no episode, so a hung I/O never moves the seed's random stream either.
+
 ## Exact Asynchronous Operations
 
 Read, write, sync, and set-length calls schedule work and return

--- a/crates/moonpool-sim/src/chaos/fault_events.rs
+++ b/crates/moonpool-sim/src/chaos/fault_events.rs
@@ -139,6 +139,11 @@ pub enum SimFaultEvent {
         /// File identifier.
         file_id: u64,
     },
+    /// A process's disk failed: every later I/O on it parks forever.
+    StorageDiskFailure {
+        /// IP of the process whose disk failed.
+        ip: String,
+    },
     /// Storage crash simulated for a process.
     StorageCrash {
         /// IP of the crashed process.
@@ -182,6 +187,7 @@ impl SimFaultEvent {
             Self::StorageReadFault { .. } => "storage_read_fault",
             Self::StorageWriteFault { .. } => "storage_write_fault",
             Self::StorageSyncFault { .. } => "storage_sync_fault",
+            Self::StorageDiskFailure { .. } => "storage_disk_failure",
             Self::StorageCrash { .. } => "storage_crash",
             Self::StorageWipe { .. } => "storage_wipe",
             Self::BlockDeviceCrash { .. } => "block_device_crash",

--- a/crates/moonpool-sim/src/chaos/fault_events.rs
+++ b/crates/moonpool-sim/src/chaos/fault_events.rs
@@ -105,6 +105,14 @@ pub enum SimFaultEvent {
         /// The connection that was closed.
         connection_id: u64,
     },
+    /// A connection was black-holed: the named sends vanish from now on.
+    BlackHole {
+        /// The connection whose I/O drew the fault.
+        connection_id: u64,
+        /// Which sends vanish: `"send"` (this endpoint's), `"recv"` (the
+        /// peer's, so this endpoint receives nothing), or `"both"`.
+        direction: String,
+    },
     /// Bit flip corruption injected during data delivery.
     BitFlip {
         /// The connection carrying corrupted data.
@@ -183,6 +191,7 @@ impl SimFaultEvent {
             Self::SendPartitionHealed { .. } => "send_partition_healed",
             Self::RecvPartitionHealed { .. } => "recv_partition_healed",
             Self::RandomClose { .. } => "random_close",
+            Self::BlackHole { .. } => "black_hole",
             Self::BitFlip { .. } => "bit_flip",
             Self::StorageReadFault { .. } => "storage_read_fault",
             Self::StorageWriteFault { .. } => "storage_write_fault",

--- a/crates/moonpool-sim/src/network/config.rs
+++ b/crates/moonpool-sim/src/network/config.rs
@@ -10,6 +10,7 @@
 //! |---------|--------------|---------|---------------------|
 //! | Random close | `random_close_probability` | 0.001% | Reconnection logic, message redelivery, connection pooling |
 //! | Close error surfacing | `random_close_explicit_ratio` | 30% explicit | Immediate-error vs timeout-based detection |
+//! | Black hole | `black_hole_probability` + `black_hole_cooldown` | 0% | Missing request timeouts, keep-alive / heartbeat detection, half-open connections |
 //! | Connect failure | `connect_failure_mode` | Probabilistic | Connection establishment retries, timeout handling |
 //!
 //! ## Network Latency & Congestion
@@ -189,10 +190,12 @@ pub enum NetworkFault {
     BuggifiedDelay,
     /// Permanent per-IP-pair latency degradation.
     PairLatency,
+    /// Connections whose sends vanish silently and forever.
+    BlackHole,
 }
 
 impl NetworkFault {
-    const fn bit(self) -> u8 {
+    const fn bit(self) -> u16 {
         match self {
             Self::Clog => 1 << 0,
             Self::Partition => 1 << 1,
@@ -202,6 +205,7 @@ impl NetworkFault {
             Self::ClockDrift => 1 << 5,
             Self::BuggifiedDelay => 1 << 6,
             Self::PairLatency => 1 << 7,
+            Self::BlackHole => 1 << 8,
         }
     }
 }
@@ -227,7 +231,7 @@ impl NetworkFault {
 /// assert!(mask.contains(NetworkFault::Partition));
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct NetworkFaultMask(u8);
+pub struct NetworkFaultMask(u16);
 
 impl Default for NetworkFaultMask {
     fn default() -> Self {
@@ -236,7 +240,7 @@ impl Default for NetworkFaultMask {
 }
 
 impl NetworkFaultMask {
-    const ALL: u8 = u8::MAX;
+    const ALL: u16 = (1 << 9) - 1;
 
     /// Retain every selected network fault family.
     #[must_use]
@@ -293,6 +297,9 @@ impl NetworkFaultMask {
         }
         if !self.contains(NetworkFault::PairLatency) {
             chaos.max_pair_latency = Duration::ZERO..Duration::ZERO;
+        }
+        if !self.contains(NetworkFault::BlackHole) {
+            chaos.black_hole_probability = 0.0;
         }
     }
 }
@@ -355,6 +362,30 @@ pub struct ChaosConfiguration {
     /// Ratio of explicit exceptions vs silent failures (0.0 - 1.0)
     /// FDB default: 0.3 (30% explicit) - see sim2.actor.cpp:602
     pub random_close_explicit_ratio: f64,
+
+    /// Per-I/O probability that a connection is *black-holed* (0.0 - 1.0).
+    ///
+    /// A black-holed direction accepts every write and delivers nothing: the
+    /// bytes are acknowledged locally and vanish, the peer's reads stay
+    /// `Pending` with no data and no EOF, and a graceful close on the holed
+    /// side never reaches the peer either. The connection looks alive to both
+    /// ends. That is what a peer whose kernel keeps acknowledging into a frozen
+    /// application, or a middlebox that dropped its state, looks like — and
+    /// it is the fault that finds a request without a timeout: nothing errors,
+    /// nothing closes, and only the caller's own deadline (an application
+    /// timeout, an HTTP/2 keep-alive ping) can notice.
+    ///
+    /// Rolled on the same I/O operations as [`random_close_probability`]
+    /// (`Self::random_close_probability`), with its own cooldown, and it picks
+    /// a direction the way random close does: this side's sends, the peer's
+    /// sends, or both. A black-holed connection never recovers; only a new
+    /// connection is clean. An abort (`RST`) still reaches the peer, as a
+    /// kernel reset would once the host is back. Recovery mode stops new
+    /// black holes but keeps the ones in force. Off by default.
+    pub black_hole_probability: f64,
+
+    /// Cooldown after a black hole before another connection may be holed.
+    pub black_hole_cooldown: Duration,
 
     /// Enable clock drift simulation
     /// When enabled, `timer()` can return a time up to `clock_drift_max` ahead of `now()`
@@ -421,9 +452,11 @@ impl Default for ChaosConfiguration {
             random_close_probability: 0.00001, // 0.001% - matches FDB's sim2.actor.cpp:584
             random_close_cooldown: Duration::from_secs(5), // Reasonable default
             random_close_explicit_ratio: 0.3,  // 30% explicit - matches FDB's sim2.actor.cpp:602
-            clock_drift_enabled: true,         // Enable by default for chaos testing
+            black_hole_probability: 0.0,       // Off by default: opt-in, like clogs and partitions
+            black_hole_cooldown: Duration::from_secs(5),
+            clock_drift_enabled: true, // Enable by default for chaos testing
             clock_drift_max: Duration::from_millis(100), // FDB default: 0.1 seconds
-            buggified_delay_enabled: true,     // Enable by default for chaos testing
+            buggified_delay_enabled: true, // Enable by default for chaos testing
             buggified_delay_max: Duration::from_millis(100), // FDB: MAX_BUGGIFIED_DELAY
             buggified_delay_probability: 0.25, // FDB: random01() < 0.25
             connect_failure_mode: ConnectFailureMode::Probabilistic, // FDB: SIM_CONNECT_ERROR_MODE = 2
@@ -452,6 +485,8 @@ impl ChaosConfiguration {
             random_close_probability: 0.0,
             random_close_cooldown: Duration::ZERO,
             random_close_explicit_ratio: 0.3,
+            black_hole_probability: 0.0,
+            black_hole_cooldown: Duration::ZERO,
             clock_drift_enabled: false,
             clock_drift_max: Duration::from_millis(100),
             buggified_delay_enabled: false,
@@ -510,6 +545,10 @@ impl ChaosConfiguration {
             // Vary max bytes for different scenarios. Appended last (after
             // max_pair_latency) so the RNG draws above keep their per-seed values.
             partial_read_max_bytes: sim_random_range(100..2000),
+            // Black holes: as rare as random closes, with the same cooldown
+            // range. Drawn after partial_read_max_bytes for the same reason.
+            black_hole_probability: f64::from(sim_random_range(1..100)) / 1_000_000.0,
+            black_hole_cooldown: Duration::from_millis(sim_random_range(1000..10_000)),
         }
     }
 
@@ -531,7 +570,7 @@ impl ChaosConfiguration {
     /// Disable each fault family with ~50% probability using the `CONFIG_RNG`
     /// stream (see [`swarm_for_seed`](Self::swarm_for_seed)).
     ///
-    /// Draws exactly eight `config_random_bool` values (one per family) so the
+    /// Draws exactly nine `config_random_bool` values (one per family) so the
     /// `CONFIG_RNG` call sequence is fixed and reproducible per seed. Durations,
     /// cooldowns, and strategy stay as sampled — they are inert once their family
     /// is off.
@@ -554,9 +593,13 @@ impl ChaosConfiguration {
         }
         self.clock_drift_enabled = config_random_bool(0.5);
         self.buggified_delay_enabled = config_random_bool(0.5);
-        // Appended last: keeps the seven draws above stable across seeds.
+        // Appended after the seven draws above so they stay stable across seeds.
         if !config_random_bool(0.5) {
             self.max_pair_latency = Duration::ZERO..Duration::ZERO;
+        }
+        // Appended last, for the same reason.
+        if !config_random_bool(0.5) {
+            self.black_hole_probability = 0.0;
         }
     }
 
@@ -573,6 +616,7 @@ impl ChaosConfiguration {
         self.partition_probability = crate::buggify_knob!(self.partition_probability, 0.3..0.8);
         self.random_close_probability =
             crate::buggify_knob!(self.random_close_probability, 0.01..0.1);
+        self.black_hole_probability = crate::buggify_knob!(self.black_hole_probability, 0.01..0.1);
     }
 
     /// Turn every network fault family off, leaving performance shaping alone.
@@ -580,15 +624,16 @@ impl ChaosConfiguration {
     /// This is the chaos half of the recovery-mode transition
     /// ([`SimWorld::enter_recovery_mode`](crate::SimWorld::enter_recovery_mode)):
     /// after this call the engine samples no new partitions, clogs, bit flips,
-    /// spontaneous closes, connect failures, clock drift, sleep delays, or
-    /// per-pair latency degradations. It is exactly
+    /// spontaneous closes, black holes, connect failures, clock drift, sleep
+    /// delays, or per-pair latency degradations. It is exactly
     /// [`NetworkFaultMask::none()`](crate::NetworkFaultMask::none) applied to
     /// this configuration and consumes no randomness.
     ///
     /// It only stops *new* faults. Everything already produced stays: a
     /// partition still in force, a clog still ticking down, corrupted bytes
-    /// already delivered, a connection the application already saw close, and
-    /// the fixed extra latency a slow pair already sampled.
+    /// already delivered, a connection the application already saw close, a
+    /// black-holed connection (it never recovers), and the fixed extra latency
+    /// a slow pair already sampled.
     ///
     /// Latencies (`bind`/`accept`/`connect`/`write`, `link_latency`) and the
     /// TCP-realistic partial read/write sizes are untouched: they are the
@@ -941,7 +986,7 @@ mod swarm_tests {
     use crate::sim::rng::{reset_sim_rng, set_config_seed, set_sim_seed};
 
     /// The on/off state of each swarmed fault family, in mask order.
-    fn enabled_families(chaos: &ChaosConfiguration) -> [bool; 7] {
+    fn enabled_families(chaos: &ChaosConfiguration) -> [bool; 8] {
         [
             chaos.clog_probability > 0.0,
             chaos.partition_probability > 0.0,
@@ -950,6 +995,7 @@ mod swarm_tests {
             chaos.connect_failure_mode != ConnectFailureMode::Disabled,
             chaos.clock_drift_enabled,
             chaos.buggified_delay_enabled,
+            chaos.black_hole_probability > 0.0,
         ]
     }
 
@@ -1015,6 +1061,28 @@ mod swarm_tests {
         assert_zero(chaos.connect_failure_probability);
         assert!(!chaos.clock_drift_enabled);
         assert!(!chaos.buggified_delay_enabled);
+        assert_zero(chaos.black_hole_probability);
+    }
+
+    #[test]
+    fn the_mask_can_suppress_black_holes_alone() {
+        use crate::{NetworkFault, NetworkFaultMask};
+
+        let mut chaos = ChaosConfiguration {
+            black_hole_probability: 1.0,
+            random_close_probability: 1.0,
+            ..ChaosConfiguration::disabled()
+        };
+        NetworkFaultMask::all()
+            .without(NetworkFault::BlackHole)
+            .apply_to(&mut chaos);
+        assert_zero(chaos.black_hole_probability);
+        assert!(
+            chaos.random_close_probability > 0.0,
+            "removing one family must leave the others alone"
+        );
+        assert!(NetworkFaultMask::all().contains(NetworkFault::BlackHole));
+        assert!(!NetworkFaultMask::none().contains(NetworkFault::BlackHole));
     }
 
     /// Assert an f64 is exactly `+0.0` (bit-exact, avoiding the float-cmp lint).

--- a/crates/moonpool-sim/src/network/sim/engine.rs
+++ b/crates/moonpool-sim/src/network/sim/engine.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use crate::{
-    SimulationError, SimulationResult,
+    SimulationError, SimulationResult, assert_reachable,
     chaos::fault_events::SimFaultEvent,
     locality::{DomainLevel, LocalityInfo},
     network::{LinkLatencyConfig, NetworkConfiguration, PartitionStrategy},
@@ -545,6 +545,12 @@ impl NetworkSimulation {
         else {
             return;
         };
+        // The chunk left a black-holed sender: it was acknowledged into that
+        // side's buffer and is gone. No bytes, no wake — the reader keeps
+        // waiting for data that will never come.
+        if self.peer_send_black_holed(id) {
+            return;
+        }
         let delivered = if stable {
             data
         } else {
@@ -557,12 +563,27 @@ impl NetworkSimulation {
     }
 
     fn handle_fin_delivery(&mut self, id: ConnectionId, wakes: &mut WakeBatch) {
+        // A FIN is a send like any other: from a black-holed peer it vanishes,
+        // and the reader never sees EOF.
+        if self.peer_send_black_holed(id) {
+            return;
+        }
         if let Some(connection) = self.state.connections.get_mut(&id)
             && !connection.flags.is_closed()
         {
             connection.flags.set_remote_fin_received(true);
             wakes.push(self.waiters.reads.remove(&id));
         }
+    }
+
+    /// Whether the endpoint that sends *to* `id` has its sends black-holed.
+    fn peer_send_black_holed(&self, id: ConnectionId) -> bool {
+        self.state
+            .connections
+            .get(&id)
+            .and_then(|connection| connection.paired_connection)
+            .and_then(|peer| self.state.connections.get(&peer))
+            .is_some_and(|peer| peer.flags.send_black_holed())
     }
 
     fn calculate_flip_bit_count(random_value: u32, min_bits: u32, max_bits: u32) -> u32 {
@@ -1422,6 +1443,87 @@ impl NetworkSimulation {
             connection_id: id.0,
         });
         (Some(explicit), actions, wakes)
+    }
+
+    /// Roll the black-hole coin for one I/O on `id` (the `rollRandomClose`
+    /// shape: own probability, own cooldown, one `buggify_with_prob!` draw).
+    ///
+    /// A hit black-holes this endpoint's sends, its peer's, or both — the same
+    /// three-way direction draw a random close makes — and is recorded once as
+    /// [`SimFaultEvent::BlackHole`]. Nothing is returned to the caller: the
+    /// operation that drew the fault proceeds normally, which is the point.
+    /// Draws nothing while the family is off.
+    pub(crate) fn roll_black_hole(&mut self, id: ConnectionId, now: Duration) -> NetworkActions {
+        let config = &self.state.config.chaos;
+        if self
+            .state
+            .connections
+            .get(&id)
+            .is_none_or(|connection| connection.flags.is_closed())
+            || config.black_hole_probability <= 0.0
+            || now.saturating_sub(self.state.last_black_hole_time) < config.black_hole_cooldown
+            || !crate::buggify_with_prob!(config.black_hole_probability)
+        {
+            return NetworkActions::default();
+        }
+        self.state.last_black_hole_time = now;
+        let a = sim_random_f64();
+        let hole_recv = a < 0.66;
+        let hole_send = a > 0.33;
+        assert_reachable!("network: connection black-holed");
+        self.black_hole(id, hole_send, hole_recv)
+    }
+
+    /// Black-hole `id`'s sends (`hole_send`) and/or its peer's (`hole_recv`).
+    ///
+    /// Permanent for the connection's lifetime and idempotent per direction;
+    /// the fault is recorded only when a direction that was not yet holed is.
+    pub(crate) fn black_hole(
+        &mut self,
+        id: ConnectionId,
+        hole_send: bool,
+        hole_recv: bool,
+    ) -> NetworkActions {
+        let paired = self
+            .state
+            .connections
+            .get(&id)
+            .and_then(|c| c.paired_connection);
+        let mut newly_send = false;
+        if hole_send
+            && let Some(c) = self.state.connections.get_mut(&id)
+            && !c.flags.send_black_holed()
+        {
+            c.flags.set_send_black_holed(true);
+            newly_send = true;
+        }
+        let mut newly_recv = false;
+        if hole_recv
+            && let Some(c) = paired.and_then(|peer| self.state.connections.get_mut(&peer))
+            && !c.flags.send_black_holed()
+        {
+            c.flags.set_send_black_holed(true);
+            newly_recv = true;
+        }
+        let mut actions = NetworkActions::default();
+        let direction = match (newly_send, newly_recv) {
+            (true, true) => "both",
+            (true, false) => "send",
+            (false, true) => "recv",
+            (false, false) => return actions,
+        };
+        actions.record(SimFaultEvent::BlackHole {
+            connection_id: id.0,
+            direction: direction.to_string(),
+        });
+        actions
+    }
+
+    pub(crate) fn is_send_black_holed(&self, id: ConnectionId) -> bool {
+        self.state
+            .connections
+            .get(&id)
+            .is_some_and(|connection| connection.flags.send_black_holed())
     }
 
     pub(crate) fn close_graceful(

--- a/crates/moonpool-sim/src/network/sim/facade.rs
+++ b/crates/moonpool-sim/src/network/sim/facade.rs
@@ -342,6 +342,35 @@ impl SimWorld {
         result
     }
 
+    /// Rolls the black-hole coin for one I/O on `id` (see
+    /// [`ChaosConfiguration::black_hole_probability`](crate::ChaosConfiguration::black_hole_probability)).
+    pub fn roll_black_hole(&self, id: ConnectionId) {
+        let mut inner = self.inner.write();
+        let now = inner.now();
+        let actions = inner.network.roll_black_hole(id, now);
+        inner.apply_network(actions);
+    }
+
+    /// Black-holes selected directions of a connection: `hole_send` makes this
+    /// endpoint's sends vanish, `hole_recv` its peer's. Writes keep succeeding
+    /// and the peer's reads never see data or EOF; only an abort still crosses.
+    ///
+    /// The scripted counterpart of
+    /// [`ChaosConfiguration::black_hole_probability`](crate::ChaosConfiguration::black_hole_probability);
+    /// it consumes no randomness, and a black hole is permanent for the
+    /// connection's lifetime.
+    pub fn black_hole_connection(&self, id: ConnectionId, hole_send: bool, hole_recv: bool) {
+        let mut inner = self.inner.write();
+        let actions = inner.network.black_hole(id, hole_send, hole_recv);
+        inner.apply_network(actions);
+    }
+
+    /// Returns whether `id`'s sends are black-holed.
+    #[must_use]
+    pub fn is_send_black_holed(&self, id: ConnectionId) -> bool {
+        self.inner.read().network.is_send_black_holed(id)
+    }
+
     /// Returns whether the send side is closed.
     #[must_use]
     pub fn is_send_closed(&self, id: ConnectionId) -> bool {

--- a/crates/moonpool-sim/src/network/sim/state.rs
+++ b/crates/moonpool-sim/src/network/sim/state.rs
@@ -47,6 +47,7 @@ impl ConnectionFlags {
     const REMOTE_FIN_RECEIVED: u16 = 1 << 7;
     const SEND_IN_PROGRESS: u16 = 1 << 8;
     const SEND_STALLED: u16 = 1 << 9;
+    const SEND_BLACK_HOLED: u16 = 1 << 10;
 
     fn get(self, mask: u16) -> bool {
         (self.0 & mask) != 0
@@ -127,6 +128,19 @@ impl ConnectionFlags {
     pub(crate) fn set_send_stalled(&mut self, value: bool) {
         self.set_bit(Self::SEND_STALLED, value);
     }
+
+    /// Whether this endpoint's sends vanish: every chunk drained from the send
+    /// buffer is dropped instead of delivered, and its FIN never leaves.
+    ///
+    /// The flag is permanent for the connection's lifetime; only a fresh
+    /// connection is clean again.
+    pub(crate) fn send_black_holed(self) -> bool {
+        self.get(Self::SEND_BLACK_HOLED)
+    }
+
+    pub(crate) fn set_send_black_holed(&mut self, value: bool) {
+        self.set_bit(Self::SEND_BLACK_HOLED, value);
+    }
 }
 
 /// State for one endpoint of a simulated TCP connection.
@@ -161,6 +175,7 @@ pub(crate) struct NetworkState {
     pub(crate) send_partitions: BTreeMap<IpAddr, Duration>,
     pub(crate) recv_partitions: BTreeMap<IpAddr, Duration>,
     pub(crate) last_random_close_time: Duration,
+    pub(crate) last_black_hole_time: Duration,
     pub(crate) pair_latencies: BTreeMap<(IpAddr, IpAddr), Duration>,
 }
 
@@ -179,6 +194,7 @@ impl NetworkState {
             send_partitions: BTreeMap::new(),
             recv_partitions: BTreeMap::new(),
             last_random_close_time: Duration::ZERO,
+            last_black_hole_time: Duration::ZERO,
             pair_latencies: BTreeMap::new(),
         }
     }

--- a/crates/moonpool-sim/src/network/sim/stream.rs
+++ b/crates/moonpool-sim/src/network/sim/stream.rs
@@ -269,6 +269,9 @@ impl AsyncRead for SimTcpStream {
         if let Some(true) = sim.roll_random_close(self.connection_id) {
             return Poll::Ready(Err(random_connection_failure_error()));
         }
+        // The black hole rolls beside the close, under the same progress
+        // rule, on its own coin. It changes nothing about this operation.
+        sim.roll_black_hole(self.connection_id);
         if sim.is_connection_closed(self.connection_id)
             && sim.close_reason(self.connection_id) == CloseReason::Aborted
         {
@@ -416,6 +419,9 @@ impl AsyncWrite for SimTcpStream {
         if let Some(true) = sim.roll_random_close(self.connection_id) {
             return Poll::Ready(Err(random_connection_failure_error()));
         }
+        // The black hole rolls beside the close, under the same progress
+        // rule, on its own coin. It changes nothing about this operation.
+        sim.roll_black_hole(self.connection_id);
         if let Some(poll) = self.write_guard_pre_backpressure(&sim) {
             return poll;
         }
@@ -471,6 +477,9 @@ impl AsyncWrite for SimTcpStream {
         if let Some(true) = sim.roll_random_close(self.connection_id) {
             return Poll::Ready(Err(random_connection_failure_error()));
         }
+        // The black hole rolls beside the close, under the same progress
+        // rule, on its own coin. It changes nothing about this operation.
+        sim.roll_black_hole(self.connection_id);
         if let Some(poll) = self.write_guard_pre_backpressure(&sim) {
             return poll;
         }

--- a/crates/moonpool-sim/src/sim/storage_ops.rs
+++ b/crates/moonpool-sim/src/sim/storage_ops.rs
@@ -243,6 +243,27 @@ impl SimWorld {
         }
     }
 
+    /// Fail `ip`'s disk outright: every read, write, sync, or `set_len` issued
+    /// to a file it owns from now on is accepted and never completes, until
+    /// [`simulate_crash_for_process`](Self::simulate_crash_for_process) or
+    /// [`wipe_storage_for_process`](Self::wipe_storage_for_process) replaces
+    /// the disk. This is the scripted counterpart of
+    /// [`StorageConfiguration::disk_failure_probability`](crate::StorageConfiguration::disk_failure_probability):
+    /// it consumes no randomness and ignores the coin's one-at-a-time budget.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the simulation lock is poisoned by a prior task panic.
+    #[instrument(skip(self))]
+    pub fn fail_disk_for_process(&self, ip: IpAddr) {
+        let wakes = {
+            let mut inner = self.inner.write();
+            let actions = inner.storage.fail_disk(ip);
+            apply_storage_actions(&mut inner, actions)
+        };
+        wakes.wake();
+    }
+
     /// Wipe all persistent storage for a specific process, block devices
     /// included.
     ///

--- a/crates/moonpool-sim/src/sim/world.rs
+++ b/crates/moonpool-sim/src/sim/world.rs
@@ -442,6 +442,13 @@ impl SimWorld {
         self.inner.read().storage.disk_episode_for(ip)
     }
 
+    /// Whether `ip`'s disk has failed and parks every operation forever (see
+    /// [`StorageConfiguration::disk_failure_probability`](crate::StorageConfiguration::disk_failure_probability)).
+    #[must_use]
+    pub fn is_disk_failed(&self, ip: IpAddr) -> bool {
+        self.inner.read().storage.is_disk_failed(ip)
+    }
+
     /// Creates a cancellable simulation sleep.
     #[must_use]
     pub fn sleep(&self, duration: Duration) -> SleepFuture {

--- a/crates/moonpool-sim/src/storage/config.rs
+++ b/crates/moonpool-sim/src/storage/config.rs
@@ -40,6 +40,16 @@
 //! | Throttle | `disk_throttle_probability` / `disk_throttle_duration` | 0% | Effective IOPS/bandwidth divided by the multipliers |
 //! | Throttle factor | `disk_throttle_iops_multiplier` / `disk_throttle_bandwidth_multiplier` | 1.0 | Divisor applied to IOPS / bandwidth |
 //!
+//! ## Disk Failure
+//!
+//! A disk that *fails* is not slow, it is gone: every I/O issued to it after
+//! the failure is accepted and never completes. FDB ref: `failedDisk` /
+//! `waitUntilDiskReady()` returning `Never()`. Off by default.
+//!
+//! | Fault | Config Field | Default | Effect while active |
+//! |-------|--------------|---------|---------------------|
+//! | Disk failure | `disk_failure_probability` | 0% | Every later read/write/sync/`set_len` on that process's disk stays pending forever |
+//!
 //! ## Configuration Examples
 //!
 //! ### Fast Local Testing (No Chaos)
@@ -200,6 +210,32 @@ pub struct StorageConfiguration {
 
     /// Divisor applied to effective bandwidth during a throttle episode (>= 1.0).
     pub disk_throttle_bandwidth_multiplier: f64,
+
+    // =========================================================================
+    // Disk Failure
+    // =========================================================================
+    /// Per-operation probability that the owning process's disk *fails*
+    /// (0.0 - 1.0).
+    ///
+    /// A failed disk answers nothing: the operation that failed it and every
+    /// read, write, sync, or `set_len` issued to that process's files afterwards
+    /// is accepted and never completes — the future stays `Pending` for the
+    /// rest of the run. Nothing errors, nothing times out on the disk's behalf;
+    /// only the caller's own timeout (or the process being killed) unblocks it.
+    /// This is `FoundationDB`'s `failedDisk`, where `waitUntilDiskReady()`
+    /// returns `Never()`.
+    ///
+    /// Scope and floor: the failure is keyed by the owning process IP, like a
+    /// degradation episode, and **at most one disk is failed at a time** across
+    /// the whole simulation, so a quorum system never loses more than one
+    /// member to a hung disk. A crash or wipe of the owning process clears it
+    /// (the reboot is the disk replacement) and fails the parked operations
+    /// with `OperationInterrupted`; the next process to draw the coin may then
+    /// fail its own disk. Recovery mode stops new failures but keeps one
+    /// already in force.
+    ///
+    /// While `0.0` (the default) no operation draws from the RNG stream.
+    pub disk_failure_probability: f64,
 }
 
 impl Default for StorageConfiguration {
@@ -237,6 +273,9 @@ impl Default for StorageConfiguration {
             disk_throttle_duration: Duration::ZERO,
             disk_throttle_iops_multiplier: 1.0,
             disk_throttle_bandwidth_multiplier: 1.0,
+
+            // Disk failure - disabled by default
+            disk_failure_probability: 0.0,
         }
     }
 }
@@ -292,6 +331,10 @@ impl StorageConfiguration {
             disk_throttle_duration: Duration::from_millis(sim_random_range(500..5000)),
             disk_throttle_iops_multiplier: f64::from(sim_random_range(2..20)),
             disk_throttle_bandwidth_multiplier: f64::from(sim_random_range(2..20)),
+
+            // Disk failure: 0 to 0.01% per operation, drawn last so every field
+            // above keeps its per-seed value.
+            disk_failure_probability: f64::from(sim_random_range(0..10)) / 100_000.0,
         }
     }
 
@@ -313,9 +356,10 @@ impl StorageConfiguration {
     /// Disable each fault family with ~50% probability using the `CONFIG_RNG`
     /// stream (see [`swarm_for_seed`](Self::swarm_for_seed)).
     ///
-    /// Draws exactly nine `config_random_bool` values (one per family: the seven
-    /// per-op faults plus the stall and throttle episode families) so the
-    /// `CONFIG_RNG` call sequence is fixed and reproducible per seed. Performance
+    /// Draws exactly ten `config_random_bool` values (one per family: the seven
+    /// per-op faults, the stall and throttle episode families, and the disk
+    /// failure) so the `CONFIG_RNG` call sequence is fixed and reproducible per
+    /// seed. Performance
     /// parameters (IOPS, bandwidth, latencies) stay as sampled — only the fault
     /// families are masked.
     fn apply_swarm_mask(&mut self) {
@@ -346,6 +390,10 @@ impl StorageConfiguration {
         if !config_random_bool(0.5) {
             self.disk_throttle_probability = 0.0;
         }
+        // Appended last: keeps the nine draws above stable across seeds.
+        if !config_random_bool(0.5) {
+            self.disk_failure_probability = 0.0;
+        }
     }
 
     /// Spike selected disk knob *magnitudes* under buggify (FDB's
@@ -373,6 +421,10 @@ impl StorageConfiguration {
             self.disk_throttle_duration,
             Duration::from_secs(1)..Duration::from_secs(5)
         );
+        // A failed disk is bounded by count (one at a time), not by rate, so a
+        // spiked rate only moves the failure earlier in the run.
+        self.disk_failure_probability =
+            crate::buggify_knob!(self.disk_failure_probability, 0.001..0.01);
     }
 
     /// Turn every storage fault family off, leaving disk performance alone.
@@ -380,13 +432,15 @@ impl StorageConfiguration {
     /// This is the storage half of the recovery-mode transition
     /// ([`SimWorld::enter_recovery_mode`](crate::SimWorld::enter_recovery_mode)):
     /// after this call no operation samples a read/write/sync/crash fault, no
-    /// write is misdirected or turned into a phantom, and no new disk stall or
-    /// throttle episode is entered. It consumes no randomness.
+    /// write is misdirected or turned into a phantom, no new disk stall or
+    /// throttle episode is entered, and no disk fails. It consumes no
+    /// randomness.
     ///
     /// It only stops *new* faults. Sectors already corrupted stay corrupted,
     /// bytes already lost stay lost, misdirected and phantom writes already
-    /// applied are not undone, and an episode already in force runs to its
-    /// expiry.
+    /// applied are not undone, an episode already in force runs to its
+    /// expiry, and a disk that already failed stays failed until its process
+    /// is crashed or wiped.
     ///
     /// IOPS, bandwidth, and the read/write/sync latency distributions are
     /// untouched — they are the disk's normal characteristics. So are the
@@ -402,6 +456,7 @@ impl StorageConfiguration {
         self.sync_failure_probability = 0.0;
         self.disk_stall_probability = 0.0;
         self.disk_throttle_probability = 0.0;
+        self.disk_failure_probability = 0.0;
     }
 
     /// Create a configuration optimized for fast local testing.
@@ -438,6 +493,9 @@ impl StorageConfiguration {
             disk_throttle_duration: Duration::ZERO,
             disk_throttle_iops_multiplier: 1.0,
             disk_throttle_bandwidth_multiplier: 1.0,
+
+            // Disk failure disabled
+            disk_failure_probability: 0.0,
         }
     }
 }
@@ -448,7 +506,7 @@ mod swarm_tests {
     use crate::sim::rng::{reset_sim_rng, set_config_seed, set_sim_seed};
 
     /// The on/off state of each swarmed fault family, in mask order.
-    fn enabled_families(config: &StorageConfiguration) -> [bool; 9] {
+    fn enabled_families(config: &StorageConfiguration) -> [bool; 10] {
         [
             config.read_fault_probability > 0.0,
             config.write_fault_probability > 0.0,
@@ -459,6 +517,7 @@ mod swarm_tests {
             config.sync_failure_probability > 0.0,
             config.disk_stall_probability > 0.0,
             config.disk_throttle_probability > 0.0,
+            config.disk_failure_probability > 0.0,
         ]
     }
 
@@ -525,6 +584,17 @@ mod swarm_tests {
         assert_zero(config.sync_failure_probability);
         assert_zero(config.disk_stall_probability);
         assert_zero(config.disk_throttle_probability);
+        assert_zero(config.disk_failure_probability);
+    }
+
+    #[test]
+    fn disable_fault_injection_turns_off_the_disk_failure_family() {
+        let mut config = StorageConfiguration {
+            disk_failure_probability: 1.0,
+            ..StorageConfiguration::fast_local()
+        };
+        config.disable_fault_injection();
+        assert_zero(config.disk_failure_probability);
     }
 
     /// Assert an f64 is exactly `+0.0` (bit-exact, avoiding the float-cmp lint).

--- a/crates/moonpool-sim/src/storage/sim/engine.rs
+++ b/crates/moonpool-sim/src/storage/sim/engine.rs
@@ -103,7 +103,8 @@ impl StorageEngine {
     /// Disk-degradation episodes already in force are deliberately left in
     /// `disk_episodes`: they carry an expiry and clear themselves on the next
     /// operation past it, so a stall that started under chaos still has to be
-    /// waited out.
+    /// waited out. A disk that already failed stays in `failed_disks`: it has
+    /// no expiry, and only a crash or wipe of its process replaces it.
     pub(crate) fn disable_fault_injection(&mut self) {
         self.state.config.disable_fault_injection();
         for config in self.state.per_process_configs.values_mut() {
@@ -113,6 +114,21 @@ impl StorageEngine {
 
     pub(crate) fn disk_episode_for(&self, ip: IpAddr) -> Option<DiskDegradationState> {
         self.state.disk_episodes.get(&ip).copied()
+    }
+
+    pub(crate) fn is_disk_failed(&self, ip: IpAddr) -> bool {
+        self.state.failed_disks.contains(&ip)
+    }
+
+    /// Fail `ip`'s disk outright: every later operation on a file it owns is
+    /// parked forever. A scripted injection, so it ignores the one-at-a-time
+    /// budget the per-operation coin honors and consumes no randomness.
+    pub(crate) fn fail_disk(&mut self, ip: IpAddr) -> StorageActions {
+        let mut actions = StorageActions::default();
+        if self.state.failed_disks.insert(ip) {
+            actions.fault(SimFaultEvent::StorageDiskFailure { ip: ip.to_string() });
+        }
+        actions
     }
 
     pub(crate) fn open_file(
@@ -226,6 +242,18 @@ impl StorageEngine {
         self.ensure_readable(handle_id)?;
         let file_id = self.open_file_id(handle_id)?;
         let owner_ip = self.owner_ip(file_id)?;
+        let pending = PendingStorageOp {
+            handle_id,
+            file_id,
+            op_type: PendingOpType::Read,
+            offset,
+            len,
+            data: None,
+            append: false,
+        };
+        if let Some(actions) = self.roll_disk_failure(owner_ip) {
+            return self.park_operation(pending, actions);
+        }
         let episode = self.update_disk_episode(owner_ip, now);
         let latency = Self::calculate_storage_latency(
             self.state.config_for(owner_ip),
@@ -235,15 +263,7 @@ impl StorageEngine {
             now,
         );
         self.schedule_operation(
-            PendingStorageOp {
-                handle_id,
-                file_id,
-                op_type: PendingOpType::Read,
-                offset,
-                len,
-                data: None,
-                append: false,
-            },
+            pending,
             StorageOperation::ReadComplete {
                 len: u32::try_from(len).expect("read length fits in u32"),
             },
@@ -263,6 +283,18 @@ impl StorageEngine {
         let append = self.open_handle(handle_id)?.options.is_append();
         let owner_ip = self.owner_ip(file_id)?;
         let len = data.len();
+        let pending = PendingStorageOp {
+            handle_id,
+            file_id,
+            op_type: PendingOpType::Write,
+            offset,
+            len,
+            data: Some(data),
+            append,
+        };
+        if let Some(actions) = self.roll_disk_failure(owner_ip) {
+            return self.park_operation(pending, actions);
+        }
         let episode = self.update_disk_episode(owner_ip, now);
         let latency = Self::calculate_storage_latency(
             self.state.config_for(owner_ip),
@@ -272,15 +304,7 @@ impl StorageEngine {
             now,
         );
         self.schedule_operation(
-            PendingStorageOp {
-                handle_id,
-                file_id,
-                op_type: PendingOpType::Write,
-                offset,
-                len,
-                data: Some(data),
-                append,
-            },
+            pending,
             StorageOperation::WriteComplete {
                 len: u32::try_from(len).expect("write length fits in u32"),
             },
@@ -295,6 +319,18 @@ impl StorageEngine {
     ) -> Result<(OperationId, StorageActions), StorageError> {
         let file_id = self.open_file_id(handle_id)?;
         let owner_ip = self.owner_ip(file_id)?;
+        let pending = PendingStorageOp {
+            handle_id,
+            file_id,
+            op_type: PendingOpType::Sync,
+            offset: 0,
+            len: 0,
+            data: None,
+            append: false,
+        };
+        if let Some(actions) = self.roll_disk_failure(owner_ip) {
+            return self.park_operation(pending, actions);
+        }
         let episode = self.update_disk_episode(owner_ip, now);
         let mut latency = sample_latency(&self.state.config_for(owner_ip).sync_latency);
         if let Some(DiskDegradationState {
@@ -305,15 +341,7 @@ impl StorageEngine {
             latency = latency.saturating_add(expires_at.saturating_sub(now));
         }
         self.schedule_operation(
-            PendingStorageOp {
-                handle_id,
-                file_id,
-                op_type: PendingOpType::Sync,
-                offset: 0,
-                len: 0,
-                data: None,
-                append: false,
-            },
+            pending,
             StorageOperation::SyncComplete,
             now.saturating_add(latency),
         )
@@ -328,20 +356,65 @@ impl StorageEngine {
         self.ensure_writable(handle_id, "set_len")?;
         let file_id = self.open_file_id(handle_id)?;
         let owner_ip = self.owner_ip(file_id)?;
+        let pending = PendingStorageOp {
+            handle_id,
+            file_id,
+            op_type: PendingOpType::SetLen,
+            offset: new_len,
+            len: 0,
+            data: None,
+            append: false,
+        };
+        if let Some(actions) = self.roll_disk_failure(owner_ip) {
+            return self.park_operation(pending, actions);
+        }
         let latency = sample_latency(&self.state.config_for(owner_ip).write_latency);
         self.schedule_operation(
-            PendingStorageOp {
-                handle_id,
-                file_id,
-                op_type: PendingOpType::SetLen,
-                offset: new_len,
-                len: 0,
-                data: None,
-                append: false,
-            },
+            pending,
             StorageOperation::SetLenComplete { new_len },
             now.saturating_add(latency),
         )
+    }
+
+    /// Whether `owner_ip`'s disk is failed, drawing the failure coin first if
+    /// the disk is healthy and the budget allows. A failed disk answers with
+    /// the actions to apply (the fault event, on the operation that failed
+    /// it); a healthy one answers `None`.
+    ///
+    /// The coin is drawn only while `disk_failure_probability` is positive, so
+    /// a configuration with the family off consumes no randomness here.
+    fn roll_disk_failure(&mut self, owner_ip: IpAddr) -> Option<StorageActions> {
+        if self.state.failed_disks.contains(&owner_ip) {
+            return Some(StorageActions::default());
+        }
+        // Floor: one failed disk at a time. The coin never takes a second
+        // member of a quorum system down while the first is still hung; a
+        // crash or wipe of the first frees the budget.
+        if !self.state.failed_disks.is_empty() {
+            return None;
+        }
+        let probability = self.state.config_for(owner_ip).disk_failure_probability;
+        if probability <= 0.0 || sim_random::<f64>() >= probability {
+            return None;
+        }
+        assert_reachable!("disk: failed, every later I/O parks forever");
+        Some(self.fail_disk(owner_ip))
+    }
+
+    /// Register `pending` as in flight without scheduling its completion.
+    ///
+    /// The operation stays `Pending` for good: nothing in the engine will ever
+    /// resolve it. It leaves `pending_ops` only when its future is dropped
+    /// (`cancel_operation`), when a crash or wipe of the owning process fails
+    /// the handle's operations, or at simulation shutdown. It samples no
+    /// latency and enters no episode, so a hung I/O draws nothing.
+    fn park_operation(
+        &mut self,
+        pending: PendingStorageOp,
+        actions: StorageActions,
+    ) -> Result<(OperationId, StorageActions), StorageError> {
+        let operation_id = self.register_operation(pending)?;
+        Ok((operation_id, actions))
     }
 
     fn schedule_operation(
@@ -350,15 +423,23 @@ impl StorageEngine {
         operation: StorageOperation,
         at: Duration,
     ) -> Result<(OperationId, StorageActions), StorageError> {
+        let handle_id = pending.handle_id;
+        let operation_id = self.register_operation(pending)?;
+        let mut actions = StorageActions::default();
+        actions.schedule(at, StorageEvent::new(operation_id, handle_id, operation));
+        Ok((operation_id, actions))
+    }
+
+    fn register_operation(
+        &mut self,
+        pending: PendingStorageOp,
+    ) -> Result<OperationId, StorageError> {
         let operation_id = OperationId(self.state.next_operation_id);
         self.state.next_operation_id += 1;
         let handle = self.open_handle_mut(pending.handle_id)?;
         handle.pending_ops.insert(operation_id);
-        let handle_id = pending.handle_id;
         self.state.pending_ops.insert(operation_id, pending);
-        let mut actions = StorageActions::default();
-        actions.schedule(at, StorageEvent::new(operation_id, handle_id, operation));
-        Ok((operation_id, actions))
+        Ok(operation_id)
     }
 
     pub(crate) fn handle_event(&mut self, event: StorageEvent) -> StorageActions {
@@ -689,6 +770,9 @@ impl StorageEngine {
     }
 
     pub(crate) fn simulate_crash(&mut self, ip: IpAddr, close_files: bool) -> StorageActions {
+        // The reboot replaces a failed disk; the operations it parked are
+        // failed below with the rest of the process's in-flight I/O.
+        self.state.failed_disks.remove(&ip);
         let probability = self.state.config_for(ip).crash_fault_probability;
         let file_ids = self
             .state
@@ -717,6 +801,7 @@ impl StorageEngine {
     }
 
     pub(crate) fn wipe_process(&mut self, ip: IpAddr) -> StorageActions {
+        self.state.failed_disks.remove(&ip);
         let files = self
             .state
             .files

--- a/crates/moonpool-sim/src/storage/sim/state.rs
+++ b/crates/moonpool-sim/src/storage/sim/state.rs
@@ -93,6 +93,9 @@ pub(crate) struct StorageState {
     pub(crate) config: StorageConfiguration,
     pub(crate) per_process_configs: BTreeMap<IpAddr, StorageConfiguration>,
     pub(crate) disk_episodes: BTreeMap<IpAddr, DiskDegradationState>,
+    /// Disks that failed: every later operation on them parks forever. Only a
+    /// crash or wipe of the owning process removes an entry.
+    pub(crate) failed_disks: BTreeSet<IpAddr>,
     pub(crate) files: BTreeMap<FileId, FileState>,
     pub(crate) handles: BTreeMap<HandleId, HandleState>,
     pub(crate) path_to_file: BTreeMap<String, FileId>,
@@ -108,6 +111,7 @@ impl StorageState {
             config,
             per_process_configs: BTreeMap::new(),
             disk_episodes: BTreeMap::new(),
+            failed_disks: BTreeSet::new(),
             files: BTreeMap::new(),
             handles: BTreeMap::new(),
             path_to_file: BTreeMap::new(),

--- a/crates/moonpool-sim/tests/chaos.rs
+++ b/crates/moonpool-sim/tests/chaos.rs
@@ -23,6 +23,8 @@ async fn drive<F: Future>(sim: &mut SimWorld, future: F) -> F::Output {
 
 #[path = "chaos/bit_flip.rs"]
 mod bit_flip;
+#[path = "chaos/black_hole.rs"]
+mod black_hole;
 #[path = "chaos/buggified_delay.rs"]
 mod buggified_delay;
 #[path = "chaos/buggify.rs"]

--- a/crates/moonpool-sim/tests/chaos/black_hole.rs
+++ b/crates/moonpool-sim/tests/chaos/black_hole.rs
@@ -1,0 +1,219 @@
+//! A black-holed connection accepts every write and delivers nothing.
+//!
+//! The bytes are acknowledged into the sender's buffer and vanish; the peer's
+//! reads stay `Pending` with no data and no EOF, and a graceful close from the
+//! holed side never arrives either. The connection looks alive to both ends,
+//! which is exactly what a request without a timeout cannot survive. Only an
+//! abort (`RST`) still crosses, as a kernel reset would once the host is back.
+//! A black hole is permanent for the connection: only a new connection is
+//! clean.
+
+use futures::{
+    io::{AsyncRead, AsyncReadExt, AsyncWriteExt},
+    task::noop_waker,
+};
+use moonpool_sim::{
+    NetworkConfiguration, NetworkProvider, SimFaultEvent, SimWorld, TcpListenerTrait, buggify_init,
+    buggify_reset,
+};
+use std::{
+    io,
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
+
+fn local_runtime() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .enable_time()
+        .build()
+        .expect("Failed to build local runtime")
+}
+
+/// One poll of a read with a no-op waker, after the world has been drained.
+/// `Pending` means no data and no EOF: nothing is left that could arrive.
+fn poll_read_once(
+    stream: &mut (impl AsyncRead + Unpin),
+    buf: &mut [u8],
+) -> Poll<io::Result<usize>> {
+    let waker = noop_waker();
+    let mut context = Context::from_waker(&waker);
+    Pin::new(stream).poll_read(&mut context, buf)
+}
+
+#[test]
+fn a_black_holed_send_side_accepts_writes_and_delivers_nothing() {
+    local_runtime().block_on(async move {
+        let mut sim = SimWorld::new_with_network_config(NetworkConfiguration::fast_local());
+        let provider = sim.network_provider("127.0.0.1".parse().expect("valid ip"));
+        let addr = "hole-send";
+        let listener = super::drive(&mut sim, provider.bind(addr)).await.unwrap();
+        let mut client = super::drive(&mut sim, provider.connect(addr))
+            .await
+            .unwrap();
+        let (mut server, _) = super::drive(&mut sim, listener.accept()).await.unwrap();
+
+        sim.black_hole_connection(client.connection_id(), true, false);
+        assert!(sim.is_send_black_holed(client.connection_id()));
+        assert!(!sim.is_send_black_holed(server.connection_id()));
+        assert!(
+            sim.take_faults()
+                .iter()
+                .any(|record| matches!(&record.event, SimFaultEvent::BlackHole { direction, .. } if direction == "send"))
+        );
+
+        // The write succeeds: the sender is told nothing.
+        client
+            .write_all(b"into the void")
+            .await
+            .expect("a black-holed write is accepted");
+        sim.run_until_empty();
+        let mut buf = [0_u8; 64];
+        assert!(
+            poll_read_once(&mut server, &mut buf).is_pending(),
+            "the peer must see neither data nor EOF"
+        );
+
+        // The other direction is untouched.
+        server.write_all(b"pong").await.expect("write");
+        sim.run_until_empty();
+        let n = client.read(&mut buf).await.expect("read");
+        assert_eq!(&buf[..n], b"pong");
+
+        // A graceful close is a send too: the FIN vanishes with the data.
+        client.close().await.expect("close");
+        sim.run_until_empty();
+        assert!(
+            poll_read_once(&mut server, &mut buf).is_pending(),
+            "the peer must not see EOF from a black-holed close"
+        );
+    });
+}
+
+#[test]
+fn a_black_holed_recv_side_swallows_the_peers_sends() {
+    local_runtime().block_on(async move {
+        let mut sim = SimWorld::new_with_network_config(NetworkConfiguration::fast_local());
+        let provider = sim.network_provider("127.0.0.1".parse().expect("valid ip"));
+        let addr = "hole-recv";
+        let listener = super::drive(&mut sim, provider.bind(addr)).await.unwrap();
+        let mut client = super::drive(&mut sim, provider.connect(addr))
+            .await
+            .unwrap();
+        let (mut server, _) = super::drive(&mut sim, listener.accept()).await.unwrap();
+
+        // "recv" on the client is "send" on the server endpoint.
+        sim.black_hole_connection(client.connection_id(), false, true);
+        assert!(!sim.is_send_black_holed(client.connection_id()));
+        assert!(sim.is_send_black_holed(server.connection_id()));
+
+        server.write_all(b"reply").await.expect("write");
+        sim.run_until_empty();
+        let mut buf = [0_u8; 64];
+        assert!(
+            poll_read_once(&mut client, &mut buf).is_pending(),
+            "the reply must never reach the client"
+        );
+
+        client.write_all(b"request").await.expect("write");
+        sim.run_until_empty();
+        let n = server.read(&mut buf).await.expect("read");
+        assert_eq!(&buf[..n], b"request", "requests still get through");
+    });
+}
+
+#[test]
+fn an_abort_still_crosses_a_black_hole() {
+    local_runtime().block_on(async move {
+        let mut sim = SimWorld::new_with_network_config(NetworkConfiguration::fast_local());
+        let provider = sim.network_provider("127.0.0.1".parse().expect("valid ip"));
+        let addr = "hole-abort";
+        let listener = super::drive(&mut sim, provider.bind(addr)).await.unwrap();
+        let mut client = super::drive(&mut sim, provider.connect(addr))
+            .await
+            .unwrap();
+        let (mut server, _) = super::drive(&mut sim, listener.accept()).await.unwrap();
+
+        sim.black_hole_connection(client.connection_id(), true, true);
+        client.write_all(b"lost").await.expect("write");
+        sim.run_until_empty();
+        let mut buf = [0_u8; 64];
+        assert!(poll_read_once(&mut server, &mut buf).is_pending());
+
+        // A process kill aborts its connections; the peer must find out.
+        sim.close_connection_abort(client.connection_id());
+        assert!(
+            poll_read_once(&mut server, &mut buf).is_ready(),
+            "an abort is not a send and is never swallowed"
+        );
+    });
+}
+
+#[test]
+fn the_coin_black_holes_a_connection_and_records_it_once() {
+    local_runtime().block_on(async move {
+        buggify_init(1.0, 1.0);
+        let mut config = NetworkConfiguration::fast_local();
+        config.chaos.black_hole_probability = 1.0;
+        config.chaos.black_hole_cooldown = Duration::ZERO;
+        let mut sim = SimWorld::new_with_network_config_and_seed(config, 20_260_904);
+        let provider = sim.network_provider("127.0.0.1".parse().expect("valid ip"));
+        let addr = "hole-coin";
+        let listener = super::drive(&mut sim, provider.bind(addr)).await.unwrap();
+        let mut client = super::drive(&mut sim, provider.connect(addr))
+            .await
+            .unwrap();
+        let (server, _) = super::drive(&mut sim, listener.accept()).await.unwrap();
+
+        // The operation that draws the fault proceeds normally.
+        client
+            .write_all(b"first")
+            .await
+            .expect("the write that drew the black hole still succeeds");
+        client.write_all(b"second").await.expect("write");
+        sim.run_until_empty();
+
+        assert!(
+            sim.is_send_black_holed(client.connection_id())
+                || sim.is_send_black_holed(server.connection_id()),
+            "a certain coin must hole at least one direction"
+        );
+        let holes = sim
+            .take_faults()
+            .into_iter()
+            .filter(|record| matches!(record.event, SimFaultEvent::BlackHole { .. }))
+            .count();
+        assert_eq!(holes, 1, "the black hole is recorded once, not per I/O");
+        buggify_reset();
+    });
+}
+
+#[test]
+fn the_family_off_holes_nothing() {
+    local_runtime().block_on(async move {
+        buggify_init(1.0, 1.0);
+        let mut sim = SimWorld::new_with_network_config(NetworkConfiguration::fast_local());
+        let provider = sim.network_provider("127.0.0.1".parse().expect("valid ip"));
+        let addr = "hole-off";
+        let listener = super::drive(&mut sim, provider.bind(addr)).await.unwrap();
+        let mut client = super::drive(&mut sim, provider.connect(addr))
+            .await
+            .unwrap();
+        let (mut server, _) = super::drive(&mut sim, listener.accept()).await.unwrap();
+
+        for i in 0..50_u8 {
+            client.write_all(&[i]).await.expect("write");
+        }
+        sim.run_until_empty();
+        let mut buf = [0_u8; 64];
+        let n = server.read(&mut buf).await.expect("read");
+        assert!(n > 0, "with the family off every byte still arrives");
+        assert!(
+            !sim.take_faults()
+                .iter()
+                .any(|record| matches!(record.event, SimFaultEvent::BlackHole { .. }))
+        );
+        buggify_reset();
+    });
+}

--- a/crates/moonpool-sim/tests/recovery_mode.rs
+++ b/crates/moonpool-sim/tests/recovery_mode.rs
@@ -90,6 +90,28 @@ fn poll_read_once(
     std::pin::Pin::new(stream).poll_read(&mut context, data)
 }
 
+/// Poll a simulation-backed future until it resolves or the world runs out of
+/// events. `Pending` means it is parked for good: nothing is left to wake it.
+fn settle<F: Future + ?Sized>(
+    sim: &mut SimWorld,
+    mut future: std::pin::Pin<&mut F>,
+) -> Poll<F::Output> {
+    let waker = noop_waker();
+    let mut context = Context::from_waker(&waker);
+
+    for _ in 0..MAX_DRIVER_STEPS {
+        if let Poll::Ready(output) = future.as_mut().poll(&mut context) {
+            return Poll::Ready(output);
+        }
+        if !sim.has_pending_events() {
+            return Poll::Pending;
+        }
+        sim.step();
+    }
+
+    panic!("simulation-backed future exceeded {MAX_DRIVER_STEPS} events")
+}
+
 /// Pump the scheduler by feeding it network maintenance ticks, which is where
 /// the engine rolls for a new random partition.
 fn tick_maintenance(sim: &mut SimWorld, ticks: usize) {
@@ -316,6 +338,66 @@ fn storage_damage_survives_recovery_mode_while_new_faults_stop() {
     assert_eq!(
         reread, corrupted,
         "recovery mode must not repair a sector that was already corrupted"
+    );
+}
+
+/// A failed disk has no expiry, so it is damage the boundary keeps, and the
+/// coin that failed it stops: once the process is crashed and the one-at-a-time
+/// budget is free again, no other disk fails in the quiet tail.
+#[test]
+fn a_failed_disk_outlives_the_boundary_and_no_other_disk_fails() {
+    let mut config = StorageConfiguration::fast_local();
+    config.disk_failure_probability = 1.0;
+    let mut sim = SimWorld::new_with_seed(20_260_901);
+    sim.set_storage_config(config);
+    let provider = sim.storage_provider(ip(1));
+    let mut file = drive(
+        &mut sim,
+        provider.open("hung.bin", OpenOptions::create_write()),
+    )
+    .expect("open");
+
+    // --- chaos phase: the first I/O fails disk 1 and parks ---
+    let mut parked = pin!(file.write_all(b"never"));
+    assert!(
+        settle(&mut sim, parked.as_mut()).is_pending(),
+        "the chaos phase must actually fail the disk, or the test proves nothing"
+    );
+    assert!(sim.is_disk_failed(ip(1)));
+
+    sim.enter_recovery_mode();
+
+    // --- the failure is damage, not a fault to stop ---
+    assert!(
+        sim.is_disk_failed(ip(1)),
+        "recovery mode must not replace a disk that already failed"
+    );
+    assert!(
+        settle(&mut sim, parked.as_mut()).is_pending(),
+        "an operation parked before the boundary stays parked"
+    );
+
+    // --- only the process reboot replaces the disk ---
+    sim.simulate_crash_for_process(ip(1), true);
+    assert!(
+        matches!(settle(&mut sim, parked.as_mut()), Poll::Ready(Err(_))),
+        "the crash fails the operations the disk parked"
+    );
+    assert!(!sim.is_disk_failed(ip(1)));
+
+    // --- quiet tail: the budget is free, and still nobody's disk fails ---
+    let provider = sim.storage_provider(ip(2));
+    drive(&mut sim, async {
+        let mut file = provider
+            .open("quiet.bin", OpenOptions::create_write())
+            .await
+            .expect("open");
+        file.write_all(b"ok").await.expect("write");
+        file.sync_all().await.expect("sync");
+    });
+    assert!(
+        !sim.is_disk_failed(ip(2)),
+        "no disk may fail after the recovery boundary"
     );
 }
 
@@ -683,6 +765,7 @@ fn set_storage_config_cannot_rearm_faults_after_recovery() {
     rearmed.read_fault_probability = 1.0;
     rearmed.phantom_write_probability = 1.0;
     rearmed.disk_stall_probability = 1.0;
+    rearmed.disk_failure_probability = 1.0;
     rearmed.iops = 4321;
     sim.set_storage_config(rearmed);
 
@@ -702,6 +785,10 @@ fn set_storage_config_cannot_rearm_faults_after_recovery() {
         assert_zero(
             config.disk_stall_probability,
             "stall episodes must not be re-armable after the boundary",
+        );
+        assert_zero(
+            config.disk_failure_probability,
+            "disk failures must not be re-armable after the boundary",
         );
         assert_eq!(
             config.iops, 4321,
@@ -734,6 +821,10 @@ fn set_storage_config_cannot_rearm_faults_after_recovery() {
     assert!(
         sim.disk_episode_for(ip(1)).is_none(),
         "no degradation episode may be entered after the boundary"
+    );
+    assert!(
+        !sim.is_disk_failed(ip(1)),
+        "no disk may fail after the boundary"
     );
 }
 

--- a/crates/moonpool-sim/tests/recovery_mode.rs
+++ b/crates/moonpool-sim/tests/recovery_mode.rs
@@ -242,6 +242,68 @@ fn endpoints_communicate_again_after_the_recovery_boundary() {
     );
 }
 
+/// A black hole never recovers: recovery mode stops new ones, and a
+/// connection already holed stays holed until the application replaces it.
+#[test]
+fn a_black_holed_connection_stays_black_through_recovery_mode() {
+    let mut config = NetworkConfiguration::fast_local();
+    config.chaos.black_hole_probability = 1.0;
+    config.chaos.black_hole_cooldown = Duration::ZERO;
+    let mut sim = SimWorld::new_with_network_config_and_seed(config, 20_260_901);
+    let server_provider = sim.network_provider(ip(2));
+    let listener = drive(&mut sim, server_provider.bind("10.0.1.2:8080")).expect("bind");
+    let client_provider = sim.network_provider(ip(1));
+    let mut client = drive(&mut sim, client_provider.connect("10.0.1.2:8080")).expect("connect");
+    let (mut server, _) = drive(&mut sim, listener.accept()).expect("accept");
+
+    // --- chaos phase: the scripted hole, so the direction is known ---
+    sim.black_hole_connection(client.connection_id(), true, false);
+    drive(&mut sim, client.write_all(b"lost")).expect("a black-holed write succeeds");
+    while sim.has_pending_events() {
+        sim.step();
+    }
+    let mut buf = [0_u8; 16];
+    assert!(
+        poll_read_once(&mut server, &mut buf).is_pending(),
+        "the chaos phase must actually swallow the bytes, or the test proves nothing"
+    );
+
+    sim.enter_recovery_mode();
+
+    // --- damage already done stays done ---
+    assert!(
+        sim.is_send_black_holed(client.connection_id()),
+        "recovery mode must not un-hole a connection"
+    );
+    drive(&mut sim, client.write_all(b"still lost")).expect("write");
+    while sim.has_pending_events() {
+        sim.step();
+    }
+    assert!(
+        poll_read_once(&mut server, &mut buf).is_pending(),
+        "a black-holed connection stays black after the boundary"
+    );
+
+    // --- and a fresh connection, the application's way out, is clean ---
+    let mut fresh = drive(&mut sim, client_provider.connect("10.0.1.2:8080")).expect("connect");
+    let (mut fresh_server, _) = drive(&mut sim, listener.accept()).expect("accept");
+    drive(&mut sim, fresh.write_all(b"hello")).expect("write");
+    let mut received = [0_u8; 5];
+    drive(&mut sim, fresh_server.read_exact(&mut received)).expect("read");
+    assert_eq!(&received, b"hello");
+    assert!(
+        !sim.is_send_black_holed(fresh.connection_id())
+            && !sim.is_send_black_holed(fresh_server.connection_id()),
+        "the coin is off after the boundary, so a new connection is never holed"
+    );
+    sim.with_network_config(|config| {
+        assert_zero(
+            config.chaos.black_hole_probability,
+            "black holes are chaos and must be off",
+        );
+    });
+}
+
 /// Recovery mode stops the environment from breaking connections. It does not
 /// mend one the application has already seen close.
 #[test]

--- a/crates/moonpool-sim/tests/storage.rs
+++ b/crates/moonpool-sim/tests/storage.rs
@@ -12,6 +12,8 @@ mod config;
 mod crash_api;
 #[path = "storage/determinism.rs"]
 mod determinism;
+#[path = "storage/disk_failure.rs"]
+mod disk_failure;
 #[path = "storage/faults.rs"]
 mod faults;
 #[path = "storage/latency.rs"]

--- a/crates/moonpool-sim/tests/storage/disk_failure.rs
+++ b/crates/moonpool-sim/tests/storage/disk_failure.rs
@@ -1,0 +1,204 @@
+//! A failed disk answers nothing.
+//!
+//! Every read, write, sync, or `set_len` issued to a failed disk is accepted
+//! and stays `Pending` for the rest of the run. This is `FoundationDB`'s
+//! `failedDisk` (`waitUntilDiskReady()` returns `Never()`), and it is
+//! deliberately not a stall: a stall has an expiry and the caller's I/O
+//! completes late, a failure has none and only the caller's own timeout, or
+//! its process being killed, unblocks it. The floor is a count, not a rate:
+//! at most one disk fails at a time, and a crash or wipe of the owning process
+//! replaces it.
+
+use std::{
+    future::Future,
+    net::IpAddr,
+    pin::pin,
+    task::{Context, Poll},
+};
+
+use futures::{io::AsyncWriteExt, task::noop_waker};
+use moonpool_core::{OpenOptions, StorageFile, StorageProvider};
+use moonpool_sim::{SimFaultEvent, SimWorld, StorageConfiguration, rng_call_count};
+
+/// How many events a driven future may consume before it is declared stuck.
+const MAX_STEPS: usize = 10_000;
+
+fn ip(last_octet: u8) -> IpAddr {
+    format!("10.0.1.{last_octet}")
+        .parse()
+        .expect("valid test IP")
+}
+
+fn failing_disk() -> StorageConfiguration {
+    StorageConfiguration {
+        disk_failure_probability: 1.0,
+        ..StorageConfiguration::fast_local()
+    }
+}
+
+/// Poll `future` until it resolves or the world runs out of events.
+///
+/// A `Pending` answer means the future is parked with nothing left that could
+/// ever wake it: the observable shape of an I/O that never completes.
+fn settle<F: Future>(sim: &mut SimWorld, future: F) -> Poll<F::Output> {
+    let mut future = pin!(future);
+    settle_pinned(sim, future.as_mut())
+}
+
+fn settle_pinned<F: Future + ?Sized>(
+    sim: &mut SimWorld,
+    mut future: std::pin::Pin<&mut F>,
+) -> Poll<F::Output> {
+    let waker = noop_waker();
+    let mut context = Context::from_waker(&waker);
+    for _ in 0..MAX_STEPS {
+        if let Poll::Ready(output) = future.as_mut().poll(&mut context) {
+            return Poll::Ready(output);
+        }
+        if !sim.has_pending_events() {
+            return Poll::Pending;
+        }
+        sim.step();
+    }
+    panic!("simulation-backed future exceeded {MAX_STEPS} events")
+}
+
+fn ready<T>(poll: Poll<T>, what: &str) -> T {
+    match poll {
+        Poll::Ready(output) => output,
+        Poll::Pending => panic!("{what} parked with an empty world"),
+    }
+}
+
+fn open(sim: &mut SimWorld, owner: IpAddr, path: &str) -> moonpool_sim::storage::SimStorageFile {
+    let provider = sim.storage_provider(owner);
+    ready(
+        settle(sim, provider.open(path, OpenOptions::create_write())),
+        "open",
+    )
+    .expect("open")
+}
+
+/// A write or sync completes on a healthy disk; used as the control.
+fn write_and_sync(
+    sim: &mut SimWorld,
+    file: &mut moonpool_sim::storage::SimStorageFile,
+) -> Poll<()> {
+    settle(sim, async {
+        file.write_all(b"payload").await.expect("write");
+        file.sync_all().await.expect("sync");
+    })
+}
+
+#[test]
+fn a_failed_disk_parks_every_later_operation() {
+    let mut sim = SimWorld::new_with_seed(20_260_904);
+    sim.set_storage_config(failing_disk());
+    let mut file = open(&mut sim, ip(1), "hung.bin");
+
+    // The first I/O draws the coin, fails the disk, and is itself parked.
+    assert!(
+        settle(&mut sim, file.write_all(b"never")).is_pending(),
+        "the write that failed the disk must never complete"
+    );
+    assert!(sim.is_disk_failed(ip(1)));
+    assert_eq!(
+        sim.pending_event_count(),
+        0,
+        "a parked operation owns no scheduled completion"
+    );
+    let faults = sim.take_faults();
+    assert!(
+        faults
+            .iter()
+            .any(|record| matches!(&record.event, SimFaultEvent::StorageDiskFailure { ip } if ip == "10.0.1.1")),
+        "the failure is recorded once as a fault event, got {faults:?}"
+    );
+
+    // Everything after it parks too, and no second fault event is recorded.
+    assert!(
+        settle(&mut sim, file.sync_all()).is_pending(),
+        "a sync on a failed disk must never complete"
+    );
+    assert!(
+        settle(&mut sim, file.set_len(0)).is_pending(),
+        "a set_len on a failed disk must never complete"
+    );
+    assert!(sim.take_faults().is_empty());
+}
+
+#[test]
+fn the_coin_fails_one_disk_at_a_time() {
+    let mut sim = SimWorld::new_with_seed(20_260_904);
+    sim.set_storage_config(failing_disk());
+    let mut first = open(&mut sim, ip(1), "first.bin");
+    let mut second = open(&mut sim, ip(2), "second.bin");
+
+    assert!(settle(&mut sim, first.write_all(b"never")).is_pending());
+    assert!(sim.is_disk_failed(ip(1)));
+
+    // Disk 2 would fail on its first operation too, but the budget is spent.
+    assert!(
+        write_and_sync(&mut sim, &mut second).is_ready(),
+        "a second disk must keep working while one is already failed"
+    );
+    assert!(!sim.is_disk_failed(ip(2)));
+}
+
+#[test]
+fn a_crash_replaces_the_disk_and_frees_the_budget() {
+    let mut sim = SimWorld::new_with_seed(20_260_904);
+    sim.set_storage_config(failing_disk());
+    let mut first = open(&mut sim, ip(1), "first.bin");
+    let mut second = open(&mut sim, ip(2), "second.bin");
+
+    let mut parked = pin!(first.write_all(b"never"));
+    assert!(settle_pinned(&mut sim, parked.as_mut()).is_pending());
+    assert!(sim.is_disk_failed(ip(1)));
+    assert!(write_and_sync(&mut sim, &mut second).is_ready());
+
+    // The reboot is the disk replacement: the parked write is failed with the
+    // rest of the process's in-flight I/O, and the failure is gone.
+    sim.simulate_crash_for_process(ip(1), true);
+    assert!(
+        matches!(
+            settle_pinned(&mut sim, parked.as_mut()),
+            Poll::Ready(Err(_))
+        ),
+        "a crash must fail the operations the disk parked"
+    );
+    assert!(!sim.is_disk_failed(ip(1)));
+
+    // The budget is free again, so the next disk to draw the coin fails.
+    assert!(
+        settle(&mut sim, second.write_all(b"never")).is_pending(),
+        "once the first failure is cleared another disk may fail"
+    );
+    assert!(sim.is_disk_failed(ip(2)));
+}
+
+#[test]
+fn a_scripted_failure_parks_without_drawing_randomness() {
+    let mut sim = SimWorld::new_with_seed(20_260_904);
+    sim.set_storage_config(StorageConfiguration::fast_local());
+    let mut file = open(&mut sim, ip(1), "scripted.bin");
+    assert!(write_and_sync(&mut sim, &mut file).is_ready());
+
+    sim.fail_disk_for_process(ip(1));
+    assert!(sim.is_disk_failed(ip(1)));
+    let draws_before = rng_call_count();
+    assert!(
+        settle(&mut sim, file.sync_all()).is_pending(),
+        "a scripted failure parks the next operation"
+    );
+    assert_eq!(
+        rng_call_count(),
+        draws_before,
+        "a parked operation samples no latency and enters no episode"
+    );
+    assert!(
+        sim.take_faults()
+            .iter()
+            .any(|record| matches!(record.event, SimFaultEvent::StorageDiskFailure { .. }))
+    );
+}


### PR DESCRIPTION
## Why

moonpool already has one "never" fault: a `Probabilistic` connect that awaits `std::future::pending()` (FDB's `wait(Never())`). Every other fault eventually answers — a stall expires, a silent close reaches EOF, a partition heals. Code with a missing timeout survives all of them. This PR adds the two seams where a real system can wait forever, so a missing deadline turns into a `Deadlock` verdict from the stall guard instead of a green run.

One commit per feature.

## 1. Failed disks (`feat(moonpool-sim): failed disks whose I/O never completes`)

`StorageConfiguration::disk_failure_probability`: a per-operation coin that fails the owning process's disk. The operation that failed it and every later read/write/sync/`set_len` on that process's files is accepted and parked with **no completion event** — the future stays `Pending` for the rest of the run. FDB's `failedDisk` / `waitUntilDiskReady()` → `Never()`.

- **Floor:** at most one disk failed at a time; the coin is not drawn while one is in force, so a quorum system never loses more than one member to a hung disk.
- **Clearing:** a crash or wipe of the process replaces the disk; parked ops fail with `OperationInterrupted` with the rest of its in-flight I/O.
- **Recovery mode** stops new failures, keeps one in force (like a killed process).
- `SimWorld::fail_disk_for_process` (scripted, no RNG, ignores the budget), `SimWorld::is_disk_failed`, `SimFaultEvent::StorageDiskFailure`, `assert_reachable!` at the coin.
- Wired into `random_for_seed` (drawn last), swarm mask (10th draw, appended), buggify knobs, `disable_fault_injection`. Off → zero RNG draws.

## 2. Black-holed connections (`feat(moonpool-sim): black-holed connections that deliver nothing`)

`ChaosConfiguration::black_hole_probability` + `black_hole_cooldown`: rolled beside random close (same progress rule, own coin). A hit black-holes this side's sends, the peer's, or both (the same three-way draw). A black-holed direction accepts every write and delivers nothing: bytes are acknowledged into the send buffer and vanish, the peer's reads stay `Pending` with no data and no EOF, and a graceful close from the holed side never arrives. Both ends see a live connection.

- Mechanism: one flag on the sending endpoint, checked in the data and FIN delivery handlers — sender-side buffer accounting, backpressure and timing are untouched.
- **Permanent** for the connection; only a fresh connection is clean (production's way out too).
- **An abort still crosses** (a process kill resets its connections), so a hang is never mistaken for a death.
- **Recovery mode** stops new holes, keeps those in force.
- `NetworkFault::BlackHole` (mask widened to 16 bits), `SimFaultEvent::BlackHole { direction }`, `SimWorld::black_hole_connection`, `SimWorld::is_send_black_holed`, `assert_reachable!` at the coin. Drawn last in `random_for_seed` and the swarm mask; buggify-spiked.

## Tests and docs

- New `tests/storage/disk_failure.rs` and `tests/chaos/black_hole.rs`; recovery-mode tests for both; swarm/mask unit tests extended.
- Book: new sections in the storage-faults and network-faults chapters, the fault reference and the configuration appendix (including the recovery-mode table).

## Verification

`cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, `clippy -p moonpool-sim --no-default-features`, `cargo check --target wasm32-unknown-unknown -p moonpool-sim --no-default-features`, doctests, `cargo nextest run --workspace` (747 passed), `mdbook build book/`.

Note: seeds shift under a chaos profile because both knobs are sampled in `random_for_seed`; they are appended last so every previously sampled field keeps its per-seed value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WV5qfVLAzKa5jSEaeBgcSu

---
_Generated by [Claude Code](https://claude.ai/code/session_01WV5qfVLAzKa5jSEaeBgcSu)_