### PR TITLE
fix(moonpool-hyper): expire reset streams by count, never by the wall clock

### DIFF
--- a/book/src/part4-integration/08-hyper-stack.md
+++ b/book/src/part4-integration/08-hyper-stack.md
@@ -177,6 +177,20 @@ and perturb later simulated network choices. `H2Server` disables the automatic
 header. A production caller using the builder escape hatch can re-enable it, or
 the service can provide a date from an application-controlled clock.
 
+**Reset streams do not expire on the wall clock.** h2 keeps a locally reset
+stream around for a while so late frames for it can be ignored, and it judges
+that expiry on `std::time::Instant::now()` — the one clock hyper's `Timer` does
+not reach — after one real second by default. A simulation that takes longer
+than that in wall time then expires those streams at a simulated instant that
+depends on how fast the machine is, and the client connection's "last stream
+closed" self-wake lands on a different poll from run to run (paros's
+determinism canary caught it as a draw that diverged at the same simulated
+nanosecond with the two fingerprints swapped between processes).
+`ReconnectingChannel` sets `reset_stream_duration` to `Duration::MAX`, so the
+count cap (`max_concurrent_reset_streams`) is the only bound on them, which is
+deterministic. hyper exposes no such knob on the server builder, so a server
+that resets streams keeps a residual dependence on wall time there.
+
 **A connection has to earn its reset.** The failure count that drives the
 backoff clears only once a connection has survived `initial_reconnect_delay`,
 not the moment the handshake completes. Without that rule, a peer that accepts

--- a/crates/moonpool-hyper/src/client/reconnect.rs
+++ b/crates/moonpool-hyper/src/client/reconnect.rs
@@ -629,6 +629,17 @@ where
         shared.providers.task().clone(),
     ));
     builder.timer(HyperTimer::new(shared.providers.time().clone()));
+    // h2 expires locally reset streams on `std::time::Instant::now()` — the
+    // one clock hyper's `Timer` does not reach — after a default of one real
+    // second (`h2::proto::DEFAULT_RESET_STREAM_SECS`). A simulation that runs
+    // longer than that in wall time expires them at a wall-clock-dependent
+    // simulated instant, and the client connection's "last stream closed"
+    // self-wake then lands on a different poll from run to run. An
+    // effectively infinite duration leaves the count cap
+    // (`max_concurrent_reset_streams`) as the only bound, which is
+    // deterministic; the same reasoning disables hyper's `Date` header on
+    // the server side.
+    builder.reset_stream_duration(Duration::MAX);
     if let Some(keep_alive) = &shared.config.keep_alive {
         builder
             .keep_alive_interval(keep_alive.interval)

--- a/crates/moonpool-hyper/src/lib.rs
+++ b/crates/moonpool-hyper/src/lib.rs
@@ -26,6 +26,15 @@
 //! providers: h2 keepalive pings and timeouts read the provider clock, and
 //! hyper's internal futures are provider tasks. Inside a simulation that makes
 //! connection lifecycles reproducible from a seed, chaos included.
+//!
+//! Two clock reads sit below hyper's `Timer` and are neutralised rather than
+//! routed: the server's automatic `Date` header (disabled, [`H2Server`]) and
+//! h2's expiry of locally reset streams, which is judged on
+//! `std::time::Instant::now()` after one real second by default — the client
+//! sets `reset_stream_duration` to `Duration::MAX` so the count cap alone
+//! bounds them ([`ReconnectingChannel`]). hyper exposes no such knob on the
+//! server side, so a server that resets streams keeps a residual dependence on
+//! wall time there.
 
 #![deny(missing_docs)]
 #![deny(clippy::unwrap_used)]


### PR DESCRIPTION
Closes #208.

h2 keeps a locally reset stream in `pending_reset_expired` and expires it in `clear_expired_reset_streams` on `std::time::Instant::now()` — the one clock hyper's `Timer` does not reach — after `DEFAULT_RESET_STREAM_SECS = 1` real second. A simulation that takes longer than that in wall time expires those streams at a simulated instant that depends on machine speed, and the h2 client `Connection::poll` self-wake ("last stream closed during poll, wake again") then lands on a different executor poll from run to run.

paros's determinism canary caught it (seed `7039269808687777003` on paros `3484b13`, red on roughly nine replays in ten): the replay diverged at the same simulated nanosecond, the two fingerprints swapped between processes, and the first differing draw was the network read coin of an h2 client task the record had polled once more at that instant; the divergence point moved with machine load. Freezing h2's reset clock made the seed green 3/3; this change — `reset_stream_duration(Duration::MAX)` on the client builder, against the unpatched h2 — does the same, and a 300-seed canary under it is 300/300. Full diagnosis in #208.

With an effectively infinite duration the count cap (`max_concurrent_reset_streams`) is the only bound on reset streams, which is deterministic; the same reasoning already disables hyper's automatic `Date` header on the server side. hyper exposes no `reset_stream_duration` on its server builder, so a server that resets streams keeps a residual dependence on wall time; recorded in the crate's *Determinism* docs and the book's hyper chapter.

Validation: `cargo fmt`, `cargo clippy -p moonpool-hyper --all-targets -- -D warnings`, `cargo nextest run -p moonpool-hyper` (40 passed), `mdbook build book/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179he2pVLhqkJPktD53dDRB