### PR TITLE
feat(moonpool-sim): in-flight faults and end-to-end TCP flow control

### DIFF
--- a/book/src/appendix/03-configuration.md
+++ b/book/src/appendix/03-configuration.md
@@ -15,6 +15,7 @@ The builder pattern for configuring and running simulation experiments. Created 
 | `processes(count, factory)` | `impl Into<ProcessCount>`, `Fn() -> Box<dyn Process>` | Add one group of server processes (system under test); repeatable, one group per role, each on its own `10.0.{group}.x` range |
 | `cluster(config, factory)` | `LocalityConfig`, `Fn() -> Box<dyn Process>` | Add one group of processes laid out across a datacenter/zone/machine topology (repeatable like `processes`) |
 | `link_latency(config)` | `LinkLatencyConfig` | Give links a distance-dependent latency, resolved through the `cluster` topology |
+| `tcp_send_window_bytes(bytes)` | `usize` | End-to-end byte window of every stream direction (default 64 KiB); a small window makes a slow reader back its writer up early |
 | `network_fault_mask(mask)` | `NetworkFaultMask` | Suppress selected families after each Random/Swarm network profile is sampled; deterministic and exploration-safe |
 | `tags(dimensions)` | `&[(&str, &[&str])]` | Attach round-robin tag distribution to processes |
 | `invariant(i)` | `impl Invariant` | Add an invariant checked after every simulation event |
@@ -152,7 +153,8 @@ Bind, connect, and accept use their latency fields as genuinely delayed
 operations. Each call remains pending until its targeted scheduler completion
 fires. Established reads wait on buffered byte delivery or a network waker.
 Write and link latency apply to ordered byte delivery after the stream accepts
-available send-buffer capacity.
+the bytes into its send window (see
+[Flow control](../part3-building/10-network-faults.md#flow-control)).
 
 | Field | Type | Default |
 |-------|------|---------|
@@ -161,6 +163,7 @@ available send-buffer capacity.
 | `connect_latency` | `LatencyDistribution` | `Uniform` 1ms..11ms |
 | `write_latency` | `LatencyDistribution` | `Uniform` 100us..600us |
 | `link_latency` | `Option<LinkLatencyConfig>` | `None` (distance-blind) |
+| `tcp_send_window_bytes` | `usize` | 64 KiB (`DEFAULT_TCP_SEND_WINDOW_BYTES`) |
 | `chaos` | `ChaosConfiguration` | See below |
 
 ### Constructor variants
@@ -286,8 +289,9 @@ Each ordered IP pair samples one fixed latency from this range at first contact 
 
 ### Black Hole
 
-A direction that accepts every write and delivers nothing, for the rest of the
-connection's life; see [Black Holes](../part3-building/10-network-faults.md#black-holes).
+A direction that delivers nothing, for the rest of the connection's life: it
+accepts writes until its send window is full, then blocks; see
+[Black Holes](../part3-building/10-network-faults.md#black-holes).
 
 | Field | Type | Default |
 |-------|------|---------|

--- a/book/src/appendix/04-fault-reference.md
+++ b/book/src/appendix/04-fault-reference.md
@@ -26,7 +26,7 @@ Configured via `ChaosConfiguration` (nested under `NetworkConfiguration::chaos`)
 | Random connection close | `random_close_probability` | 0.001% | Reconnection logic, message redelivery, connection pooling |
 | Close error surfacing | `random_close_explicit_ratio` | 30% immediate error, 70% silent close | Explicit-error and timeout-based detection |
 | Close cooldown | `random_close_cooldown` | 5s | Prevents cascading failures after a close event |
-| Black hole | `black_hole_probability` | 0% (off) | A direction that accepts every write and delivers nothing, forever: missing request timeouts, keep-alive and heartbeat detection, half-open connections |
+| Black hole | `black_hole_probability` | 0% (off) | A direction that delivers nothing, forever: writes are accepted until the send window fills, then block. Missing request timeouts, keep-alive and heartbeat detection, half-open connections, writers without a deadline |
 | Black hole cooldown | `black_hole_cooldown` | 5s | Spaces out black holes across connections |
 | Connect failure | `connect_failure_mode` | `Probabilistic` (50% refused, 50% hang) | Connection establishment retries, timeout handling |
 | Connect failure probability | `connect_failure_probability` | 50% | Ratio of failed vs hanging connections |

--- a/book/src/part3-building/10-network-faults.md
+++ b/book/src/part3-building/10-network-faults.md
@@ -52,7 +52,7 @@ A cooldown period prevents cascading closes from overwhelming the system. The go
 
 ### Black Holes
 
-A silent close still ends: the peer eventually reads EOF and learns something. A **black hole** never ends. When `black_hole_probability` fires, one direction of a connection (this side's sends, the peer's, or both, the same three-way draw random close makes) starts accepting every write and delivering nothing. The bytes are acknowledged into the sender's buffer and vanish, the peer's reads stay `Pending` with no data and no EOF, and a graceful close from the holed side never arrives either. Both ends see a connection that looks perfectly alive. That is what a peer whose kernel keeps acknowledging into a frozen application looks like, or a middlebox that dropped its connection state, and it is the fault that finds a request without a timeout: nothing errors, nothing closes, and only the caller's own deadline can notice. An application-level timeout, an HTTP/2 keep-alive ping, a heartbeat: whatever detects it in production is what has to detect it here.
+A silent close still ends: the peer eventually reads EOF and learns something. A **black hole** never ends. When `black_hole_probability` fires, one direction of a connection (this side's sends, the peer's, or both, the same three-way draw random close makes) starts accepting every write and delivering nothing. The bytes are acknowledged into the sender's buffer and vanish when they would land, the peer's reads stay `Pending` with no data and no EOF, and a graceful close from the holed side never arrives either. Both ends see a connection that looks perfectly alive. That is what a peer whose kernel keeps acknowledging into a frozen application looks like, or a middlebox that dropped its connection state, and it is the fault that finds a request without a timeout: nothing errors, nothing closes, and only the caller's own deadline can notice. An application-level timeout, an HTTP/2 keep-alive ping, a heartbeat: whatever detects it in production is what has to detect it here.
 
 ```rust
 let mut config = NetworkConfiguration::fast_local();
@@ -139,6 +139,36 @@ framed protocol (h2 on the same connection) would corrupt the frame that follows
 This mirrors FoundationDB's `SimClogging`, where a clogged pair adds delay and
 only an explicit disconnect fails the connection.
 
+The same holds for bytes that are already **on the wire**. A chunk that left
+the send buffer has a delivery time sampled from the write latency, and that
+time was sampled before the partition existed; the partition still decides
+its fate. Every byte moves through four places, in order:
+
+```text
+application write
+    │  poll_write
+local send queue          stalls under a cut
+    │  ProcessSendBuffer samples latency
+in flight                 frozen under a cut, re-timed by the heal
+    │  Delivery event
+peer receive buffer       the peer's now; nothing takes it back
+    │  poll_read
+application read
+```
+
+When a cut lands, every chunk (and any FIN) in flight on the cut direction is
+**frozen** where it is. Its `Delivery` event still fires at the old time and
+does nothing. When every partition blocking the direction has healed, each
+frozen item is re-timed by exactly the time the direction spent cut, so a cut
+of `D` delays every byte it caught by `D`, the stream keeps its order (a chunk
+sent after the heal lands behind the last frozen one), and no randomness is
+drawn: the latencies already sampled are reused. A response written at `t=0`
+with `100ms` of latency does not slip through a partition that starts at
+`t=50ms`; it lands at `100ms + (heal − 50ms)`. Directed, send-wide, and
+receive-wide cuts all freeze the same way, an explicit heal and the
+recovery-mode heal both thaw the same way, and a FIN is an item like any
+other: the peer sees the last bytes and then EOF, never EOF first.
+
 The first three strategies are IP-blind: they pick nodes out of a hat. `IsolateZone` and `IsolateDatacenter` read the [`.cluster()`](09-attrition.md#failure-domains-correlated-reboots) topology instead, so the cut lands exactly where a real one would, on the boundary that shares a switch or a region. Without a topology they fall back to `Random` selection, which keeps them safe to draw for any seed.
 
 The asymmetric pair is worth dwelling on. A node whose sends are blocked still hears every heartbeat from the cluster, so it happily believes it is healthy while everyone else marks it dead. Systems that infer liveness from "I can see you" rather than "you can see me" split brains here. Both arms record their own fault events (`SendPartitionCreated`, `RecvPartitionCreated`) on the timeline, so an invariant can correlate application behavior with the exact one-way cut that caused it.
@@ -156,11 +186,9 @@ The hanging mode is particularly nasty. Code that does not implement connect tim
 
 When a connection closes, moonpool models two distinct TCP behaviors:
 
-**Graceful close** implements TCP half-close semantics. The closing side marks its send direction as closed and schedules a `FinDelivery` event that arrives after all in-flight data has been delivered. The remote side continues reading buffered data normally and sees EOF only after the FIN arrives. This models a clean `shutdown(SHUT_WR)` followed by `close()`.
+**Graceful close** implements TCP half-close semantics. The closing side marks its send direction as closed and puts a FIN on the wire behind every byte still queued or in flight, so it lands after all of them and is held by a partition with them. The remote side continues reading buffered data normally and sees EOF only after the FIN arrives. This models a clean `shutdown(SHUT_WR)` followed by `close()`.
 
-**Abort close** immediately terminates both directions. No FIN, no buffer drain. The remote side gets a connection reset error on its next read or write. This models a crashed process or a force-killed connection.
-
-The distinction matters because many protocols depend on reading remaining data after the peer signals shutdown. HTTP/1.1 relies on this for chunked transfer encoding. gRPC uses it for trailing metadata. If your simulation only models abort closes, you will miss bugs in graceful shutdown handling.
+**Abort close** immediately terminates both directions. No FIN, no buffer drain: the send queue and the flight are gone. The remote side gets a connection reset error on its next read or write. This models a crashed process or a force-killed connection.
 
 ## The Swizzling Insight
 

--- a/book/src/part3-building/10-network-faults.md
+++ b/book/src/part3-building/10-network-faults.md
@@ -52,7 +52,7 @@ A cooldown period prevents cascading closes from overwhelming the system. The go
 
 ### Black Holes
 
-A silent close still ends: the peer eventually reads EOF and learns something. A **black hole** never ends. When `black_hole_probability` fires, one direction of a connection (this side's sends, the peer's, or both, the same three-way draw random close makes) starts accepting every write and delivering nothing. The bytes are acknowledged into the sender's buffer and vanish when they would land, the peer's reads stay `Pending` with no data and no EOF, and a graceful close from the holed side never arrives either. Both ends see a connection that looks perfectly alive. That is what a peer whose kernel keeps acknowledging into a frozen application looks like, or a middlebox that dropped its connection state, and it is the fault that finds a request without a timeout: nothing errors, nothing closes, and only the caller's own deadline can notice. An application-level timeout, an HTTP/2 keep-alive ping, a heartbeat: whatever detects it in production is what has to detect it here.
+A silent close still ends: the peer eventually reads EOF and learns something. A **black hole** never ends. When `black_hole_probability` fires, one direction of a connection (this side's sends, the peer's, or both, the same three-way draw random close makes) starts delivering nothing. The bytes are acknowledged into the sender's window and vanish when they would land, the peer's reads stay `Pending` with no data and no EOF, and a graceful close from the holed side never arrives either. Both ends see a connection that looks perfectly alive. Because the window is end-to-end (see [Flow control](#flow-control)) the swallowed bytes stay charged to the writer: a small request goes in and times out at the application, exactly the failure the fault exists for, while a bulk stream fills its window and its writer parks forever, as a TCP sender whose peer stopped acknowledging would. That is what a peer whose kernel keeps acknowledging into a frozen application looks like, or a middlebox that dropped its connection state, and it is the fault that finds a request without a timeout: nothing errors, nothing closes, and only the caller's own deadline can notice. An application-level timeout, an HTTP/2 keep-alive ping, a heartbeat: whatever detects it in production is what has to detect it here.
 
 ```rust
 let mut config = NetworkConfiguration::fast_local();
@@ -146,13 +146,13 @@ its fate. Every byte moves through four places, in order:
 
 ```text
 application write
-    │  poll_write
+    │  poll_write takes window
 local send queue          stalls under a cut
     │  ProcessSendBuffer samples latency
 in flight                 frozen under a cut, re-timed by the heal
     │  Delivery event
 peer receive buffer       the peer's now; nothing takes it back
-    │  poll_read
+    │  poll_read returns window
 application read
 ```
 
@@ -186,9 +186,45 @@ The hanging mode is particularly nasty. Code that does not implement connect tim
 
 When a connection closes, moonpool models two distinct TCP behaviors:
 
-**Graceful close** implements TCP half-close semantics. The closing side marks its send direction as closed and puts a FIN on the wire behind every byte still queued or in flight, so it lands after all of them and is held by a partition with them. The remote side continues reading buffered data normally and sees EOF only after the FIN arrives. This models a clean `shutdown(SHUT_WR)` followed by `close()`.
+**Graceful close** implements TCP half-close semantics. The closing side marks its send direction as closed and puts a FIN on the wire behind every byte still queued or in flight, so it lands after all of them and is held by a partition with them. The remote side continues reading buffered data normally and sees EOF only after the FIN arrives. What the closing side itself never read is discarded and its window returned to the peer's writer, as a kernel frees a closed socket's receive buffer. This models a clean `shutdown(SHUT_WR)` followed by `close()`.
 
-**Abort close** immediately terminates both directions. No FIN, no buffer drain: the send queue and the flight are gone. The remote side gets a connection reset error on its next read or write. This models a crashed process or a force-killed connection.
+**Abort close** immediately terminates both directions. No FIN, no buffer drain: the send queue, the flight, and the unread bytes are gone. The remote side gets a connection reset error on its next read or write, and a writer parked on a full window is woken to that error rather than left waiting on credits nothing can return. This models a crashed process or a force-killed connection.
+
+## Flow control
+
+Each direction of a connection has one **byte window**
+(`NetworkConfiguration::tcp_send_window_bytes`, `SimulationBuilder::tcp_send_window_bytes`,
+64 KiB by default). The window is taken when `poll_write` accepts bytes and
+returned only when the *peer's application reads them*, byte for byte:
+
+```text
+outstanding = queued + in flight + unread at the peer (+ swallowed by a black hole)
+outstanding ≤ window
+available   = window − outstanding
+```
+
+Moving bytes from the send queue onto the wire, or from the wire into the
+peer's receive buffer, releases nothing; they are the same outstanding bytes
+in a different place. A write accepts `min(len, available)` (a short write,
+like `write(2)`) and parks with `Poll::Pending` when `available` is zero; the
+peer's next read wakes it with exactly the bytes it consumed, so a partial
+read of 137 bytes lets the writer send 137 more. A reader that stops reading
+therefore backs its writer up end to end, even after every byte has reached
+the receive buffer, which is the TCP behavior behind "the server kept
+streaming into a client that had stopped consuming" and the pipeline that
+deadlocks on its own replies. A partition returns no credit (delay is not
+consumption), a black hole never returns it, a peer that closes with bytes
+unread returns them, and an abort wakes the parked writer to the error.
+
+Backpressure is entropy-neutral: a `Poll::Pending` on a full window, the
+wake that follows a read, and every move between the three places consume no
+simulation randomness, so a run that blocks and resumes replays draw for
+draw. Congestion control, retransmission, and segment boundaries are out of
+scope: the model is a reliable ordered byte stream with a bounded number of
+bytes outstanding, which is what exposes the distributed-system behaviors a
+simulation is after.
+
+The distinction matters because many protocols depend on reading remaining data after the peer signals shutdown. HTTP/1.1 relies on this for chunked transfer encoding. gRPC uses it for trailing metadata. If your simulation only models abort closes, you will miss bugs in graceful shutdown handling.
 
 ## The Swizzling Insight
 

--- a/book/src/part3-building/22-event-trace.md
+++ b/book/src/part3-building/22-event-trace.md
@@ -22,7 +22,7 @@ lock.
 When you enable trace-level logging (`RUST_LOG=trace`), you see every event as it fires:
 
 ```
-  Processing event at t=1.234s seq=47: Network(DataDelivery { connection_id: 3, ... })
+  Processing event at t=1.234s seq=47: Network(Delivery { connection_id: 3, seq: 12 })
   Processing event at t=1.234s seq=48: Timer { task_id: 12 }
   Processing event at t=2.500s seq=49: Storage(operation_id=9, WriteComplete)
 ```
@@ -36,9 +36,12 @@ The simulation has a small set of event types, and learning to recognize them ma
 **Timer** events wake sleeping tasks. When your workload calls `time.sleep(Duration::from_secs(1))`, that schedules a Timer event one second in the future. These are the heartbeat of your simulation.
 
 **Network** events target the network engine. `OperationReady` completes one
-delayed bind, connect, or accept latency. `DataDelivery` puts bytes into a
-connection's receive buffer. `ProcessSendBuffer` drains the send side.
-`FinDelivery` signals a graceful close after all data has been delivered.
+delayed bind, connect, or accept latency. `ProcessSendBuffer` moves the next
+chunk of a connection's send queue onto the wire. `Delivery` says an in-flight
+item (a data chunk, or the FIN of a graceful close) has reached its delivery
+time; the item itself lives in the sender's in-flight queue, and the event
+lands it only if no partition is holding that direction, so a `Delivery` that
+fires under a cut does nothing and the heal re-times the item.
 
 **Network maintenance** events change connection-wide state. `PartitionRestore`,
 `SendPartitionClear`, and `RecvPartitionClear` remove expired cuts. `ClogClear`
@@ -59,12 +62,12 @@ only that operation's waiter.
 When an assertion fires, the question is: **what caused this?** The event trace gives you the answer, but you read it backwards.
 
 Start at the failure. Look at the last few events before the assertion. Usually
-one of them is the trigger: a `DataDelivery` that delivered a stale message, a
+one of them is the trigger: a `Delivery` that landed a stale message, a
 `Timer` that expired causing a timeout, or an `OperationReady` that let a
 connection race complete. Then ask which component requested that schedule.
 Follow the chain back through the trace.
 
-For example, suppose your conservation law invariant fires after event #312. Look at event #312: it is a `DataDelivery` on connection 7. What was connection 7? The trace shows it was established at event #201 between the workload and a KV server process. What did the delivery contain? A withdraw response. But the model expected a deposit. Now you have a lead.
+For example, suppose your conservation law invariant fires after event #312. Look at event #312: it is a `Delivery` on connection 7. What was connection 7? The trace shows it was established at event #201 between the workload and a KV server process. What did the delivery contain? A withdraw response. But the model expected a deposit. Now you have a lead.
 
 ## Using RNG Call Count
 
@@ -84,7 +87,7 @@ simulation state but do not represent application work.
 The simulation uses this distinction internally to decide when to terminate.
 After all workloads finish, if only infrastructure events remain in the
 scheduler, the simulation can safely end. When reading traces, you can often
-skip them and focus on `OperationReady`, `DataDelivery`, `Timer`, and `Storage`
+skip them and focus on `OperationReady`, `Delivery`, `Timer`, and `Storage`
 events that directly affect application progress.
 
 ## Practical Tips

--- a/book/src/part4-integration/04-scope-and-tradeoffs.md
+++ b/book/src/part4-integration/04-scope-and-tradeoffs.md
@@ -23,7 +23,7 @@ Running an axum service inside moonpool-sim exercises a specific slice of your a
 
 **TLS**. Simulated TCP streams are plaintext. TLS handshake failures, certificate validation, protocol negotiation: not exercised. If your service has a TLS configuration bug, you need integration tests against real TLS.
 
-**Real TCP backpressure and congestion**. moonpool-sim models connection-level faults (drops, latency, corruption) but not TCP flow control, window sizing, or congestion algorithms. If your service has a bug that only manifests under real TCP backpressure, simulation won't find it.
+**Real TCP congestion**. moonpool-sim models connection-level faults (drops, latency, corruption) and end-to-end flow control (a fixed byte window per direction that a slow reader fills, see [Flow control](../part3-building/10-network-faults.md#flow-control)), but not congestion algorithms, window autotuning, retransmission timers, or real segment boundaries. A bug that only manifests under a kernel's actual congestion behavior won't be found here; one that manifests because a writer never expected to block will.
 
 **OS resource limits**. File descriptor exhaustion, memory pressure, CPU scheduling. The simulation runs in a single process with no OS-level resource constraints. A service that leaks file descriptors will appear healthy in simulation.
 

--- a/book/src/part4-networking/01-simulating-network.md
+++ b/book/src/part4-networking/01-simulating-network.md
@@ -66,7 +66,7 @@ does **not** own logical time or a private queue.
 
 `SimWorld` coordinates a single `Scheduler<Event>` for timers, network events,
 storage events, and process lifecycle. A network transition returns ordered
-actions such as scheduling a `DataDelivery`, cancelling an operation, or
+actions such as scheduling a `Delivery`, cancelling an operation, or
 recording a fault. The coordinator applies those actions, releases its lock,
 then wakes tasks. Keeping wake calls outside the lock lets a re-entrant waker
 poll network state without deadlocking.

--- a/crates/moonpool-sim/src/network/config.rs
+++ b/crates/moonpool-sim/src/network/config.rs
@@ -715,9 +715,29 @@ pub struct NetworkConfiguration {
     /// topology. See [`LinkLatencyConfig`].
     pub link_latency: Option<LinkLatencyConfig>,
 
+    /// End-to-end byte window of each stream direction, in bytes.
+    ///
+    /// This many bytes may be written ahead of what the peer's application
+    /// has read, counting the local send queue, everything in flight and the
+    /// peer's unread receive buffer together. Once the window is full,
+    /// `poll_write` returns `Poll::Pending` until the peer reads, so a slow
+    /// reader backs a fast writer up end to end, as TCP flow control does.
+    /// A direction that stops making progress (a partition, a black hole)
+    /// fills its window and blocks instead of accepting data forever.
+    ///
+    /// The value is read when a connection is created; changing it later
+    /// applies to new connections only. Default 64 KiB
+    /// ([`DEFAULT_TCP_SEND_WINDOW_BYTES`]); `fast_local` and the per-seed
+    /// configurations keep the default, a smaller window is a deliberate
+    /// choice for a test that wants backpressure to bite early.
+    pub tcp_send_window_bytes: usize,
+
     /// Chaos injection configuration
     pub chaos: ChaosConfiguration,
 }
+
+/// Default [`NetworkConfiguration::tcp_send_window_bytes`]: 64 KiB.
+pub const DEFAULT_TCP_SEND_WINDOW_BYTES: usize = 64 * 1024;
 
 impl Default for NetworkConfiguration {
     fn default() -> Self {
@@ -740,6 +760,7 @@ impl Default for NetworkConfiguration {
             },
             // Realism knob, opt-in: distance-blind by default.
             link_latency: None,
+            tcp_send_window_bytes: DEFAULT_TCP_SEND_WINDOW_BYTES,
             chaos: ChaosConfiguration::default(),
         }
     }
@@ -946,6 +967,9 @@ impl NetworkConfiguration {
             // Distance latency models the deployment, not the seed, so chaos
             // runs leave it to the caller (and draw no RNG for it).
             link_latency: None,
+            // The window is a deployment property too: keep it fixed so a
+            // seed's draw schedule is not spent on it.
+            tcp_send_window_bytes: DEFAULT_TCP_SEND_WINDOW_BYTES,
             chaos: ChaosConfiguration::random_for_seed(),
         }
     }
@@ -975,6 +999,7 @@ impl NetworkConfiguration {
             connect_latency: uniform(ten_us, ten_us),
             write_latency: uniform(one_us, one_us),
             link_latency: None,
+            tcp_send_window_bytes: DEFAULT_TCP_SEND_WINDOW_BYTES,
             chaos: ChaosConfiguration::disabled(),
         }
     }

--- a/crates/moonpool-sim/src/network/sim/engine.rs
+++ b/crates/moonpool-sim/src/network/sim/engine.rs
@@ -22,7 +22,8 @@ use super::{
     ConnectionId, ListenerId, NetworkEvent,
     event::NetworkOperationId,
     state::{
-        ClogState, CloseReason, ConnectionFlags, ConnectionState, NetworkState, PartitionState,
+        ClogState, CloseReason, ConnectionFlags, ConnectionState, InFlight, InFlightPayload,
+        NetworkState, PartitionState,
     },
 };
 
@@ -161,6 +162,14 @@ impl NetworkSimulation {
         Ok(limit)
     }
 
+    /// Drop everything `id` has on the wire: an abort resets the flight.
+    fn discard_in_flight(&mut self, id: ConnectionId) {
+        if let Some(connection) = self.state.connections.get_mut(&id) {
+            connection.in_flight.clear();
+            connection.in_flight_held_since = None;
+        }
+    }
+
     pub(crate) fn has_readable_data(&self, connection_id: ConnectionId) -> bool {
         self.state
             .connections
@@ -192,7 +201,6 @@ impl NetworkSimulation {
         &mut self,
         client_addr: &str,
         server_addr: &str,
-        now: Duration,
     ) -> (ConnectionId, ConnectionId) {
         const DEFAULT_SEND_BUFFER_CAPACITY: usize = 64 * 1024;
         let client_conn = ConnectionId(self.state.next_connection_id);
@@ -231,11 +239,13 @@ impl NetworkSimulation {
             receive_buffer: VecDeque::new(),
             paired_connection: Some(paired_connection),
             send_buffer: VecDeque::new(),
-            next_send_time: now,
+            in_flight: VecDeque::new(),
+            in_flight_held_since: None,
+            next_in_flight_seq: 0,
+            last_delivery_at: None,
             flags: ConnectionFlags::default(),
             close_reason: CloseReason::None,
             send_buffer_capacity: DEFAULT_SEND_BUFFER_CAPACITY,
-            last_data_delivery_scheduled_at: None,
         };
         self.state.connections.insert(
             client_conn,
@@ -472,31 +482,25 @@ impl NetworkSimulation {
                 self.state.ip_partitions.retain(|_, state| {
                     state.expires_at != expected_deadline || now < expected_deadline
                 });
-                self.resume_stalled_sends(now, &mut actions);
+                self.resume_after_heal(now, &mut actions);
             }
             NetworkEvent::SendPartitionClear { expected_deadline } => {
                 self.state.send_partitions.retain(|_, deadline| {
                     *deadline != expected_deadline || now < expected_deadline
                 });
-                self.resume_stalled_sends(now, &mut actions);
+                self.resume_after_heal(now, &mut actions);
             }
             NetworkEvent::RecvPartitionClear { expected_deadline } => {
                 self.state.recv_partitions.retain(|_, deadline| {
                     *deadline != expected_deadline || now < expected_deadline
                 });
-                self.resume_stalled_sends(now, &mut actions);
+                self.resume_after_heal(now, &mut actions);
             }
-            NetworkEvent::DataDelivery {
-                connection_id,
-                data,
-            } => {
-                self.handle_data_delivery(connection_id, &data, now, &mut actions, &mut wakes);
+            NetworkEvent::Delivery { connection_id, seq } => {
+                self.handle_delivery(connection_id, seq, now, &mut actions, &mut wakes);
             }
             NetworkEvent::ProcessSendBuffer { connection_id } => {
                 self.handle_process_send_buffer(connection_id, now, &mut actions, &mut wakes);
-            }
-            NetworkEvent::FinDelivery { connection_id } => {
-                self.handle_fin_delivery(connection_id, &mut wakes);
             }
         }
         (actions, wakes)
@@ -523,54 +527,230 @@ impl NetworkSimulation {
         }
     }
 
-    fn handle_data_delivery(
+    /// Land every item at the head of `sender`'s flight whose delivery time
+    /// has come.
+    ///
+    /// The event that wakes this names one item, but the flight is the truth:
+    /// an item is delivered only from the head, only once its `deliver_at`
+    /// has passed, and never while the direction is held by a partition. A
+    /// stale event (its item already delivered, or re-timed by a heal) finds
+    /// nothing to do. Faults are judged *now*, at landing, not when the
+    /// chunk was put on the wire: a partition or black hole injected while
+    /// the bytes were in flight still decides their fate.
+    fn handle_delivery(
         &mut self,
-        id: ConnectionId,
-        data: &[u8],
+        sender: ConnectionId,
+        seq: u64,
         now: Duration,
         actions: &mut NetworkActions,
         wakes: &mut WakeBatch,
     ) {
-        if !self.state.connections.get(&id).is_some_and(|connection| {
-            !connection.flags.is_closed() && !connection.flags.recv_closed()
-        }) {
-            return;
+        loop {
+            let Some(connection) = self.state.connections.get(&sender) else {
+                return;
+            };
+            if connection.in_flight_held_since.is_some() {
+                return;
+            }
+            let Some(head) = connection.in_flight.front() else {
+                return;
+            };
+            if head.deliver_at > now {
+                return;
+            }
+            // A partition that somehow reached this direction without freezing
+            // the flight (there is no such path today) still holds it here,
+            // from this instant, rather than letting the bytes cross the cut.
+            if self
+                .state
+                .connection_partition_clear_at(sender, now)
+                .is_some()
+            {
+                self.hold_in_flight(sender, now);
+                return;
+            }
+            let Some(connection) = self.state.connections.get_mut(&sender) else {
+                return;
+            };
+            let Some(item) = connection.in_flight.pop_front() else {
+                return;
+            };
+            debug_assert!(
+                item.seq <= seq,
+                "a delivery event never lands an item queued after the one it names"
+            );
+            self.land(sender, item.payload, now, actions, wakes);
         }
-        // The chunk left a black-holed sender: it was acknowledged into that
-        // side's buffer and is gone. No bytes, no wake — the reader keeps
-        // waiting for data that will never come.
-        if self.peer_send_black_holed(id) {
-            return;
-        }
-        let delivered = self.maybe_corrupt_data(id, data, now, actions);
-        if let Some(connection) = self.state.connections.get_mut(&id) {
-            connection.receive_buffer.extend(delivered);
-        }
-        wakes.push(self.waiters.reads.take(&id));
     }
 
-    fn handle_fin_delivery(&mut self, id: ConnectionId, wakes: &mut WakeBatch) {
-        // A FIN is a send like any other: from a black-holed peer it vanishes,
-        // and the reader never sees EOF.
-        if self.peer_send_black_holed(id) {
+    /// Put one item that reached its delivery time where it belongs.
+    fn land(
+        &mut self,
+        sender: ConnectionId,
+        payload: InFlightPayload,
+        now: Duration,
+        actions: &mut NetworkActions,
+        wakes: &mut WakeBatch,
+    ) {
+        let Some((black_holed, receiver)) = self.state.connections.get(&sender).map(|connection| {
+            (
+                connection.flags.send_black_holed(),
+                connection.paired_connection,
+            )
+        }) else {
+            return;
+        };
+        // The item left a black-holed sender: it was acknowledged into that
+        // side's buffer and is gone. No bytes, no EOF, no wake — the reader
+        // keeps waiting for data that will never come.
+        if black_holed {
             return;
         }
+        let receiver_open = receiver
+            .and_then(|id| self.state.connections.get(&id))
+            .is_some_and(|connection| !connection.flags.is_closed());
+        match payload {
+            InFlightPayload::Data(data) => {
+                let receiver_reading = receiver
+                    .and_then(|id| self.state.connections.get(&id))
+                    .is_some_and(|connection| {
+                        !connection.flags.is_closed() && !connection.flags.recv_closed()
+                    });
+                let Some(receiver) = receiver.filter(|_| receiver_reading) else {
+                    // A closed or receive-shut peer discards what arrives.
+                    return;
+                };
+                let delivered = self.maybe_corrupt_data(receiver, &data, now, actions);
+                if let Some(connection) = self.state.connections.get_mut(&receiver) {
+                    connection.receive_buffer.extend(delivered);
+                }
+                wakes.push(self.waiters.reads.take(&receiver));
+            }
+            InFlightPayload::Fin => {
+                if let Some(receiver) = receiver.filter(|_| receiver_open)
+                    && let Some(connection) = self.state.connections.get_mut(&receiver)
+                {
+                    connection.flags.set_remote_fin_received(true);
+                    wakes.push(self.waiters.reads.take(&receiver));
+                }
+            }
+        }
+    }
+
+    /// Put `payload` on the wire from `id`, strictly after everything already
+    /// in flight, and schedule the event that will land it.
+    ///
+    /// `at` is the delivery time the sender computed; the flight's FIFO floor
+    /// (`last_delivery_at + 1ns`) still applies. Enqueuing into a direction a
+    /// partition currently cuts freezes the flight from this instant, which
+    /// is how a FIN queued under a partition (the one send that bypasses the
+    /// send queue) waits for the heal like everything else.
+    fn put_in_flight(
+        &mut self,
+        id: ConnectionId,
+        payload: InFlightPayload,
+        at: Duration,
+        now: Duration,
+        actions: &mut NetworkActions,
+    ) {
+        let partitioned = self.state.connection_partition_clear_at(id, now).is_some();
+        let Some(connection) = self.state.connections.get_mut(&id) else {
+            return;
+        };
+        let deliver_at = connection.last_delivery_at.map_or(at, |last| {
+            at.max(last.saturating_add(Duration::from_nanos(1)))
+        });
+        let seq = connection.next_in_flight_seq;
+        connection.next_in_flight_seq += 1;
+        connection.last_delivery_at = Some(deliver_at);
+        connection.in_flight.push_back(InFlight {
+            seq,
+            deliver_at,
+            payload,
+        });
+        if partitioned && connection.in_flight_held_since.is_none() {
+            connection.in_flight_held_since = Some(now);
+        }
+        actions.schedule_at(
+            deliver_at,
+            NetworkEvent::Delivery {
+                connection_id: id,
+                seq,
+            },
+        );
+    }
+
+    /// Freeze `id`'s flight as of `now`. Idempotent while held.
+    fn hold_in_flight(&mut self, id: ConnectionId, now: Duration) {
         if let Some(connection) = self.state.connections.get_mut(&id)
-            && !connection.flags.is_closed()
+            && connection.in_flight_held_since.is_none()
+            && !connection.in_flight.is_empty()
         {
-            connection.flags.set_remote_fin_received(true);
-            wakes.push(self.waiters.reads.take(&id));
+            connection.in_flight_held_since = Some(now);
         }
     }
 
-    /// Whether the endpoint that sends *to* `id` has its sends black-holed.
-    fn peer_send_black_holed(&self, id: ConnectionId) -> bool {
-        self.state
+    /// A partition just went up: freeze the flight of every direction it
+    /// cuts. Bytes on the wire when a cut lands do not cross it.
+    fn hold_partitioned_in_flight(&mut self, now: Duration) {
+        let cut = self
+            .state
             .connections
-            .get(&id)
-            .and_then(|connection| connection.paired_connection)
-            .and_then(|peer| self.state.connections.get(&peer))
-            .is_some_and(|peer| peer.flags.send_black_holed())
+            .iter()
+            .filter(|(id, connection)| {
+                connection.in_flight_held_since.is_none()
+                    && !connection.in_flight.is_empty()
+                    && self
+                        .state
+                        .connection_partition_clear_at(**id, now)
+                        .is_some()
+            })
+            .map(|(id, _)| *id)
+            .collect::<Vec<_>>();
+        for id in cut {
+            self.hold_in_flight(id, now);
+        }
+    }
+
+    /// Thaw every held flight whose partitions have all healed.
+    ///
+    /// Each item is re-timed by the time the direction spent cut and its
+    /// delivery event re-scheduled; the FIFO floor moves with it, so a chunk
+    /// sent after the heal still lands behind the last one that was frozen.
+    fn release_held_in_flight(&mut self, now: Duration, actions: &mut NetworkActions) {
+        let thawed = self
+            .state
+            .connections
+            .iter()
+            .filter_map(|(id, connection)| {
+                connection.in_flight_held_since.and_then(|since| {
+                    self.state
+                        .connection_partition_clear_at(*id, now)
+                        .is_none()
+                        .then_some((*id, since))
+                })
+            })
+            .collect::<Vec<_>>();
+        for (id, since) in thawed {
+            let Some(connection) = self.state.connections.get_mut(&id) else {
+                continue;
+            };
+            let shift = now.saturating_sub(since);
+            connection.in_flight_held_since = None;
+            connection.last_delivery_at = connection
+                .last_delivery_at
+                .map(|last| last.saturating_add(shift));
+            for item in &mut connection.in_flight {
+                item.deliver_at = item.deliver_at.saturating_add(shift);
+                actions.schedule_at(
+                    item.deliver_at,
+                    NetworkEvent::Delivery {
+                        connection_id: id,
+                        seq: item.seq,
+                    },
+                );
+            }
+        }
     }
 
     fn calculate_flip_bit_count(random_value: u32, min_bits: u32, max_bits: u32) -> u32 {
@@ -670,7 +850,7 @@ impl NetworkSimulation {
     /// backpressure until the send actually drains.
     ///
     /// A stalled connection owns no scheduled work. It is re-driven by
-    /// [`resume_stalled_sends`](Self::resume_stalled_sends) when the partitions
+    /// [`resume_after_heal`](Self::resume_after_heal) when the partitions
     /// blocking it heal, whether that happens at their deadline or earlier.
     fn stall_partitioned_send(&mut self, id: ConnectionId) {
         if let Some(connection) = self.state.connections.get_mut(&id) {
@@ -678,12 +858,17 @@ impl NetworkSimulation {
         }
     }
 
-    /// Re-drive every connection whose blocking partitions have healed.
+    /// Re-drive every direction whose blocking partitions have healed: thaw
+    /// what was frozen in flight, then resume the stalled send queue behind
+    /// it.
     ///
     /// Runs from each partition-clearing path, so a stream stalled by a
     /// partition that is healed early releases its bytes early instead of
-    /// waiting out the deadline it stalled under.
-    fn resume_stalled_sends(&mut self, now: Duration, actions: &mut NetworkActions) {
+    /// waiting out the deadline it stalled under. Consumes no randomness: the
+    /// thawed items keep the latency they sampled, and the queued chunk
+    /// samples its own when its `ProcessSendBuffer` runs, as it always did.
+    fn resume_after_heal(&mut self, now: Duration, actions: &mut NetworkActions) {
+        self.release_held_in_flight(now, actions);
         let resumed = self
             .state
             .connections
@@ -715,14 +900,13 @@ impl NetworkSimulation {
         let Some(snapshot) = self.state.connections.get(&id).map(|connection| {
             (
                 connection.paired_connection,
-                connection.next_send_time,
                 connection.local_ip,
                 connection.remote_ip,
             )
         }) else {
             return;
         };
-        let (paired_id, next_send_time, local_ip, remote_ip) = snapshot;
+        let (paired_id, local_ip, remote_ip) = snapshot;
         let pair_extra = local_ip
             .zip(remote_ip)
             .and_then(|pair| self.state.pair_latencies.get(&pair).copied())
@@ -736,12 +920,7 @@ impl NetworkSimulation {
             connection.flags.set_send_in_progress(false);
             if connection.flags.graceful_close_pending() {
                 connection.flags.set_graceful_close_pending(false);
-                Self::schedule_fin(
-                    connection.paired_connection,
-                    connection.last_data_delivery_scheduled_at,
-                    now,
-                    actions,
-                );
+                self.put_fin_in_flight(id, now, actions);
             }
             return;
         };
@@ -760,49 +939,43 @@ impl NetworkSimulation {
         } else {
             Duration::from_nanos(1)
         };
-        let earliest = now.saturating_add(base_delay).max(next_send_time);
-        connection.next_send_time = earliest.saturating_add(Duration::from_nanos(1));
-        if let Some(paired) = paired_id {
-            let at = earliest.saturating_add(pair_extra);
-            actions.schedule_at(
-                at,
-                NetworkEvent::DataDelivery {
-                    connection_id: paired,
-                    data,
-                },
-            );
-            connection.last_data_delivery_scheduled_at = Some(at);
+        let at = now.saturating_add(base_delay).saturating_add(pair_extra);
+        let queue_drained = connection.send_buffer.is_empty();
+        let close_pending = connection.flags.graceful_close_pending();
+        if paired_id.is_some() {
+            self.put_in_flight(id, InFlightPayload::Data(data), at, now, actions);
         }
-        if connection.send_buffer.is_empty() {
+        let Some(connection) = self.state.connections.get_mut(&id) else {
+            return;
+        };
+        if queue_drained {
             connection.flags.set_send_in_progress(false);
-            if connection.flags.graceful_close_pending() {
+            if close_pending {
                 connection.flags.set_graceful_close_pending(false);
-                Self::schedule_fin(
-                    connection.paired_connection,
-                    connection.last_data_delivery_scheduled_at,
-                    now,
-                    actions,
-                );
+                self.put_fin_in_flight(id, now, actions);
             }
         } else {
             actions.schedule_at(now, NetworkEvent::ProcessSendBuffer { connection_id: id });
         }
     }
 
-    fn schedule_fin(
-        paired: Option<ConnectionId>,
-        last_delivery: Option<Duration>,
-        now: Duration,
-        actions: &mut NetworkActions,
-    ) {
-        let Some(connection_id) = paired else {
+    /// Put `id`'s FIN on the wire, behind every data chunk in flight.
+    fn put_fin_in_flight(&mut self, id: ConnectionId, now: Duration, actions: &mut NetworkActions) {
+        if self
+            .state
+            .connections
+            .get(&id)
+            .is_none_or(|connection| connection.paired_connection.is_none())
+        {
             return;
-        };
-        let at = last_delivery
-            .filter(|time| *time >= now)
-            .unwrap_or(now)
-            .saturating_add(Duration::from_nanos(1));
-        actions.schedule_at(at, NetworkEvent::FinDelivery { connection_id });
+        }
+        self.put_in_flight(
+            id,
+            InFlightPayload::Fin,
+            now.saturating_add(Duration::from_nanos(1)),
+            now,
+            actions,
+        );
     }
 
     pub(crate) fn shutdown_waiters(&mut self) -> WakeBatch {
@@ -918,11 +1091,32 @@ impl NetworkSimulation {
             .map_or(0, |c| c.send_buffer_capacity)
     }
 
-    pub(crate) fn send_buffer_used(&self, id: ConnectionId) -> usize {
+    pub(crate) fn queued_send_bytes(&self, id: ConnectionId) -> usize {
         self.state
             .connections
             .get(&id)
-            .map_or(0, |c| c.send_buffer.iter().map(Vec::len).sum())
+            .map_or(0, ConnectionState::queued_bytes)
+    }
+
+    pub(crate) fn in_flight_bytes(&self, id: ConnectionId) -> usize {
+        self.state
+            .connections
+            .get(&id)
+            .map_or(0, ConnectionState::in_flight_bytes)
+    }
+
+    pub(crate) fn unread_bytes(&self, id: ConnectionId) -> usize {
+        self.state
+            .connections
+            .get(&id)
+            .map_or(0, |c| c.receive_buffer.len())
+    }
+
+    pub(crate) fn is_in_flight_held(&self, id: ConnectionId) -> bool {
+        self.state
+            .connections
+            .get(&id)
+            .is_some_and(|c| c.in_flight_held_since.is_some())
     }
 
     pub(crate) fn register_send_buffer(&mut self, id: ConnectionId, waker: &Waker) -> bool {
@@ -1164,6 +1358,7 @@ impl NetworkSimulation {
                 expected_deadline: deadline,
             },
         );
+        self.hold_partitioned_in_flight(now);
         actions
     }
 
@@ -1244,6 +1439,7 @@ impl NetworkSimulation {
             from: from.to_string(),
             to: to.to_string(),
         });
+        self.hold_partitioned_in_flight(now);
         actions
     }
 
@@ -1263,6 +1459,7 @@ impl NetworkSimulation {
             },
         );
         actions.record(SimFaultEvent::SendPartitionCreated { ip: ip.to_string() });
+        self.hold_partitioned_in_flight(now);
         actions
     }
 
@@ -1282,6 +1479,7 @@ impl NetworkSimulation {
             },
         );
         actions.record(SimFaultEvent::RecvPartitionCreated { ip: ip.to_string() });
+        self.hold_partitioned_in_flight(now);
         actions
     }
 
@@ -1298,7 +1496,7 @@ impl NetworkSimulation {
             from: from.to_string(),
             to: to.to_string(),
         });
-        self.resume_stalled_sends(now, &mut actions);
+        self.resume_after_heal(now, &mut actions);
         actions
     }
 
@@ -1306,8 +1504,10 @@ impl NetworkSimulation {
     /// cuts plus the send-side and receive-side blocks that
     /// [`restore_partition`](Self::restore_partition) cannot reach.
     ///
-    /// Connections held back by a partition are re-driven, so a stalled send
-    /// resumes instead of waiting out a deadline that no longer applies.
+    /// Connections held back by a partition are re-driven — what was frozen in
+    /// flight thaws and the stalled send queue follows it — so a stalled
+    /// stream resumes instead of waiting out a deadline that no longer
+    /// applies. No new randomness: this only re-times work already sampled.
     pub(crate) fn heal_all_partitions(&mut self, now: Duration) -> NetworkActions {
         let mut actions = NetworkActions::default();
         for (from, to) in std::mem::take(&mut self.state.ip_partitions).into_keys() {
@@ -1322,7 +1522,7 @@ impl NetworkSimulation {
         for ip in std::mem::take(&mut self.state.recv_partitions).into_keys() {
             actions.record(SimFaultEvent::RecvPartitionHealed { ip: ip.to_string() });
         }
-        self.resume_stalled_sends(now, &mut actions);
+        self.resume_after_heal(now, &mut actions);
         actions
     }
 
@@ -1473,30 +1673,31 @@ impl NetworkSimulation {
         let mut wakes = WakeBatch::default();
         let Some(snapshot) = self.state.connections.get(&id).map(|c| {
             (
-                c.paired_connection,
                 c.flags.send_closed(),
                 c.flags.is_closed(),
                 c.flags.send_in_progress(),
                 c.send_buffer.is_empty(),
-                c.last_data_delivery_scheduled_at,
             )
         }) else {
             return (actions, wakes);
         };
-        if snapshot.1 || snapshot.2 {
+        let (send_closed, is_closed, send_in_progress, queue_empty) = snapshot;
+        if send_closed || is_closed {
             return (actions, wakes);
         }
         if let Some(c) = self.state.connections.get_mut(&id) {
             c.flags.set_is_closed(true);
             c.flags.set_send_closed(true);
             c.close_reason = CloseReason::Graceful;
-            if snapshot.3 || !snapshot.4 {
+            if send_in_progress || !queue_empty {
                 c.flags.set_graceful_close_pending(true);
             }
         }
         wakes.push(self.waiters.reads.take(&id));
-        if !snapshot.3 && snapshot.4 {
-            Self::schedule_fin(snapshot.0, snapshot.5, now, &mut actions);
+        // The FIN goes on the wire behind whatever is already in flight; it
+        // can never overtake the stream's last bytes.
+        if !send_in_progress && queue_empty {
+            self.put_fin_in_flight(id, now, &mut actions);
         }
         (actions, wakes)
     }
@@ -1518,6 +1719,8 @@ impl NetworkSimulation {
                 c.send_buffer.clear();
                 c.close_reason = CloseReason::Aborted;
             }
+            // An RST resets both directions: the queue and the flight are gone.
+            self.discard_in_flight(current);
         }
         let mut wakes = WakeBatch::default();
         for current in [Some(id), paired].into_iter().flatten() {

--- a/crates/moonpool-sim/src/network/sim/engine.rs
+++ b/crates/moonpool-sim/src/network/sim/engine.rs
@@ -23,7 +23,7 @@ use super::{
     event::NetworkOperationId,
     state::{
         ClogState, CloseReason, ConnectionFlags, ConnectionState, InFlight, InFlightPayload,
-        NetworkState, PartitionState,
+        NetworkState, PartitionState, SendWindow,
     },
 };
 
@@ -134,17 +134,28 @@ impl NetworkSimulation {
         id
     }
 
+    /// Drain up to `buf.len()` bytes from `connection_id`'s receive buffer.
+    ///
+    /// Exactly the bytes handed to the application are released from the
+    /// peer's send window (see [`SendWindow`]): a partial read returns a
+    /// partial credit, and a writer parked on that window is woken. Draws
+    /// randomness only when data is available and the partial-read fault
+    /// fires; an empty read consumes none.
     pub(crate) fn read(
         &mut self,
         connection_id: ConnectionId,
         buf: &mut [u8],
-    ) -> SimulationResult<usize> {
+    ) -> (SimulationResult<usize>, WakeBatch) {
         let partial_read_max_bytes = self.state.config.chaos.partial_read_max_bytes;
-        let connection = self
-            .state
-            .connections
-            .get_mut(&connection_id)
-            .ok_or_else(|| SimulationError::InvalidState("connection not found".to_string()))?;
+        let mut wakes = WakeBatch::default();
+        let Some(connection) = self.state.connections.get_mut(&connection_id) else {
+            return (
+                Err(SimulationError::InvalidState(
+                    "connection not found".to_string(),
+                )),
+                wakes,
+            );
+        };
         let available = buf.len().min(connection.receive_buffer.len());
         let limit = if available > 0 && crate::buggify!() {
             let max_read = available.min(partial_read_max_bytes);
@@ -159,14 +170,59 @@ impl NetworkSimulation {
         for (slot, byte) in buf.iter_mut().zip(connection.receive_buffer.drain(..limit)) {
             *slot = byte;
         }
-        Ok(limit)
+        if limit > 0
+            && let Some(sender) = connection.paired_connection
+        {
+            self.release_window(sender, limit, &mut wakes);
+        }
+        (Ok(limit), wakes)
     }
 
-    /// Drop everything `id` has on the wire: an abort resets the flight.
+    /// Return `bytes` to `sender`'s window and wake a writer parked on it.
+    fn release_window(&mut self, sender: ConnectionId, bytes: usize, wakes: &mut WakeBatch) {
+        if bytes == 0 {
+            return;
+        }
+        if let Some(sender_state) = self.state.connections.get_mut(&sender) {
+            sender_state.window.release(bytes);
+            Self::take_waiter(&mut self.waiters.send_buffers, sender, wakes);
+        }
+    }
+
+    /// Drop everything still queued locally on `id`, returning its bytes to
+    /// the window: nothing can deliver them any more, so nothing else could
+    /// ever release them.
+    fn discard_send_queue(&mut self, id: ConnectionId) {
+        if let Some(connection) = self.state.connections.get_mut(&id) {
+            let queued = connection.queued_bytes();
+            connection.send_buffer.clear();
+            connection.window.release(queued);
+        }
+    }
+
+    /// Drop what `id` received but never read — its application closed or shut
+    /// its receive side, so nothing will read it now — and return the bytes
+    /// to the peer's window, waking a writer parked on them. The kernel does
+    /// the same: a receive buffer freed by a close was acknowledged already.
+    fn discard_receive_buffer(&mut self, id: ConnectionId, wakes: &mut WakeBatch) {
+        let Some(connection) = self.state.connections.get_mut(&id) else {
+            return;
+        };
+        let unread = connection.receive_buffer.len();
+        connection.receive_buffer.clear();
+        if let Some(sender) = connection.paired_connection {
+            self.release_window(sender, unread, wakes);
+        }
+    }
+
+    /// Drop everything `id` has on the wire (an abort resets the flight) and
+    /// return its bytes to the window.
     fn discard_in_flight(&mut self, id: ConnectionId) {
         if let Some(connection) = self.state.connections.get_mut(&id) {
+            let in_flight = connection.in_flight_bytes();
             connection.in_flight.clear();
             connection.in_flight_held_since = None;
+            connection.window.release(in_flight);
         }
     }
 
@@ -188,6 +244,9 @@ impl NetworkSimulation {
             .connections
             .get_mut(&connection_id)
             .ok_or_else(|| SimulationError::InvalidState("connection not found".to_string()))?;
+        // The window is taken here, the moment the application's bytes are
+        // accepted, and given back only by the peer's read.
+        connection.window.acquire(data.len());
         connection.send_buffer.push_back(data);
         let mut actions = NetworkActions::default();
         if !connection.flags.send_in_progress() {
@@ -202,7 +261,7 @@ impl NetworkSimulation {
         client_addr: &str,
         server_addr: &str,
     ) -> (ConnectionId, ConnectionId) {
-        const DEFAULT_SEND_BUFFER_CAPACITY: usize = 64 * 1024;
+        let send_window = self.state.config.tcp_send_window_bytes;
         let client_conn = ConnectionId(self.state.next_connection_id);
         self.state.next_connection_id += 1;
         let server_conn = ConnectionId(self.state.next_connection_id);
@@ -245,7 +304,7 @@ impl NetworkSimulation {
             last_delivery_at: None,
             flags: ConnectionFlags::default(),
             close_reason: CloseReason::None,
-            send_buffer_capacity: DEFAULT_SEND_BUFFER_CAPACITY,
+            window: SendWindow::new(send_window),
         };
         self.state.connections.insert(
             client_conn,
@@ -601,8 +660,10 @@ impl NetworkSimulation {
             return;
         };
         // The item left a black-holed sender: it was acknowledged into that
-        // side's buffer and is gone. No bytes, no EOF, no wake — the reader
-        // keeps waiting for data that will never come.
+        // side's window and is gone. No bytes, no EOF, no wake, and the
+        // window credit it took is never returned — the reader keeps waiting
+        // for data that will never come, and once the window is full the
+        // writer waits with it.
         if black_holed {
             return;
         }
@@ -617,7 +678,10 @@ impl NetworkSimulation {
                         !connection.flags.is_closed() && !connection.flags.recv_closed()
                     });
                 let Some(receiver) = receiver.filter(|_| receiver_reading) else {
-                    // A closed or receive-shut peer discards what arrives.
+                    // A closed or receive-shut peer discards what arrives and
+                    // acknowledges it, so the writer is not left waiting on
+                    // credits nobody will ever read back.
+                    self.release_window(sender, data.len(), wakes);
                     return;
                 };
                 let delivered = self.maybe_corrupt_data(receiver, &data, now, actions);
@@ -812,8 +876,8 @@ impl NetworkSimulation {
             (connection.flags.is_closed() || connection.flags.send_closed())
                 && !connection.flags.graceful_close_pending()
         }) {
+            self.discard_send_queue(id);
             if let Some(connection) = self.state.connections.get_mut(&id) {
-                connection.send_buffer.clear();
                 connection.flags.set_send_in_progress(false);
                 connection.flags.set_send_stalled(false);
             }
@@ -831,7 +895,7 @@ impl NetworkSimulation {
         if has_queued_bytes && self.state.connection_partition_clear_at(id, now).is_some() {
             self.stall_partitioned_send(id);
         } else {
-            self.handle_normal_send(id, now, actions, wakes);
+            self.handle_normal_send(id, now, actions);
         }
     }
 
@@ -845,9 +909,10 @@ impl NetworkSimulation {
     /// a clogged pair into added delay (`getRecvDelay` clamps to
     /// `clogPairUntil`), and only an explicit disconnect fails the connection.
     ///
-    /// Send-buffer waiters are deliberately left registered: no buffer space is
-    /// released while the stream is stalled, so writers keep seeing
-    /// backpressure until the send actually drains.
+    /// Send-window waiters are deliberately left registered: no window is
+    /// released while the stream is stalled (nothing reaches the peer's
+    /// reader), so writers keep seeing backpressure until the bytes land and
+    /// are read.
     ///
     /// A stalled connection owns no scheduled work. It is re-driven by
     /// [`resume_after_heal`](Self::resume_after_heal) when the partitions
@@ -895,7 +960,6 @@ impl NetworkSimulation {
         id: ConnectionId,
         now: Duration,
         actions: &mut NetworkActions,
-        wakes: &mut WakeBatch,
     ) {
         let Some(snapshot) = self.state.connections.get(&id).map(|connection| {
             (
@@ -924,7 +988,9 @@ impl NetworkSimulation {
             }
             return;
         };
-        Self::take_waiter(&mut self.waiters.send_buffers, id, wakes);
+        // No window is released here: the bytes have only moved from the
+        // queue onto the wire, and they stay charged to the writer until the
+        // peer's application reads them.
         if crate::buggify!() && !data.is_empty() {
             let max_send = data.len().min(partial_max);
             let truncate_to = sim_random_range(0..max_send + 1);
@@ -1084,11 +1150,25 @@ impl NetworkSimulation {
             .is_some_and(|c| c.flags.remote_fin_received())
     }
 
-    pub(crate) fn send_buffer_capacity(&self, id: ConnectionId) -> usize {
+    pub(crate) fn send_window_bytes(&self, id: ConnectionId) -> usize {
         self.state
             .connections
             .get(&id)
-            .map_or(0, |c| c.send_buffer_capacity)
+            .map_or(0, |c| c.window.capacity())
+    }
+
+    pub(crate) fn outstanding_send_bytes(&self, id: ConnectionId) -> usize {
+        self.state
+            .connections
+            .get(&id)
+            .map_or(0, |c| c.window.outstanding())
+    }
+
+    pub(crate) fn available_send_bytes(&self, id: ConnectionId) -> usize {
+        self.state
+            .connections
+            .get(&id)
+            .map_or(0, |c| c.window.available())
     }
 
     pub(crate) fn queued_send_bytes(&self, id: ConnectionId) -> usize {
@@ -1562,7 +1642,9 @@ impl NetworkSimulation {
         let close_send = a > 0.33;
         if close_send && let Some(c) = self.state.connections.get_mut(&id) {
             c.flags.set_send_closed(true);
-            c.send_buffer.clear();
+        }
+        if close_send {
+            self.discard_send_queue(id);
         }
         if close_recv && let Some(c) = paired.and_then(|peer| self.state.connections.get_mut(&peer))
         {
@@ -1571,9 +1653,11 @@ impl NetworkSimulation {
         let mut wakes = WakeBatch::default();
         if close_send {
             wakes.push(self.waiters.reads.take(&id));
+            Self::take_waiter(&mut self.waiters.send_buffers, id, &mut wakes);
         }
         if close_recv && let Some(peer) = paired {
             wakes.push(self.waiters.reads.take(&peer));
+            self.discard_receive_buffer(peer, &mut wakes);
         }
         let explicit = sim_random_f64() < self.state.config.chaos.random_close_explicit_ratio;
         let mut actions = NetworkActions::default();
@@ -1694,6 +1778,9 @@ impl NetworkSimulation {
             }
         }
         wakes.push(self.waiters.reads.take(&id));
+        // A close frees what this side never read; the peer's writer gets the
+        // window back (and, on its next write, the FIN below).
+        self.discard_receive_buffer(id, &mut wakes);
         // The FIN goes on the wire behind whatever is already in flight; it
         // can never overtake the stream's last bytes.
         if !send_in_progress && queue_empty {
@@ -1716,13 +1803,18 @@ impl NetworkSimulation {
                 c.flags.set_send_in_progress(false);
                 c.flags.set_send_stalled(false);
                 c.flags.set_graceful_close_pending(false);
-                c.send_buffer.clear();
                 c.close_reason = CloseReason::Aborted;
             }
-            // An RST resets both directions: the queue and the flight are gone.
+            // An RST resets both directions: the queue, the flight and the
+            // unread bytes are gone, and every writer parked on the window
+            // wakes to the error.
+            self.discard_send_queue(current);
             self.discard_in_flight(current);
         }
         let mut wakes = WakeBatch::default();
+        for current in [Some(id), paired].into_iter().flatten() {
+            self.discard_receive_buffer(current, &mut wakes);
+        }
         for current in [Some(id), paired].into_iter().flatten() {
             wakes.push(self.waiters.reads.take(&current));
             Self::take_waiter(&mut self.waiters.write_clogs, current, &mut wakes);
@@ -1745,7 +1837,9 @@ impl NetworkSimulation {
             .and_then(|c| c.paired_connection);
         if close_send && let Some(c) = self.state.connections.get_mut(&id) {
             c.flags.set_send_closed(true);
-            c.send_buffer.clear();
+        }
+        if close_send {
+            self.discard_send_queue(id);
         }
         if close_recv && let Some(c) = paired.and_then(|peer| self.state.connections.get_mut(&peer))
         {
@@ -1754,9 +1848,11 @@ impl NetworkSimulation {
         let mut wakes = WakeBatch::default();
         if close_send {
             wakes.push(self.waiters.reads.take(&id));
+            Self::take_waiter(&mut self.waiters.send_buffers, id, &mut wakes);
         }
         if close_recv && let Some(peer) = paired {
             wakes.push(self.waiters.reads.take(&peer));
+            self.discard_receive_buffer(peer, &mut wakes);
         }
         wakes
     }

--- a/crates/moonpool-sim/src/network/sim/event.rs
+++ b/crates/moonpool-sim/src/network/sim/event.rs
@@ -9,7 +9,11 @@ use super::ConnectionId;
 pub struct NetworkOperationId(pub(crate) u64);
 
 /// A targeted network transition or delivery.
-#[derive(Debug, Clone, PartialEq, Eq)]
+///
+/// Events carry identities and deadlines only, never payload: the bytes an
+/// event lands live in the engine's per-connection in-flight queue, where a
+/// fault injected after scheduling can still reach them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NetworkEvent {
     /// Wake-up feed used to evaluate network maintenance at the current time.
     Maintenance,
@@ -47,21 +51,21 @@ pub enum NetworkEvent {
         /// Deadline of the receive partition that created this event.
         expected_deadline: Duration,
     },
-    /// Deliver bytes to a connection.
-    DataDelivery {
-        /// Receiving connection.
+    /// An in-flight item (data chunk or FIN) reached its delivery time.
+    ///
+    /// The item itself lives in the sender's in-flight queue, so a fault
+    /// injected after this event was scheduled still decides its fate: the
+    /// event is a wake-up, not the payload. It is a no-op when the item was
+    /// already delivered or re-timed by a partition.
+    Delivery {
+        /// Sending connection whose flight holds the item.
         connection_id: ConnectionId,
-        /// Delivered bytes.
-        data: Vec<u8>,
+        /// Sequence number of the item within that flight.
+        seq: u64,
     },
     /// Process the next buffered send.
     ProcessSendBuffer {
         /// Connection whose next buffered write should run.
-        connection_id: ConnectionId,
-    },
-    /// Deliver a graceful FIN.
-    FinDelivery {
-        /// Connection receiving the FIN.
         connection_id: ConnectionId,
     },
 }

--- a/crates/moonpool-sim/src/network/sim/facade.rs
+++ b/crates/moonpool-sim/src/network/sim/facade.rs
@@ -50,7 +50,11 @@ impl SimWorld {
         id: ConnectionId,
         buf: &mut [u8],
     ) -> SimulationResult<usize> {
-        self.inner.write().network.read(id, buf)
+        let (result, wakes) = self.inner.write().network.read(id, buf);
+        // The bytes just read return window to the peer's writer; wake it
+        // outside the lock like every other waiter.
+        wakes.wake();
+        result
     }
 
     pub(crate) fn has_readable_data(&self, id: ConnectionId) -> bool {
@@ -227,23 +231,27 @@ impl SimWorld {
         self.inner.write().network.register_read_clog(id, waker)
     }
 
-    /// Returns send-buffer capacity.
+    /// The end-to-end byte window of `id`'s sending direction (see
+    /// [`NetworkConfiguration::tcp_send_window_bytes`]).
     #[must_use]
-    pub fn send_buffer_capacity(&self, id: ConnectionId) -> usize {
-        self.inner.read().network.send_buffer_capacity(id)
+    pub fn send_window_bytes(&self, id: ConnectionId) -> usize {
+        self.inner.read().network.send_window_bytes(id)
     }
 
-    /// Returns used send-buffer bytes.
+    /// Bytes `id` has written that its peer's application has not read yet,
+    /// wherever they sit: queued locally, in flight, or unread at the peer.
+    /// Never exceeds [`send_window_bytes`](Self::send_window_bytes).
     #[must_use]
-    pub fn send_buffer_used(&self, id: ConnectionId) -> usize {
-        self.queued_send_bytes(id)
+    pub fn outstanding_send_bytes(&self, id: ConnectionId) -> usize {
+        self.inner.read().network.outstanding_send_bytes(id)
     }
 
-    /// Returns available send-buffer bytes.
+    /// Bytes a write on `id` may accept right now: the window minus what is
+    /// outstanding. Zero means the next `poll_write` parks until the peer
+    /// reads.
     #[must_use]
-    pub fn available_send_buffer(&self, id: ConnectionId) -> usize {
-        self.send_buffer_capacity(id)
-            .saturating_sub(self.send_buffer_used(id))
+    pub fn available_send_bytes(&self, id: ConnectionId) -> usize {
+        self.inner.read().network.available_send_bytes(id)
     }
 
     /// Bytes `id` has accepted but not yet put on the wire.

--- a/crates/moonpool-sim/src/network/sim/facade.rs
+++ b/crates/moonpool-sim/src/network/sim/facade.rs
@@ -70,9 +70,10 @@ impl SimWorld {
         client: &str,
         server: &str,
     ) -> (ConnectionId, ConnectionId) {
-        let mut inner = self.inner.write();
-        let now = inner.now();
-        inner.network.create_connection_pair(client, server, now)
+        self.inner
+            .write()
+            .network
+            .create_connection_pair(client, server)
     }
 
     pub(crate) fn discard_connection_pair(&self, id: ConnectionId) {
@@ -235,7 +236,7 @@ impl SimWorld {
     /// Returns used send-buffer bytes.
     #[must_use]
     pub fn send_buffer_used(&self, id: ConnectionId) -> usize {
-        self.inner.read().network.send_buffer_used(id)
+        self.queued_send_bytes(id)
     }
 
     /// Returns available send-buffer bytes.
@@ -243,6 +244,30 @@ impl SimWorld {
     pub fn available_send_buffer(&self, id: ConnectionId) -> usize {
         self.send_buffer_capacity(id)
             .saturating_sub(self.send_buffer_used(id))
+    }
+
+    /// Bytes `id` has accepted but not yet put on the wire.
+    #[must_use]
+    pub fn queued_send_bytes(&self, id: ConnectionId) -> usize {
+        self.inner.read().network.queued_send_bytes(id)
+    }
+
+    /// Bytes `id` has on the wire: sent, not yet in the peer's receive buffer.
+    #[must_use]
+    pub fn in_flight_bytes(&self, id: ConnectionId) -> usize {
+        self.inner.read().network.in_flight_bytes(id)
+    }
+
+    /// Bytes delivered to `id` that its application has not read yet.
+    #[must_use]
+    pub fn unread_bytes(&self, id: ConnectionId) -> usize {
+        self.inner.read().network.unread_bytes(id)
+    }
+
+    /// Whether a partition is currently freezing what `id` has in flight.
+    #[must_use]
+    pub fn is_in_flight_held(&self, id: ConnectionId) -> bool {
+        self.inner.read().network.is_in_flight_held(id)
     }
 
     pub(crate) fn register_send_buffer_waker(&self, id: ConnectionId, waker: &Waker) -> bool {

--- a/crates/moonpool-sim/src/network/sim/state.rs
+++ b/crates/moonpool-sim/src/network/sim/state.rs
@@ -7,7 +7,7 @@
 //!
 //! ```text
 //! application write
-//!     |  poll_write accepts up to the send buffer's free capacity
+//!     |  poll_write accepts min(len, available window)
 //! local send queue        ConnectionState::send_buffer      (sender side)
 //!     |  ProcessSendBuffer: latency sampled, chunk put on the wire
 //! in flight               ConnectionState::in_flight        (sender side)
@@ -223,7 +223,8 @@ pub(crate) struct ConnectionState {
     pub(crate) last_delivery_at: Option<Duration>,
     pub(crate) flags: ConnectionFlags,
     pub(crate) close_reason: CloseReason,
-    pub(crate) send_buffer_capacity: usize,
+    /// Byte budget shared by every stage of this direction, see [`SendWindow`].
+    pub(crate) window: SendWindow,
 }
 
 impl ConnectionState {
@@ -235,6 +236,91 @@ impl ConnectionState {
     /// Bytes on the wire (excluding the FIN, which carries none).
     pub(crate) fn in_flight_bytes(&self) -> usize {
         self.in_flight.iter().map(|item| item.payload.len()).sum()
+    }
+}
+
+/// The end-to-end byte window of one stream direction.
+///
+/// `outstanding` counts every byte the application has written that the peer
+/// application has not yet read, wherever it currently sits: the local send
+/// queue, the flight, or the peer's receive buffer. It is acquired when
+/// `poll_write` accepts the bytes and released only when the peer's
+/// `poll_read` hands them to its application, byte for byte, so a slow reader
+/// backs the writer up through every stage in between — the invariant is
+///
+/// ```text
+/// outstanding = queued + in_flight + unread_at_peer + vanished
+/// outstanding <= capacity
+/// ```
+///
+/// where `vanished` are bytes a black hole swallowed: they never land, so the
+/// credit they took is never returned, and a black-holed direction fills its
+/// window and blocks instead of accepting data forever.
+///
+/// Moving bytes between the stages neither acquires nor releases. Bytes a
+/// closed or receive-shut peer discards on arrival are released (the kernel
+/// acknowledges what it throws away), and bytes a close discards from the
+/// local queue are released too, so a writer is never left parked on credits
+/// nothing can return.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SendWindow {
+    capacity: usize,
+    outstanding: usize,
+}
+
+impl SendWindow {
+    pub(crate) fn new(capacity: usize) -> Self {
+        Self {
+            capacity,
+            outstanding: 0,
+        }
+    }
+
+    pub(crate) fn capacity(self) -> usize {
+        self.capacity
+    }
+
+    pub(crate) fn outstanding(self) -> usize {
+        self.outstanding
+    }
+
+    pub(crate) fn available(self) -> usize {
+        self.capacity
+            .checked_sub(self.outstanding)
+            .expect("send window: outstanding bytes exceed the capacity")
+    }
+
+    /// Take `bytes` of the window.
+    ///
+    /// # Panics
+    ///
+    /// Panics if that would push `outstanding` past the capacity: `poll_write`
+    /// clamps to [`available`](Self::available) before it buffers, so an
+    /// over-acquire is an accounting bug, not an operating condition.
+    pub(crate) fn acquire(&mut self, bytes: usize) {
+        let outstanding = self
+            .outstanding
+            .checked_add(bytes)
+            .expect("send window: outstanding bytes overflow");
+        assert!(
+            outstanding <= self.capacity,
+            "send window: acquired {bytes} bytes with only {} available",
+            self.available()
+        );
+        self.outstanding = outstanding;
+    }
+
+    /// Return `bytes` to the window.
+    ///
+    /// # Panics
+    ///
+    /// Panics if more is released than is outstanding: a double release would
+    /// otherwise let a writer overrun the window silently.
+    pub(crate) fn release(&mut self, bytes: usize) {
+        self.outstanding = self
+            .outstanding
+            .checked_sub(bytes)
+            .expect("send window: released more bytes than were outstanding");
     }
 }
 
@@ -326,5 +412,40 @@ impl NetworkState {
     ) -> Option<Duration> {
         let connection = self.connections.get(&connection_id)?;
         self.partition_clear_at(connection.local_ip?, connection.remote_ip?, now)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SendWindow;
+
+    #[test]
+    fn the_window_accounts_byte_for_byte() {
+        let mut window = SendWindow::new(10);
+        assert_eq!(window.available(), 10);
+        window.acquire(7);
+        assert_eq!(window.outstanding(), 7);
+        assert_eq!(window.available(), 3);
+        window.release(3);
+        window.release(4);
+        assert_eq!(window.outstanding(), 0);
+        assert_eq!(window.available(), 10);
+    }
+
+    #[test]
+    #[should_panic(expected = "released more bytes than were outstanding")]
+    fn a_double_release_is_caught() {
+        let mut window = SendWindow::new(10);
+        window.acquire(4);
+        window.release(4);
+        window.release(1);
+    }
+
+    #[test]
+    #[should_panic(expected = "acquired 5 bytes with only 2 available")]
+    fn an_over_acquire_is_caught() {
+        let mut window = SendWindow::new(10);
+        window.acquire(8);
+        window.acquire(5);
     }
 }

--- a/crates/moonpool-sim/src/network/sim/state.rs
+++ b/crates/moonpool-sim/src/network/sim/state.rs
@@ -1,4 +1,28 @@
 //! Mutable state owned by the simulated network engine.
+//!
+//! # Byte lifecycle
+//!
+//! Every byte an application writes to a simulated stream moves through four
+//! places, always in this order and never skipping one:
+//!
+//! ```text
+//! application write
+//!     |  poll_write accepts up to the send buffer's free capacity
+//! local send queue        ConnectionState::send_buffer      (sender side)
+//!     |  ProcessSendBuffer: latency sampled, chunk put on the wire
+//! in flight               ConnectionState::in_flight        (sender side)
+//!     |  Delivery event at deliver_at, unless the direction is held
+//! peer receive buffer     ConnectionState::receive_buffer   (receiver side)
+//!     |  poll_read drains
+//! application read
+//! ```
+//!
+//! A fault is defined for every stage. A partition that cuts the direction
+//! stalls the send queue *and* freezes what is already in flight
+//! ([`ConnectionState::in_flight_held_since`]); a black hole makes in-flight
+//! bytes vanish at the instant they would land; an abort discards the send
+//! queue and the flight and resets the peer. Bytes that reached the receive
+//! buffer are the peer's: nothing on the wire can take them back.
 
 use std::{
     collections::{BTreeMap, BTreeSet, VecDeque},
@@ -26,6 +50,40 @@ pub enum CloseReason {
     Graceful,
     /// Aborted RST close.
     Aborted,
+}
+
+/// One item that has left its sender and not yet reached the peer's receive
+/// buffer: a data chunk or the FIN that ends the stream.
+///
+/// Items are delivered strictly in `seq` order at `deliver_at`, which only
+/// ever moves later (a partition freezes the flight and shifts every item by
+/// the time it stayed cut). The `seq` doubles as the identity a scheduled
+/// [`NetworkEvent::Delivery`](super::NetworkEvent::Delivery) refers to, so a
+/// delivery event that fires for an item already delivered, or re-timed, is a
+/// no-op.
+#[derive(Debug, Clone)]
+pub(crate) struct InFlight {
+    pub(crate) seq: u64,
+    pub(crate) deliver_at: Duration,
+    pub(crate) payload: InFlightPayload,
+}
+
+/// What an in-flight item carries.
+#[derive(Debug, Clone)]
+pub(crate) enum InFlightPayload {
+    /// Ordered stream bytes.
+    Data(Vec<u8>),
+    /// A graceful close; always the last item of a stream.
+    Fin,
+}
+
+impl InFlightPayload {
+    pub(crate) fn len(&self) -> usize {
+        match self {
+            Self::Data(bytes) => bytes.len(),
+            Self::Fin => 0,
+        }
+    }
 }
 
 /// A directed partition between two IP addresses.
@@ -135,6 +193,10 @@ impl ConnectionFlags {
 }
 
 /// State for one endpoint of a simulated TCP connection.
+///
+/// The sending half (`send_buffer`, `in_flight`, the delivery clock) belongs
+/// to this endpoint and describes the direction `local_ip -> remote_ip`; the
+/// receiving half is `receive_buffer`, filled by the peer's deliveries.
 #[derive(Debug, Clone)]
 pub(crate) struct ConnectionState {
     pub(crate) local_ip: Option<IpAddr>,
@@ -142,12 +204,38 @@ pub(crate) struct ConnectionState {
     pub(crate) peer_address: String,
     pub(crate) receive_buffer: VecDeque<u8>,
     pub(crate) paired_connection: Option<ConnectionId>,
+    /// Chunks accepted from the application and not yet put on the wire.
     pub(crate) send_buffer: VecDeque<Vec<u8>>,
-    pub(crate) next_send_time: Duration,
+    /// Chunks (and at most one trailing FIN) on the wire towards the peer, in
+    /// delivery order.
+    pub(crate) in_flight: VecDeque<InFlight>,
+    /// Set while a partition freezes the flight: the instant it was cut.
+    ///
+    /// A held direction delivers nothing. When every partition blocking it has
+    /// healed, each in-flight item is re-timed by the time the direction spent
+    /// cut, so the cut delays every byte it caught by exactly its own length
+    /// and never reorders the stream.
+    pub(crate) in_flight_held_since: Option<Duration>,
+    /// Next `seq` to hand an in-flight item.
+    pub(crate) next_in_flight_seq: u64,
+    /// Delivery time of the most recent item put on the wire; the next item
+    /// is delivered strictly after it, which is what keeps the stream FIFO.
+    pub(crate) last_delivery_at: Option<Duration>,
     pub(crate) flags: ConnectionFlags,
     pub(crate) close_reason: CloseReason,
     pub(crate) send_buffer_capacity: usize,
-    pub(crate) last_data_delivery_scheduled_at: Option<Duration>,
+}
+
+impl ConnectionState {
+    /// Bytes waiting in the local send queue.
+    pub(crate) fn queued_bytes(&self) -> usize {
+        self.send_buffer.iter().map(Vec::len).sum()
+    }
+
+    /// Bytes on the wire (excluding the FIN, which carries none).
+    pub(crate) fn in_flight_bytes(&self) -> usize {
+        self.in_flight.iter().map(|item| item.payload.len()).sum()
+    }
 }
 
 /// Protocol state owned exclusively by the simulated network engine.

--- a/crates/moonpool-sim/src/network/sim/stream.rs
+++ b/crates/moonpool-sim/src/network/sim/stream.rs
@@ -71,10 +71,20 @@ fn connection_aborted_error() -> io::Error {
 /// - Achieved through per-connection send buffering
 /// - Critical for protocols that depend on message ordering
 ///
-/// ### 3. Flow Control Simulation
+/// ### 3. Flow Control
 /// - Read operations block (`Poll::Pending`) when no data is available
-/// - Write operations complete immediately (buffering model)
-/// - Backpressure handled at the application layer
+/// - Each direction has an end-to-end byte window
+///   ([`NetworkConfiguration::tcp_send_window_bytes`](crate::NetworkConfiguration::tcp_send_window_bytes)):
+///   a write accepts at most what the window has left (a short write when
+///   some room remains) and parks when it has none
+/// - The window is taken when the write is accepted and returned only when
+///   the *peer's application reads* the bytes, so a slow reader backs the
+///   writer up through the send queue, the flight and the peer's receive
+///   buffer alike; a direction that stops delivering (partition, black hole)
+///   fills its window and blocks instead of accepting data forever
+/// - A parked writer is woken by the peer's read, or by the connection
+///   failing (an abort wakes it to the error; it is never left waiting on a
+///   destroyed connection)
 ///
 /// ## Usage Examples
 ///
@@ -82,7 +92,7 @@ fn connection_aborted_error() -> io::Error {
 ///
 /// ## Performance Characteristics
 ///
-/// - **Write Latency**: O(1) - writes are buffered immediately
+/// - **Write Latency**: O(1) while the window has room
 /// - **Read Latency**: `O(network_delay)` - depends on simulation configuration
 /// - **Memory Usage**: `O(buffered_data)` - proportional to unread data
 /// - **CPU Overhead**: Minimal - leverages efficient event system
@@ -399,12 +409,14 @@ impl AsyncWrite for SimTcpStream {
             return Poll::Ready(Ok(0));
         }
 
-        // Match write(2): accept a short write when some capacity remains and
-        // park only when the send buffer has no room at all.
-        let available = sim.available_send_buffer(self.connection_id);
+        // Match write(2): accept a short write when some window remains and
+        // park only when the window has no room at all. The window is
+        // end-to-end (queued + in flight + unread at the peer), so this is
+        // where a slow reader shows up as backpressure.
+        let available = sim.available_send_bytes(self.connection_id);
         if available == 0 {
             tracing::debug!(
-                "SimTcpStream::poll_write connection_id={} buffer full (needed={}), waiting",
+                "SimTcpStream::poll_write connection_id={} window full (needed={}), waiting",
                 self.connection_id.0,
                 buf.len()
             );
@@ -414,7 +426,7 @@ impl AsyncWrite for SimTcpStream {
             return Poll::Pending;
         }
 
-        // A full send buffer makes this a no-progress poll, not a fresh I/O
+        // A full window makes this a no-progress poll, not a fresh I/O
         // operation. Roll random-close chaos only after capacity is available
         // so backpressure repolls cannot perturb deterministic replay.
         if let Some(true) = sim.roll_random_close(self.connection_id) {
@@ -467,7 +479,7 @@ impl AsyncWrite for SimTcpStream {
 
         // writev(2) partial-accept semantics: if there's SOME room, accept what
         // fits and report a short count; only block when there is NO room at all.
-        let available = sim.available_send_buffer(self.connection_id);
+        let available = sim.available_send_bytes(self.connection_id);
         if available == 0 {
             if !sim.register_send_buffer_waker(self.connection_id, cx.waker()) {
                 return Poll::Ready(Err(sim_shutdown_error()));

--- a/crates/moonpool-sim/src/network/sim/stream.rs
+++ b/crates/moonpool-sim/src/network/sim/stream.rs
@@ -48,12 +48,13 @@ fn connection_aborted_error() -> io::Error {
 ///                                                        
 /// stream.write_all(data) ──► poll_write(data) ────────► buffer_send(data)
 ///                                                        └─► ProcessSendBuffer event
-///                                                            └─► DataDelivery event
-///                                                                └─► paired connection
-///                                                        
+///                                                            └─► in-flight queue
+///                                                                └─► Delivery event
+///                                                                    └─► peer receive_buffer
+///
 /// stream.read(buf) ◄────── poll_read(buf) ◄──────────── receive_buffer
 ///                          │                           └─► waker registration
-///                          └─► Poll::Pending/Ready     
+///                          └─► Poll::Pending/Ready
 /// ```
 ///
 /// ## TCP Semantics Implemented

--- a/crates/moonpool-sim/src/runner/builder.rs
+++ b/crates/moonpool-sim/src/runner/builder.rs
@@ -256,6 +256,9 @@ pub struct SimulationBuilder {
     network_fault_mask: crate::NetworkFaultMask,
     /// Distance-based link latency, applied to every iteration's network config.
     link_latency: Option<crate::network::LinkLatencyConfig>,
+    /// End-to-end byte window per stream direction, applied to every
+    /// iteration's network config; `None` keeps the default.
+    tcp_send_window_bytes: Option<usize>,
     /// Buggify-driven knob value-perturbation, enabled via [`Chaos::BuggifyKnobs`].
     /// Internal flag (not a public builder method) so the opt-in stays inside the
     /// `enable_chaos`/`Chaos` model.
@@ -311,6 +314,7 @@ impl SimulationBuilder {
             storage_chaos: None,
             network_fault_mask: crate::NetworkFaultMask::all(),
             link_latency: None,
+            tcp_send_window_bytes: None,
             buggify_knobs: false,
             swarm_operations: false,
             check_determinism: false,
@@ -500,6 +504,20 @@ impl SimulationBuilder {
     #[must_use]
     pub fn link_latency(mut self, config: crate::network::LinkLatencyConfig) -> Self {
         self.link_latency = Some(config);
+        self
+    }
+
+    /// Set the end-to-end byte window of every stream direction (see
+    /// [`NetworkConfiguration::tcp_send_window_bytes`](crate::NetworkConfiguration::tcp_send_window_bytes)).
+    ///
+    /// A small window makes a slow reader back its writer up early, which is
+    /// how flow-control bugs (a server that keeps streaming into a client
+    /// that stopped reading, a pipeline that deadlocks on its own replies)
+    /// become reachable in a short run. Deployment shape rather than chaos:
+    /// applied verbatim on every seed and consumes no draws.
+    #[must_use]
+    pub fn tcp_send_window_bytes(mut self, bytes: usize) -> Self {
+        self.tcp_send_window_bytes = Some(bytes);
         self
     }
 
@@ -1092,6 +1110,7 @@ impl SimulationBuilder {
         storage_chaos: Option<ChaosMode>,
         network_fault_mask: crate::NetworkFaultMask,
         link_latency: Option<crate::network::LinkLatencyConfig>,
+        tcp_send_window_bytes: Option<usize>,
         buggify_knobs: bool,
         seed: u64,
     ) -> crate::sim::SimWorld {
@@ -1123,6 +1142,9 @@ impl SimulationBuilder {
         // Distance latency is deployment shape, not a per-seed fault: it is
         // applied verbatim, whatever the chaos mode.
         network_config.link_latency = link_latency;
+        if let Some(window) = tcp_send_window_bytes {
+            network_config.tcp_send_window_bytes = window;
+        }
         let mut sim = crate::sim::SimWorld::new_with_network_config_and_seed(network_config, seed);
         // Unlike raw `SimWorld` use, a builder campaign has explicit phases.
         // Setup and the post-chaos quiet tail must not inherit the global sleep
@@ -1834,6 +1856,7 @@ impl SimulationBuilder {
             self.storage_chaos,
             self.network_fault_mask,
             self.link_latency.clone(),
+            self.tcp_send_window_bytes,
             self.buggify_knobs,
             seed,
         );
@@ -2225,8 +2248,15 @@ mod tests {
     ) -> (crate::NetworkConfiguration, u64) {
         crate::sim::reset_sim_rng();
         crate::sim::set_sim_seed(seed);
-        let sim =
-            SimulationBuilder::build_sim_for_iteration(Some(mode), None, mask, None, false, seed);
+        let sim = SimulationBuilder::build_sim_for_iteration(
+            Some(mode),
+            None,
+            mask,
+            None,
+            None,
+            false,
+            seed,
+        );
         let config = sim.with_network_config(Clone::clone);
         let draws_consumed = crate::sim::rng_call_count();
         (config, draws_consumed)

--- a/crates/moonpool-sim/tests/flow_control.rs
+++ b/crates/moonpool-sim/tests/flow_control.rs
@@ -1,0 +1,615 @@
+//! End-to-end TCP flow control: one byte window per stream direction.
+//!
+//! The window is acquired when a write is accepted and released only when
+//! the peer's application reads the bytes. Moving bytes from the send queue
+//! onto the wire, or from the wire into the peer's receive buffer, releases
+//! nothing: they are the same outstanding bytes in a different place. So a
+//! reader that stops reading backs the writer up end to end, a direction
+//! that stops delivering fills its window and blocks, and a partial read
+//! returns exactly the credit it consumed.
+//!
+//! The first half drives a raw `SimWorld` and checks the accounting after
+//! every event; the second half runs the metastability-shaped scenario (a
+//! server streaming into a slow client, under latency, partial I/O and a
+//! temporary partition) through `SimulationBuilder` with the determinism
+//! canary armed.
+
+use std::{
+    future::Future,
+    io,
+    net::IpAddr,
+    pin::{Pin, pin},
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    task::{Context, Poll, Wake, Waker},
+    time::Duration,
+};
+
+use async_trait::async_trait;
+use futures::{
+    future::poll_fn,
+    io::{AsyncRead, AsyncReadExt, AsyncWrite},
+    task::noop_waker,
+};
+use moonpool_sim::{
+    FaultContext, FaultInjector, LatencyDistribution, NetworkConfiguration, NetworkFaultMask,
+    NetworkProvider, Process, SimContext, SimWorld, SimulationBuilder, SimulationReport,
+    SimulationResult, TcpListenerTrait, TimeProvider, Workload, assert_always, assert_sometimes,
+    buggify_reset, network::sim::SimTcpStream,
+};
+
+const MAX_DRIVER_STEPS: usize = 100_000;
+
+fn client_ip() -> IpAddr {
+    "10.0.1.1".parse().expect("valid test IP")
+}
+
+fn server_ip() -> IpAddr {
+    "10.0.1.2".parse().expect("valid test IP")
+}
+
+fn drive<F: Future>(sim: &mut SimWorld, future: F) -> F::Output {
+    let mut future = pin!(future);
+    let waker = noop_waker();
+    let mut context = Context::from_waker(&waker);
+    for _ in 0..MAX_DRIVER_STEPS {
+        if let Poll::Ready(output) = future.as_mut().poll(&mut context) {
+            return output;
+        }
+        assert!(
+            sim.has_pending_events(),
+            "simulation-backed future stalled without a pending event"
+        );
+        sim.step();
+    }
+    panic!("simulation-backed future exceeded {MAX_DRIVER_STEPS} events")
+}
+
+fn poll_write_with(
+    stream: &mut (impl AsyncWrite + Unpin),
+    data: &[u8],
+    waker: &Waker,
+) -> Poll<io::Result<usize>> {
+    let mut context = Context::from_waker(waker);
+    Pin::new(stream).poll_write(&mut context, data)
+}
+
+fn poll_write_once(stream: &mut (impl AsyncWrite + Unpin), data: &[u8]) -> Poll<io::Result<usize>> {
+    poll_write_with(stream, data, &noop_waker())
+}
+
+fn poll_read_once(
+    stream: &mut (impl AsyncRead + Unpin),
+    data: &mut [u8],
+) -> Poll<io::Result<usize>> {
+    let waker = noop_waker();
+    let mut context = Context::from_waker(&waker);
+    Pin::new(stream).poll_read(&mut context, data)
+}
+
+fn poll_close_once(stream: &mut (impl AsyncWrite + Unpin)) -> Poll<io::Result<()>> {
+    let waker = noop_waker();
+    let mut context = Context::from_waker(&waker);
+    Pin::new(stream).poll_close(&mut context)
+}
+
+struct WakeCounter(AtomicUsize);
+
+impl Wake for WakeCounter {
+    fn wake(self: Arc<Self>) {
+        self.0.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+fn counting_waker() -> (Arc<WakeCounter>, Waker) {
+    let counter = Arc::new(WakeCounter(AtomicUsize::new(0)));
+    let waker = Waker::from(Arc::clone(&counter));
+    (counter, waker)
+}
+
+fn config(window: usize, latency: Duration) -> NetworkConfiguration {
+    let mut config = NetworkConfiguration::fast_local();
+    config.tcp_send_window_bytes = window;
+    config.write_latency = LatencyDistribution::Uniform {
+        start: latency,
+        end: latency,
+    };
+    config
+}
+
+fn connected(config: NetworkConfiguration) -> (SimWorld, SimTcpStream, SimTcpStream) {
+    buggify_reset();
+    let mut sim = SimWorld::new_with_network_config_and_seed(config, 20_260_905);
+    let server_provider = sim.network_provider(server_ip());
+    let listener = drive(&mut sim, server_provider.bind("10.0.1.2:8080")).expect("bind");
+    let client_provider = sim.network_provider(client_ip());
+    let client = drive(&mut sim, client_provider.connect("10.0.1.2:8080")).expect("connect");
+    let (server, _) = drive(&mut sim, listener.accept()).expect("accept");
+    sim.run_until_empty();
+    (sim, client, server)
+}
+
+/// Write until the window refuses, returning how much it took.
+fn fill_window(stream: &mut SimTcpStream, chunk: usize) -> usize {
+    let payload = vec![0x5a; chunk];
+    let mut written = 0;
+    loop {
+        match poll_write_once(stream, &payload) {
+            Poll::Ready(Ok(n)) => written += n,
+            Poll::Ready(Err(error)) => panic!("write failed: {error}"),
+            Poll::Pending => return written,
+        }
+    }
+}
+
+/// The accounting identity every event must preserve when nothing vanished.
+fn assert_accounted(sim: &SimWorld, sender: &SimTcpStream, receiver: &SimTcpStream) {
+    let outstanding = sim.outstanding_send_bytes(sender.connection_id());
+    assert!(outstanding <= sim.send_window_bytes(sender.connection_id()));
+    assert_eq!(
+        outstanding,
+        sim.queued_send_bytes(sender.connection_id())
+            + sim.in_flight_bytes(sender.connection_id())
+            + sim.unread_bytes(receiver.connection_id()),
+        "outstanding = queued + in flight + unread at the peer"
+    );
+}
+
+/// The central test: a writer that never sees its bytes read fills the
+/// window and parks, even once every byte sits in the peer's receive buffer;
+/// the peer's read hands back exactly what it consumed and wakes the writer.
+#[test]
+fn a_reader_that_never_reads_parks_the_writer_at_the_window() {
+    const WINDOW: usize = 64 * 1024;
+    let (mut sim, mut client, mut server) = connected(config(WINDOW, Duration::from_micros(1)));
+    assert_eq!(sim.send_window_bytes(client.connection_id()), WINDOW);
+
+    assert_eq!(fill_window(&mut client, 8 * 1024), WINDOW);
+    assert_eq!(sim.available_send_bytes(client.connection_id()), 0);
+
+    // Everything reaches the peer's receive buffer and still counts.
+    sim.run_until_empty();
+    assert_eq!(sim.unread_bytes(server.connection_id()), WINDOW);
+    assert_eq!(sim.outstanding_send_bytes(client.connection_id()), WINDOW);
+    assert_accounted(&sim, &client, &server);
+    let (wake_count, waker) = counting_waker();
+    assert!(poll_write_with(&mut client, b"x", &waker).is_pending());
+
+    // The reader takes 4 KiB: that, and only that, comes back.
+    let mut buf = vec![0_u8; 4096];
+    assert_eq!(
+        poll_read_once(&mut server, &mut buf).map(|result| result.expect("read")),
+        Poll::Ready(4096)
+    );
+    assert_eq!(
+        wake_count.0.load(Ordering::Relaxed),
+        1,
+        "the parked writer is woken"
+    );
+    assert_eq!(sim.available_send_bytes(client.connection_id()), 4096);
+    assert_eq!(
+        poll_write_once(&mut client, &vec![0_u8; 8192]).map(|result| result.expect("write")),
+        Poll::Ready(4096),
+        "the next write accepts at most what was read"
+    );
+    assert_accounted(&sim, &client, &server);
+}
+
+#[test]
+fn a_partial_read_releases_exactly_what_it_consumed() {
+    const WINDOW: usize = 1000;
+    let (mut sim, mut client, mut server) = connected(config(WINDOW, Duration::from_micros(1)));
+    assert_eq!(fill_window(&mut client, 1000), WINDOW);
+    sim.run_until_empty();
+
+    let mut buf = vec![0_u8; 137];
+    assert_eq!(
+        poll_read_once(&mut server, &mut buf).map(|result| result.expect("read")),
+        Poll::Ready(137)
+    );
+    assert_eq!(sim.available_send_bytes(client.connection_id()), 137);
+    assert_eq!(
+        sim.outstanding_send_bytes(client.connection_id()),
+        WINDOW - 137
+    );
+    assert_accounted(&sim, &client, &server);
+}
+
+/// A held flight stays outstanding: no credit comes back for delay.
+#[test]
+fn a_partition_returns_no_credit_until_the_peer_reads() {
+    const WINDOW: usize = 4096;
+    const PAYLOAD: &[u8] = b"held-and-still-charged";
+    let (mut sim, mut client, mut server) = connected(config(WINDOW, Duration::from_millis(10)));
+    assert_eq!(
+        poll_write_once(&mut client, PAYLOAD).map(|result| result.expect("write")),
+        Poll::Ready(PAYLOAD.len())
+    );
+    assert!(sim.step(), "the chunk goes on the wire");
+    sim.partition_pair(client_ip(), server_ip(), Duration::from_millis(200));
+    while sim.is_partitioned(client_ip(), server_ip()) {
+        assert!(sim.step());
+        assert_eq!(
+            sim.outstanding_send_bytes(client.connection_id()),
+            PAYLOAD.len()
+        );
+        assert_accounted(&sim, &client, &server);
+    }
+    let mut received = vec![0_u8; PAYLOAD.len()];
+    drive(&mut sim, server.read_exact(&mut received)).expect("the payload lands");
+    assert_eq!(sim.outstanding_send_bytes(client.connection_id()), 0);
+    assert_eq!(sim.available_send_bytes(client.connection_id()), WINDOW);
+}
+
+/// A black-holed direction accepts a window's worth and then blocks: a small
+/// RPC still goes in and times out at the application, a bulk transfer stops.
+#[test]
+fn a_black_hole_fills_its_window_and_then_applies_backpressure() {
+    const WINDOW: usize = 1024;
+    let (mut sim, mut client, mut server) = connected(config(WINDOW, Duration::from_micros(1)));
+    sim.black_hole_connection(client.connection_id(), true, false);
+
+    // The small request is accepted as before...
+    assert_eq!(
+        poll_write_once(&mut client, &[7; 100]).map(|result| result.expect("write")),
+        Poll::Ready(100)
+    );
+    sim.run_until_empty();
+    let mut buf = [0_u8; 256];
+    assert!(poll_read_once(&mut server, &mut buf).is_pending());
+    assert_eq!(
+        sim.outstanding_send_bytes(client.connection_id()),
+        100,
+        "swallowed bytes stay charged"
+    );
+
+    // ...but the direction cannot absorb data forever.
+    assert_eq!(fill_window(&mut client, 4096), WINDOW - 100);
+    sim.run_until_empty();
+    let (wake_count, waker) = counting_waker();
+    assert!(poll_write_with(&mut client, b"x", &waker).is_pending());
+    assert_eq!(sim.outstanding_send_bytes(client.connection_id()), WINDOW);
+    assert_eq!(
+        wake_count.0.load(Ordering::Relaxed),
+        0,
+        "nothing will ever wake it"
+    );
+    assert!(poll_read_once(&mut server, &mut buf).is_pending());
+}
+
+/// An abort wakes a parked writer to the error instead of leaving it on
+/// credits the connection can no longer return.
+#[test]
+fn an_abort_wakes_a_writer_parked_on_the_window() {
+    const WINDOW: usize = 1024;
+    let (mut sim, mut client, server) = connected(config(WINDOW, Duration::from_micros(1)));
+    assert_eq!(fill_window(&mut client, 4096), WINDOW);
+    sim.run_until_empty();
+    let (wake_count, waker) = counting_waker();
+    assert!(poll_write_with(&mut client, b"x", &waker).is_pending());
+
+    sim.close_connection_abort(server.connection_id());
+
+    assert_eq!(wake_count.0.load(Ordering::Relaxed), 1);
+    assert!(
+        matches!(poll_write_once(&mut client, b"x"), Poll::Ready(Err(_))),
+        "the woken writer observes the connection error, not another Pending"
+    );
+    assert_eq!(
+        sim.close_reason(client.connection_id()),
+        moonpool_sim::network::sim::CloseReason::Aborted
+    );
+}
+
+/// A peer that closes with the window's bytes unread frees them: the writer
+/// is woken and, on its next write, told the stream is gone.
+#[test]
+fn a_peer_close_with_unread_bytes_frees_the_window() {
+    const WINDOW: usize = 1024;
+    let (mut sim, mut client, mut server) = connected(config(WINDOW, Duration::from_micros(1)));
+    assert_eq!(fill_window(&mut client, 4096), WINDOW);
+    sim.run_until_empty();
+    assert_eq!(sim.unread_bytes(server.connection_id()), WINDOW);
+    let (wake_count, waker) = counting_waker();
+    assert!(poll_write_with(&mut client, b"x", &waker).is_pending());
+
+    assert!(matches!(poll_close_once(&mut server), Poll::Ready(Ok(()))));
+
+    assert_eq!(
+        wake_count.0.load(Ordering::Relaxed),
+        1,
+        "the writer is woken"
+    );
+    assert_eq!(sim.outstanding_send_bytes(client.connection_id()), 0);
+    assert_eq!(
+        poll_write_once(&mut client, b"after-close").map(|result| result.expect("write")),
+        Poll::Ready(11),
+        "writes into a closed peer are accepted, as before, and discarded"
+    );
+    sim.run_until_empty();
+    assert_eq!(
+        sim.outstanding_send_bytes(client.connection_id()),
+        0,
+        "what a closed peer discards on arrival is released too"
+    );
+    let mut byte = [0_u8; 1];
+    assert_eq!(
+        drive(&mut sim, client.read(&mut byte)).expect("read"),
+        0,
+        "the FIN arrives"
+    );
+}
+
+/// The FIN goes behind the last byte, even when the window held that byte
+/// back in the send queue.
+#[test]
+fn the_fin_never_overtakes_outstanding_data() {
+    const WINDOW: usize = 512;
+    let (mut sim, mut client, mut server) = connected(config(WINDOW, Duration::from_micros(1)));
+    let payload = (0..WINDOW)
+        .map(|i| u8::try_from(i % 251).expect("small"))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        poll_write_once(&mut client, &payload).map(|result| result.expect("write")),
+        Poll::Ready(WINDOW)
+    );
+    assert!(matches!(poll_close_once(&mut client), Poll::Ready(Ok(()))));
+
+    let mut received = vec![0_u8; WINDOW];
+    drive(&mut sim, server.read_exact(&mut received)).expect("every byte lands");
+    assert_eq!(received, payload);
+    let mut byte = [0_u8; 1];
+    assert_eq!(drive(&mut sim, server.read(&mut byte)).expect("read"), 0);
+}
+
+/// The budget stays bounded and exactly accounted through a whole scripted
+/// run: large latency, a slow reader taking small bites, a temporary cut.
+#[test]
+fn the_outstanding_budget_stays_bounded_under_latency_and_a_cut() {
+    const WINDOW: usize = 2048;
+    const TOTAL: usize = 16 * 1024;
+    let (mut sim, mut client, mut server) = connected(config(WINDOW, Duration::from_millis(50)));
+    let payload = (0..TOTAL)
+        .map(|i| u8::try_from(i % 253).expect("small"))
+        .collect::<Vec<_>>();
+    let mut written = 0;
+    let mut received = Vec::with_capacity(TOTAL);
+    let mut max_outstanding = 0;
+    let mut cut = false;
+    let mut steps = 0;
+    while received.len() < TOTAL {
+        if written < TOTAL
+            && let Poll::Ready(Ok(n)) = poll_write_once(&mut client, &payload[written..])
+        {
+            written += n;
+        }
+        // The reader takes small bites, and only every other event.
+        if steps % 2 == 0 {
+            let mut buf = [0_u8; 300];
+            if let Poll::Ready(Ok(n)) = poll_read_once(&mut server, &mut buf) {
+                received.extend_from_slice(&buf[..n]);
+            }
+        }
+        if !cut && received.len() > TOTAL / 4 {
+            sim.partition_pair(client_ip(), server_ip(), Duration::from_millis(300));
+            cut = true;
+        }
+        assert_accounted(&sim, &client, &server);
+        max_outstanding = max_outstanding.max(sim.outstanding_send_bytes(client.connection_id()));
+        if sim.has_pending_events() {
+            sim.step();
+        }
+        steps += 1;
+        assert!(steps < MAX_DRIVER_STEPS, "the transfer stalled");
+    }
+    assert_eq!(received, payload, "the stream arrives intact and in order");
+    assert_eq!(max_outstanding, WINDOW, "the writer ran up to the window");
+    assert_eq!(sim.outstanding_send_bytes(client.connection_id()), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Campaign: a server streaming into a slow client.
+// ---------------------------------------------------------------------------
+
+/// Bytes the server streams over one connection.
+const STREAM_LEN: usize = 48 * 1024;
+/// Window small enough that the streamer blocks many times per run.
+const CAMPAIGN_WINDOW: usize = 4096;
+const SERVER_PORT: u16 = 9000;
+
+fn expected_byte(index: usize) -> u8 {
+    u8::try_from(index % 241).expect("small")
+}
+
+/// Streams `STREAM_LEN` patterned bytes to every client, counting how often
+/// the window parked it.
+struct Streamer;
+
+#[async_trait]
+impl Process for Streamer {
+    fn name(&self) -> &'static str {
+        "streamer"
+    }
+
+    async fn run(&mut self, ctx: &SimContext) -> SimulationResult<()> {
+        let listener = ctx
+            .network()
+            .bind(&format!("{}:{SERVER_PORT}", ctx.my_ip()))
+            .await?;
+        loop {
+            let accepted = moonpool_sim::select! {
+                biased;
+                r = listener.accept() => r,
+                () = ctx.shutdown().cancelled() => return Ok(()),
+            };
+            let Ok((mut stream, _)) = accepted else {
+                continue;
+            };
+            let payload = (0..STREAM_LEN).map(expected_byte).collect::<Vec<_>>();
+            let mut written = 0;
+            let mut parked = 0_u64;
+            while written < payload.len() {
+                let result =
+                    poll_fn(
+                        |cx| match Pin::new(&mut stream).poll_write(cx, &payload[written..]) {
+                            Poll::Pending => {
+                                parked += 1;
+                                Poll::Pending
+                            }
+                            ready @ Poll::Ready(_) => ready,
+                        },
+                    )
+                    .await;
+                match result {
+                    Ok(n) => written += n,
+                    Err(_) => break,
+                }
+            }
+            assert_sometimes!(
+                parked > 0,
+                "flow control: the streamer parked on a full window"
+            );
+            assert_always!(
+                written <= payload.len(),
+                "flow control: the streamer never writes past its payload"
+            );
+        }
+    }
+}
+
+/// Reads the stream in small bites with a pause between them, checking the
+/// pattern as it goes.
+struct SlowReader;
+
+#[async_trait]
+impl Workload for SlowReader {
+    fn name(&self) -> &'static str {
+        "slow-reader"
+    }
+
+    async fn run(&mut self, ctx: &SimContext) -> SimulationResult<()> {
+        let server = ctx.topology().all_process_ips()[0].clone();
+        let mut stream = ctx
+            .network()
+            .connect(&format!("{server}:{SERVER_PORT}"))
+            .await?;
+        let mut received = 0;
+        let mut buf = [0_u8; 256];
+        while received < STREAM_LEN {
+            let n = stream.read(&mut buf).await?;
+            if n == 0 {
+                break;
+            }
+            for (offset, byte) in buf[..n].iter().enumerate() {
+                assert_always!(
+                    *byte == expected_byte(received + offset),
+                    "flow control: the slow reader sees the stream in order"
+                );
+            }
+            received += n;
+            let _ = ctx.time().sleep(Duration::from_millis(1)).await;
+        }
+        assert_always!(
+            received == STREAM_LEN,
+            "flow control: the slow reader receives the whole stream"
+        );
+        Ok(())
+    }
+}
+
+/// Cuts the client from the server for a while, twice, then stays quiet.
+struct TemporaryCut;
+
+#[async_trait]
+impl FaultInjector for TemporaryCut {
+    fn name(&self) -> &'static str {
+        "temporary-cut"
+    }
+
+    async fn inject(&mut self, ctx: &FaultContext) -> SimulationResult<()> {
+        let server = ctx.process_ips()[0].clone();
+        let client = "10.0.0.1";
+        for _ in 0..2 {
+            moonpool_sim::select! {
+                biased;
+                () = ctx.chaos_shutdown().cancelled() => return Ok(()),
+                _ = ctx.time().sleep(Duration::from_millis(40)) => {}
+            }
+            ctx.partition(client, &server)?;
+            moonpool_sim::select! {
+                biased;
+                () = ctx.chaos_shutdown().cancelled() => {}
+                _ = ctx.time().sleep(Duration::from_millis(60)) => {}
+            }
+            ctx.heal_partition(client, &server)?;
+        }
+        Ok(())
+    }
+}
+
+/// Latency, partial writes and reads (buggify is live in a campaign), the
+/// scripted cut, and nothing that could end the stream on its own: a random
+/// close or a hung connect would turn a flow-control run into a different
+/// test, and a bit flip would break the pattern check for a reason that is
+/// not the window.
+fn campaign() -> SimulationBuilder {
+    SimulationBuilder::new()
+        .processes(1, || Box::new(Streamer))
+        .workload_factory(|| Box::new(SlowReader))
+        .fault_factory(|| Box::new(TemporaryCut))
+        .network_fault_mask(NetworkFaultMask::none())
+        .tcp_send_window_bytes(CAMPAIGN_WINDOW)
+        .chaos_duration(Duration::from_secs(2))
+}
+
+fn sometimes_pass_count(report: &SimulationReport, message: &str) -> u64 {
+    report
+        .assertion_details
+        .iter()
+        .find(|detail| detail.msg == message)
+        .map_or(0, |detail| detail.pass_count)
+}
+
+/// The metastability shape: the streamer fills the window, parks, is woken
+/// by the slow reader, resumes — through latency, partial writes and reads,
+/// and a temporary cut — and every seed replays draw for draw.
+#[test]
+fn a_streamer_into_a_slow_reader_blocks_resumes_and_replays_deterministically() {
+    let report = campaign()
+        .check_determinism()
+        .set_iterations(4)
+        .set_debug_seeds(vec![1, 2, 3, 4])
+        .run();
+
+    assert_eq!(
+        report.failed_runs,
+        0,
+        "{:?} {:?} {:?}",
+        report.assertion_violations,
+        report.seeds_failing,
+        report
+            .individual_metrics
+            .iter()
+            .filter_map(|m| m.as_ref().err())
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(report.iterations, 4);
+    assert_eq!(
+        sometimes_pass_count(
+            &report,
+            "flow control: the streamer parked on a full window"
+        ),
+        8,
+        "the window parked the streamer on every seed, on the record run and the replay"
+    );
+    assert_eq!(
+        sometimes_pass_count(
+            &report,
+            "determinism canary: replay matched the recorded draw sequence"
+        ),
+        4,
+        "one canary verdict per seed"
+    );
+}

--- a/crates/moonpool-sim/tests/network.rs
+++ b/crates/moonpool-sim/tests/network.rs
@@ -2,6 +2,8 @@
 //!
 //! Contains tests for network simulation and configuration.
 
+#[path = "network/in_flight.rs"]
+mod in_flight;
 #[path = "network/latency.rs"]
 mod latency;
 #[path = "network/partition.rs"]

--- a/crates/moonpool-sim/tests/network/in_flight.rs
+++ b/crates/moonpool-sim/tests/network/in_flight.rs
@@ -1,0 +1,367 @@
+//! Faults reach traffic that is already on the wire.
+//!
+//! Every test fixes the write latency so the moment a chunk would land is
+//! known exactly, sends, waits until the chunk is in flight (it has left the
+//! send queue and has a delivery time), and only *then* injects the fault.
+//! The delivery time was sampled before the fault existed; the fault must
+//! still decide the chunk's fate. The semantic under test is the one the
+//! partition chapter documents: a cut **stalls** the stream and never punches
+//! a hole in it, so a held chunk lands after the heal, in order, with the
+//! flight time it still had left when it was frozen.
+
+use futures::{
+    io::{AsyncRead, AsyncReadExt, AsyncWrite},
+    task::noop_waker,
+};
+use moonpool_sim::{
+    LatencyDistribution, NetworkConfiguration, NetworkProvider, SimWorld, TcpListenerTrait,
+    buggify_reset, network::sim::SimTcpStream, reset_rng_call_count, rng_call_count,
+};
+use std::{
+    future::Future,
+    io,
+    net::IpAddr,
+    pin::{Pin, pin},
+    task::{Context, Poll},
+    time::Duration,
+};
+
+/// Every chunk lands this long after it is put on the wire.
+const LATENCY: Duration = Duration::from_millis(10);
+/// How long a scripted partition stays up on its own.
+const CUT: Duration = Duration::from_millis(200);
+/// How many events a driven future may consume before it is declared stuck.
+const MAX_DRIVER_STEPS: usize = 10_000;
+
+fn client_ip() -> IpAddr {
+    "10.0.1.1".parse().expect("valid test IP")
+}
+
+fn server_ip() -> IpAddr {
+    "10.0.1.2".parse().expect("valid test IP")
+}
+
+fn fixed_latency_config() -> NetworkConfiguration {
+    let mut config = NetworkConfiguration::fast_local();
+    config.write_latency = LatencyDistribution::Uniform {
+        start: LATENCY,
+        end: LATENCY,
+    };
+    config
+}
+
+/// Poll a simulation-backed future, advancing virtual time whenever it parks.
+fn drive<F: Future>(sim: &mut SimWorld, future: F) -> F::Output {
+    let mut future = pin!(future);
+    let waker = noop_waker();
+    let mut context = Context::from_waker(&waker);
+    for _ in 0..MAX_DRIVER_STEPS {
+        if let Poll::Ready(output) = future.as_mut().poll(&mut context) {
+            return output;
+        }
+        assert!(
+            sim.has_pending_events(),
+            "simulation-backed future stalled without a pending event"
+        );
+        sim.step();
+    }
+    panic!("simulation-backed future exceeded {MAX_DRIVER_STEPS} events")
+}
+
+fn poll_write_once(stream: &mut (impl AsyncWrite + Unpin), data: &[u8]) -> Poll<io::Result<usize>> {
+    let waker = noop_waker();
+    let mut context = Context::from_waker(&waker);
+    Pin::new(stream).poll_write(&mut context, data)
+}
+
+fn poll_read_once(
+    stream: &mut (impl AsyncRead + Unpin),
+    data: &mut [u8],
+) -> Poll<io::Result<usize>> {
+    let waker = noop_waker();
+    let mut context = Context::from_waker(&waker);
+    Pin::new(stream).poll_read(&mut context, data)
+}
+
+fn poll_close_once(stream: &mut (impl AsyncWrite + Unpin)) -> Poll<io::Result<()>> {
+    let waker = noop_waker();
+    let mut context = Context::from_waker(&waker);
+    Pin::new(stream).poll_close(&mut context)
+}
+
+/// An established, settled connection between `10.0.1.1` and `10.0.1.2`.
+fn connected() -> (SimWorld, SimTcpStream, SimTcpStream) {
+    buggify_reset();
+    let mut sim = SimWorld::new_with_network_config_and_seed(fixed_latency_config(), 20_260_905);
+    let server_provider = sim.network_provider(server_ip());
+    let listener = drive(&mut sim, server_provider.bind("10.0.1.2:8080")).expect("bind");
+    let client_provider = sim.network_provider(client_ip());
+    let client = drive(&mut sim, client_provider.connect("10.0.1.2:8080")).expect("connect");
+    let (server, _) = drive(&mut sim, listener.accept()).expect("accept");
+    sim.run_until_empty();
+    assert_eq!(sim.pending_event_count(), 0, "the handshake has settled");
+    (sim, client, server)
+}
+
+/// Write `data` and drain it onto the wire, so it is in flight with a known
+/// delivery time and nothing left in the send queue.
+fn put_on_the_wire(sim: &mut SimWorld, stream: &mut SimTcpStream, data: &[u8]) {
+    let before = sim.in_flight_bytes(stream.connection_id());
+    assert_eq!(
+        poll_write_once(stream, data).map(|result| result.expect("write is accepted")),
+        Poll::Ready(data.len())
+    );
+    assert!(sim.step(), "the engine drains the queued send");
+    assert_eq!(sim.queued_send_bytes(stream.connection_id()), 0);
+    assert_eq!(
+        sim.in_flight_bytes(stream.connection_id()),
+        before + data.len(),
+        "the chunk is on the wire"
+    );
+}
+
+fn assert_nothing_readable(sim: &SimWorld, stream: &mut SimTcpStream) {
+    let mut byte = [0_u8; 1];
+    assert!(
+        poll_read_once(stream, &mut byte).is_pending(),
+        "no byte and no EOF crosses the cut"
+    );
+    assert_eq!(sim.unread_bytes(stream.connection_id()), 0);
+}
+
+/// The central case: the chunk is in flight, its delivery time already
+/// sampled, when the partition lands. It must not cross, and once the cut
+/// heals it lands with exactly the flight time it had left.
+#[test]
+fn a_partition_after_the_send_holds_the_bytes_in_flight() {
+    const PAYLOAD: &[u8] = b"response-already-on-the-wire";
+    let (mut sim, mut client, mut server) = connected();
+    let sent_at = sim.now();
+    put_on_the_wire(&mut sim, &mut client, PAYLOAD);
+
+    sim.partition_pair(client_ip(), server_ip(), CUT);
+    assert!(sim.is_in_flight_held(client.connection_id()));
+
+    // The original delivery time comes and goes.
+    assert!(sim.step());
+    assert_eq!(
+        sim.now(),
+        sent_at + LATENCY,
+        "the stale delivery event fired"
+    );
+    assert!(sim.is_partitioned(client_ip(), server_ip()));
+    assert_nothing_readable(&sim, &mut server);
+    assert_eq!(sim.in_flight_bytes(client.connection_id()), PAYLOAD.len());
+
+    // The cut expires: the flight thaws, but the bytes still need the
+    // remaining flight time, so nothing has landed yet.
+    assert!(sim.step());
+    assert_eq!(sim.now(), sent_at + CUT);
+    assert!(!sim.is_partitioned(client_ip(), server_ip()));
+    assert!(!sim.is_in_flight_held(client.connection_id()));
+    assert_nothing_readable(&sim, &mut server);
+
+    let mut received = vec![0_u8; PAYLOAD.len()];
+    drive(&mut sim, server.read_exact(&mut received)).expect("the payload lands after the heal");
+    assert_eq!(received, PAYLOAD);
+    assert_eq!(
+        sim.now(),
+        sent_at + LATENCY + CUT,
+        "a cut of D delays a caught chunk by exactly D"
+    );
+}
+
+/// A cut healed by hand releases the flight from that instant, not from the
+/// deadline it was cut under.
+#[test]
+fn healing_by_hand_releases_the_held_flight_with_its_remaining_time() {
+    const PAYLOAD: &[u8] = b"held-then-released";
+    let (mut sim, mut client, mut server) = connected();
+    put_on_the_wire(&mut sim, &mut client, PAYLOAD);
+    sim.partition_pair(client_ip(), server_ip(), Duration::from_hours(1));
+    assert!(sim.step(), "the stale delivery event fires under the cut");
+    assert_nothing_readable(&sim, &mut server);
+    let healed_at = sim.now();
+
+    sim.restore_partition(client_ip(), server_ip());
+    assert_nothing_readable(&sim, &mut server);
+
+    let mut received = vec![0_u8; PAYLOAD.len()];
+    drive(&mut sim, server.read_exact(&mut received)).expect("the payload lands");
+    assert_eq!(received, PAYLOAD);
+    assert_eq!(
+        sim.now().saturating_sub(healed_at),
+        LATENCY,
+        "the chunk was frozen the instant it was sent, so it needs its whole flight"
+    );
+}
+
+/// A directed cut holds one direction and leaves the other flowing.
+#[test]
+fn a_directional_partition_holds_only_the_cut_direction() {
+    const PING: &[u8] = b"ping-towards-the-server";
+    const PONG: &[u8] = b"pong-towards-the-client";
+    let (mut sim, mut client, mut server) = connected();
+    let sent_at = sim.now();
+    put_on_the_wire(&mut sim, &mut client, PING);
+    put_on_the_wire(&mut sim, &mut server, PONG);
+
+    sim.partition_pair(client_ip(), server_ip(), CUT);
+    assert!(sim.is_in_flight_held(client.connection_id()));
+    assert!(!sim.is_in_flight_held(server.connection_id()));
+
+    let mut towards_client = vec![0_u8; PONG.len()];
+    drive(&mut sim, client.read_exact(&mut towards_client))
+        .expect("the unaffected direction lands");
+    assert_eq!(towards_client, PONG);
+    assert_eq!(sim.now(), sent_at + LATENCY);
+    assert_nothing_readable(&sim, &mut server);
+
+    let mut towards_server = vec![0_u8; PING.len()];
+    drive(&mut sim, server.read_exact(&mut towards_server))
+        .expect("the cut direction lands after the heal");
+    assert_eq!(towards_server, PING);
+    assert_eq!(sim.now(), sent_at + LATENCY + CUT);
+}
+
+/// Send-wide and receive-wide cuts hold the flight like a pair cut does.
+#[test]
+fn send_and_recv_partitions_hold_the_flight_too() {
+    const PAYLOAD: &[u8] = b"held-by-a-node-wide-cut";
+    for cut in [
+        |sim: &SimWorld| sim.partition_send_from(client_ip(), CUT),
+        |sim: &SimWorld| sim.partition_recv_to(server_ip(), CUT),
+    ] {
+        let (mut sim, mut client, mut server) = connected();
+        let sent_at = sim.now();
+        put_on_the_wire(&mut sim, &mut client, PAYLOAD);
+        cut(&sim);
+        assert!(sim.is_in_flight_held(client.connection_id()));
+        assert!(sim.step(), "the stale delivery event fires under the cut");
+        assert_nothing_readable(&sim, &mut server);
+
+        let mut received = vec![0_u8; PAYLOAD.len()];
+        drive(&mut sim, server.read_exact(&mut received)).expect("the payload lands");
+        assert_eq!(received, PAYLOAD);
+        assert_eq!(sim.now(), sent_at + LATENCY + CUT);
+    }
+}
+
+/// Chunks on both sides of the cut keep their order: two already in flight,
+/// one queued behind the cut, all three land as written.
+#[test]
+fn healing_never_lets_a_later_chunk_overtake_an_earlier_one() {
+    const FIRST: &[u8] = b"first-in-flight";
+    const SECOND: &[u8] = b"second-in-flight";
+    const THIRD: &[u8] = b"third-queued-behind-the-cut";
+    let (mut sim, mut client, mut server) = connected();
+    put_on_the_wire(&mut sim, &mut client, FIRST);
+    put_on_the_wire(&mut sim, &mut client, SECOND);
+
+    sim.partition_pair(client_ip(), server_ip(), CUT);
+    assert_eq!(
+        poll_write_once(&mut client, THIRD).map(|result| result.expect("write is accepted")),
+        Poll::Ready(THIRD.len())
+    );
+    assert!(sim.step(), "the queued send stalls under the cut");
+    assert_eq!(sim.queued_send_bytes(client.connection_id()), THIRD.len());
+    assert_eq!(
+        sim.in_flight_bytes(client.connection_id()),
+        FIRST.len() + SECOND.len()
+    );
+    // Both stale delivery events fire under the cut.
+    while sim.is_partitioned(client_ip(), server_ip()) {
+        assert!(sim.step());
+    }
+    assert_nothing_readable(&sim, &mut server);
+
+    let mut received = vec![0_u8; FIRST.len() + SECOND.len() + THIRD.len()];
+    drive(&mut sim, server.read_exact(&mut received)).expect("all three chunks land");
+    assert_eq!(
+        received,
+        [FIRST, SECOND, THIRD].concat(),
+        "the stream is delivered in the order it was written"
+    );
+}
+
+/// A FIN on the wire is held with the data ahead of it: the peer sees neither
+/// the bytes nor EOF through the cut, then both, in that order.
+#[test]
+fn an_in_flight_fin_does_not_cross_a_partition() {
+    const PAYLOAD: &[u8] = b"last-bytes-before-the-fin";
+    let (mut sim, mut client, mut server) = connected();
+    put_on_the_wire(&mut sim, &mut client, PAYLOAD);
+    assert!(matches!(poll_close_once(&mut client), Poll::Ready(Ok(()))));
+
+    sim.partition_pair(client_ip(), server_ip(), CUT);
+    while sim.is_partitioned(client_ip(), server_ip()) {
+        assert!(sim.step());
+    }
+    assert_nothing_readable(&sim, &mut server);
+
+    let mut received = vec![0_u8; PAYLOAD.len()];
+    drive(&mut sim, server.read_exact(&mut received)).expect("the data lands first");
+    assert_eq!(received, PAYLOAD);
+    let mut byte = [0_u8; 1];
+    let eof = drive(&mut sim, server.read(&mut byte)).expect("then the FIN");
+    assert_eq!(eof, 0, "EOF follows the last byte, never precedes it");
+}
+
+/// A graceful close issued *under* the cut puts its FIN behind the held data.
+#[test]
+fn a_close_under_the_partition_queues_its_fin_behind_the_held_data() {
+    const PAYLOAD: &[u8] = b"data-frozen-before-the-close";
+    let (mut sim, mut client, mut server) = connected();
+    put_on_the_wire(&mut sim, &mut client, PAYLOAD);
+    sim.partition_pair(client_ip(), server_ip(), CUT);
+    assert!(matches!(poll_close_once(&mut client), Poll::Ready(Ok(()))));
+    while sim.is_partitioned(client_ip(), server_ip()) {
+        assert!(sim.step());
+    }
+    assert_nothing_readable(&sim, &mut server);
+
+    let mut received = vec![0_u8; PAYLOAD.len()];
+    drive(&mut sim, server.read_exact(&mut received)).expect("the data lands first");
+    assert_eq!(received, PAYLOAD);
+    let mut byte = [0_u8; 1];
+    assert_eq!(
+        drive(&mut sim, server.read(&mut byte)).expect("then the FIN"),
+        0
+    );
+}
+
+/// Recovery mode heals the cut and re-drives the held flight without a
+/// single new draw on the simulation stream.
+#[test]
+fn recovery_mode_releases_the_held_flight_without_drawing() {
+    const PAYLOAD: &[u8] = b"released-by-the-recovery-boundary";
+    let (mut sim, mut client, mut server) = connected();
+    put_on_the_wire(&mut sim, &mut client, PAYLOAD);
+    sim.partition_pair(client_ip(), server_ip(), Duration::from_hours(1));
+    assert!(sim.step(), "the stale delivery event fires under the cut");
+    assert_nothing_readable(&sim, &mut server);
+
+    reset_rng_call_count();
+    sim.enter_recovery_mode();
+    assert!(!sim.is_partitioned(client_ip(), server_ip()));
+    let mut received = vec![0_u8; PAYLOAD.len()];
+    drive(&mut sim, server.read_exact(&mut received)).expect("the payload lands");
+    assert_eq!(received, PAYLOAD);
+    assert_eq!(
+        rng_call_count(),
+        0,
+        "healing and re-driving the flight is entropy-neutral"
+    );
+}
+
+/// A black hole opened while the chunk is in flight swallows it at landing.
+#[test]
+fn a_black_hole_opened_mid_flight_swallows_the_chunk() {
+    const PAYLOAD: &[u8] = b"into-the-void-mid-flight";
+    let (mut sim, mut client, mut server) = connected();
+    put_on_the_wire(&mut sim, &mut client, PAYLOAD);
+    sim.black_hole_connection(client.connection_id(), true, false);
+    sim.run_until_empty();
+    assert_eq!(sim.in_flight_bytes(client.connection_id()), 0);
+    assert_nothing_readable(&sim, &mut server);
+}

--- a/crates/moonpool-sim/tests/network/latency.rs
+++ b/crates/moonpool-sim/tests/network/latency.rs
@@ -184,6 +184,7 @@ fn test_custom_latency_configuration() {
             write_latency: uniform(Duration::from_millis(2), Duration::from_millis(2)),
             link_latency: None,
             chaos: ChaosConfiguration::disabled(),
+            ..NetworkConfiguration::default()
         };
 
         let mut sim = SimWorld::new_with_network_config(config);
@@ -229,6 +230,7 @@ fn test_latency_range_sampling() {
             write_latency: uniform(Duration::from_millis(1), Duration::from_millis(6)),
             link_latency: None,
             chaos: ChaosConfiguration::disabled(),
+            ..NetworkConfiguration::default()
         };
 
         let mut execution_times = Vec::new();
@@ -283,6 +285,7 @@ fn test_network_randomization_ranges() {
             write_latency: uniform(Duration::from_micros(500), Duration::from_micros(500)),
             link_latency: None,
             chaos: ChaosConfiguration::disabled(),
+            ..NetworkConfiguration::default()
         };
 
         let mut sim = SimWorld::new_with_network_config(config);

--- a/crates/moonpool-sim/tests/network/partition.rs
+++ b/crates/moonpool-sim/tests/network/partition.rs
@@ -266,7 +266,7 @@ fn a_partition_between_chunks_never_leaves_a_hole_in_the_stream() {
     sim.run_until_empty();
     assert_eq!(sim.pending_event_count(), 0, "the handshake has settled");
 
-    let capacity = sim.available_send_buffer(client.connection_id());
+    let capacity = sim.available_send_bytes(client.connection_id());
     assert_eq!(
         poll_write_once(&mut client, FIRST).map(|result| result.expect("first chunk is accepted")),
         Poll::Ready(FIRST.len())
@@ -278,7 +278,7 @@ fn a_partition_between_chunks_never_leaves_a_hole_in_the_stream() {
     assert!(sim.step(), "the engine drains the queued send");
 
     assert_eq!(
-        sim.available_send_buffer(client.connection_id()),
+        sim.available_send_bytes(client.connection_id()),
         capacity - FIRST.len(),
         "a partitioned send holds its bytes instead of dropping them"
     );

--- a/crates/moonpool-sim/tests/raw_network_characterization.rs
+++ b/crates/moonpool-sim/tests/raw_network_characterization.rs
@@ -122,13 +122,14 @@ fn scalar_and_vectored_writes_share_partial_backpressure_semantics() {
         drive(&mut sim, provider.connect("backpressure-listener")).expect("scalar client connects");
     let mut vectored = drive(&mut sim, provider.connect("backpressure-listener"))
         .expect("vectored client connects");
-    let (_scalar_server, _) = drive(&mut sim, listener.accept()).expect("accept scalar client");
-    let (_vectored_server, _) = drive(&mut sim, listener.accept()).expect("accept vectored client");
+    let (mut scalar_server, _) = drive(&mut sim, listener.accept()).expect("accept scalar client");
+    let (mut vectored_server, _) =
+        drive(&mut sim, listener.accept()).expect("accept vectored client");
 
-    let capacity = sim.available_send_buffer(scalar.connection_id());
+    let capacity = sim.available_send_bytes(scalar.connection_id());
     assert!(capacity > 0, "a fresh connection has send capacity");
     assert_eq!(
-        sim.available_send_buffer(vectored.connection_id()),
+        sim.available_send_bytes(vectored.connection_id()),
         capacity,
         "fresh connections use the same send capacity"
     );
@@ -145,15 +146,21 @@ fn scalar_and_vectored_writes_share_partial_backpressure_semantics() {
 
     assert_eq!(scalar_accepted, Poll::Ready(capacity));
     assert_eq!(vectored_accepted, Poll::Ready(capacity));
-    assert_eq!(sim.available_send_buffer(scalar.connection_id()), 0);
-    assert_eq!(sim.available_send_buffer(vectored.connection_id()), 0);
+    assert_eq!(sim.available_send_bytes(scalar.connection_id()), 0);
+    assert_eq!(sim.available_send_bytes(vectored.connection_id()), 0);
     assert!(poll_write_once(&mut scalar, b"x").is_pending());
     assert!(poll_write_once(&mut vectored, b"x").is_pending());
 
-    // Processing the queued sends releases capacity for both forms.
+    // Draining the queue onto the wire releases nothing: the window is
+    // end-to-end, and only the peer's read returns it, for both forms.
     sim.run_until_empty();
-    assert!(sim.available_send_buffer(scalar.connection_id()) > 0);
-    assert!(sim.available_send_buffer(vectored.connection_id()) > 0);
+    assert_eq!(sim.available_send_bytes(scalar.connection_id()), 0);
+    assert_eq!(sim.available_send_bytes(vectored.connection_id()), 0);
+    let mut sink = vec![0_u8; 1024];
+    let read = drive(&mut sim, scalar_server.read(&mut sink)).expect("scalar peer reads");
+    assert_eq!(sim.available_send_bytes(scalar.connection_id()), read);
+    let read = drive(&mut sim, vectored_server.read(&mut sink)).expect("vectored peer reads");
+    assert_eq!(sim.available_send_bytes(vectored.connection_id()), read);
 }
 
 #[test]
@@ -166,12 +173,12 @@ fn no_progress_io_polls_do_not_consume_simulation_rng() {
         drive(&mut sim, provider.connect("poll-entropy-listener")).expect("client connects");
     let (mut server, _) = drive(&mut sim, listener.accept()).expect("server accepts");
 
-    let capacity = sim.available_send_buffer(client.connection_id());
+    let capacity = sim.available_send_bytes(client.connection_id());
     let payload = vec![0x5a; capacity];
     let accepted = poll_write_once(&mut client, &payload)
         .map(|result| result.expect("initial write succeeds"));
     assert_eq!(accepted, Poll::Ready(capacity));
-    assert_eq!(sim.available_send_buffer(client.connection_id()), 0);
+    assert_eq!(sim.available_send_bytes(client.connection_id()), 0);
 
     let mut chaos = NetworkConfiguration::fast_local();
     chaos.chaos.random_close_probability = 0.5;


### PR DESCRIPTION
Two related changes to the simulated network, one commit each.

## 1. Faults reach traffic already in flight

**Before.** A chunk that left the send queue travelled *inside* its scheduled `DataDelivery { data }` event. Once the write latency was sampled, nothing could touch it: `handle_data_delivery` checked the receiver's close flags and the black hole, never a partition. So a response written at t=0 with 100ms of latency crossed a partition that started at t=50ms, and so did an in-flight FIN. Only the chunk still sitting in the queue stalled.

**After.** The bytes live in the engine, in a per-connection `in_flight` queue owned by the sender (`InFlight { seq, deliver_at, payload: Data | Fin }`). The scheduler event is a payload-free wake-up, `NetworkEvent::Delivery { connection_id, seq }`. A delivery lands only from the head of the flight, only once `deliver_at` has passed, and never while the direction is held, so faults are judged at landing:

- every partition insertion (pair, send-wide, receive-wide, random strategies) freezes the flight of each direction it cuts;
- every heal (deadline, `restore_partition`, recovery mode) re-times each frozen item by exactly the time the direction spent cut and re-schedules it, so a cut of D delays every byte it caught by D, the stream stays FIFO, and no randomness is drawn;
- a black hole opened mid-flight swallows the chunk at landing; an abort discards the flight with the queue;
- the FIN is an in-flight item behind the data, so it can neither overtake the last bytes nor cross a cut ahead of them.

Semantics stay the documented FDB-style one: a partition stalls the stream and never punches a hole in it.

## 2. End-to-end TCP flow control

**Before.** The 64 KiB send buffer only bounded the local queue. `ProcessSendBuffer` released capacity the moment a chunk left the queue, so a writer could run forever as long as the engine kept moving bytes into the scheduler and then into an unbounded receive buffer. A reader that stopped reading never backed its writer up.

**After.** Each direction has one `SendWindow` (`NetworkConfiguration::tcp_send_window_bytes`, `SimulationBuilder::tcp_send_window_bytes`, default 64 KiB as before):

```
outstanding = queued + in_flight + unread_at_peer (+ vanished)
outstanding <= capacity
```

Credit is acquired when `poll_write` accepts bytes and released only when the peer's `poll_read` hands them to its application, byte for byte (a 137-byte partial read returns 137 bytes). Moving bytes between the queue, the wire and the receive buffer releases nothing. A partition returns no credit; a black hole never returns it, so a black-holed direction accepts a window's worth (the small RPC that must time out at the application still goes in) and then blocks; an abort discards everything and wakes a parked writer to the error; a peer that closes with bytes unread frees them. `SendWindow::acquire`/`release` assert instead of saturating, so an over-acquire or double release panics.

Backpressure is entropy-neutral: a `Poll::Pending` on a full window, the wake after a read, and every move between the three places consume no simulation randomness. The campaign test runs under `check_determinism`.

## Tests

- `tests/network/in_flight.rs` (fixed 10ms latency): partition after the send with exact landing time, heal by hand, directionality, send-wide and receive-wide cuts, FIFO across the cut boundary, in-flight FIN, close under the cut, recovery mode with zero RNG draws, mid-flight black hole.
- `tests/flow_control.rs`: writer parks at 64 KiB even with every byte in the receive buffer and a 4 KiB read lets exactly 4 KiB through; partial-read credit; partition returns nothing until the read; black-hole backpressure; abort and peer close wake a parked writer; FIN behind data; a scripted run under 50ms latency, small partial reads and a temporary cut asserting the accounting identity after every event; and the `SimulationBuilder` campaign (streamer into a slow reader, 4 KiB window, partial I/O, latency, two scripted cuts) with the determinism canary green on every seed.
- `SendWindow` unit tests pin the double-release and over-acquire panics.

## API changes

- `NetworkEvent::DataDelivery` / `FinDelivery` become `NetworkEvent::Delivery { connection_id, seq }`; `NetworkEvent` is now `Copy`.
- `SimWorld::send_buffer_capacity/send_buffer_used/available_send_buffer` become `send_window_bytes/outstanding_send_bytes/available_send_bytes`; `queued_send_bytes`, `in_flight_bytes`, `unread_bytes`, `is_in_flight_held` added.
- `NetworkConfiguration::tcp_send_window_bytes` (+ `DEFAULT_TCP_SEND_WINDOW_BYTES`) and `SimulationBuilder::tcp_send_window_bytes`.

Book: partition section documents the four-stage byte lifecycle and the freeze/thaw rule; new Flow control section; scope chapter no longer lists TCP backpressure as unmodelled; event-trace and config appendix updated.

## Validation

`cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `clippy -p moonpool-sim --no-default-features --all-targets -- -D warnings`, `cargo check --target wasm32-unknown-unknown -p moonpool-sim --no-default-features`, `cargo nextest run --workspace` (770 passed), `mdbook build book/`.

## Known gaps, tracked separately

- #203 connect establishment still ignores partitions
- #204 a closed peer still accepts and discards later writes rather than answering RST
- #205 send-window occupancy is not yet exposed as metrics
- #206 congestion control, retransmission and segment boundaries are recorded as non-goals

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VXnMuFCFvF66WYwXUyXDJz