### PR TITLE
fix(moonpool-sim): count a failing Workload::check() as a failed run

### DIFF
--- a/book/src/part2-foundations/10-workload.md
+++ b/book/src/part2-foundations/10-workload.md
@@ -81,7 +81,7 @@ async fn run(&mut self, ctx: &SimContext) -> SimulationResult<()> {
 
 `check()` runs **sequentially** after all workloads finish and all pending events drain. The system is quiescent. No more messages in flight, no more timeouts pending.
 
-Use check for final state validation. Did the conservation law hold? Are all balances non-negative? Did every committed write survive?
+Use check for final state validation. Did the conservation law hold? Are all balances non-negative? Did every committed write survive? The verdict counts: a `check()` that returns `Err` (or panics) fails the seed exactly as a failing `run()` does, even when every `run()` returned `Ok`.
 
 ```rust
 async fn check(&mut self, _ctx: &SimContext) -> SimulationResult<()> {

--- a/crates/moonpool-sim/src/runner/orchestrator.rs
+++ b/crates/moonpool-sim/src/runner/orchestrator.rs
@@ -553,7 +553,7 @@ impl WorkloadOrchestrator {
         Self::pump_observability(sim, obs);
 
         // === 7. CHECK PHASE (executor spawn + cooperative stepping) ===
-        let final_workloads = Self::do_check_phase(CheckPhaseInputs {
+        let (final_workloads, check_results) = Self::do_check_phase(CheckPhaseInputs {
             sim,
             metrics,
             workloads: returned_workloads,
@@ -566,6 +566,11 @@ impl WorkloadOrchestrator {
         })
         .await
         .map_err(|()| (vec![seed], 1usize))?;
+        // A `check()` verdict is part of the iteration's result: a workload
+        // whose `run()` succeeded but whose final validation returned `Err`
+        // (or panicked) fails the seed exactly as a failing `run()` does.
+        let mut results = results;
+        results.extend(check_results);
         // Scraped last, after `check()` has run: a workload that drives its
         // final requests from `check()` still has them counted.
         let sim_metrics = Self::extract_metrics(sim, metrics);
@@ -579,12 +584,14 @@ impl WorkloadOrchestrator {
 
     /// Run the entire check phase: build per-workload contexts, spawn
     /// `check()` futures, drive the cooperative loop, and collect the
-    /// resulting workloads.
+    /// resulting workloads beside each one's `check()` verdict.
     ///
     /// # Errors
     ///
     /// Returns `Err(())` if a workload IP fails to parse.
-    async fn do_check_phase(inputs: CheckPhaseInputs<'_>) -> Result<Vec<Box<dyn Workload>>, ()> {
+    async fn do_check_phase(
+        inputs: CheckPhaseInputs<'_>,
+    ) -> Result<(Vec<Box<dyn Workload>>, Vec<SimulationResult<()>>), ()> {
         let CheckPhaseInputs {
             sim,
             metrics,
@@ -925,13 +932,16 @@ impl WorkloadOrchestrator {
     }
 
     /// Spawn the check phase tasks, drive them cooperatively, and collect
-    /// the resulting workloads.
+    /// the resulting workloads beside one `check()` result per workload.
+    ///
+    /// A `check()` that panics yields no workload (the task owned it) and an
+    /// `Err` in its place, so the verdict is never lost with the instance.
     async fn run_check_phase(
         sim: &mut crate::sim::SimWorld,
         workloads: Vec<Box<dyn Workload>>,
         contexts: Vec<SimContext>,
         obs: &SimulationLayerHandle,
-    ) -> Vec<Box<dyn Workload>> {
+    ) -> (Vec<Box<dyn Workload>>, Vec<SimulationResult<()>>) {
         let mut check_handles = Vec::with_capacity(workloads.len());
         for (workload, ctx) in workloads.into_iter().zip(contexts) {
             let ip = ctx.my_ip().to_string();
@@ -943,7 +953,7 @@ impl WorkloadOrchestrator {
                     if let Err(ref e) = result {
                         tracing::error!("Workload '{}' check failed: {}", w.name(), e);
                     }
-                    w
+                    (w, result)
                 }
                 .instrument(tracing::info_span!("workload", ip = %ip)),
             );
@@ -968,15 +978,19 @@ impl WorkloadOrchestrator {
 
         // Collect check results.
         let mut final_workloads = Vec::with_capacity(check_handles.len());
+        let mut check_results = Vec::with_capacity(check_handles.len());
         for handle in check_handles {
-            match handle.await {
-                Ok(w) => final_workloads.push(w),
-                Err(_) => {
-                    tracing::error!("Check task panicked");
-                }
+            if let Ok((w, result)) = handle.await {
+                final_workloads.push(w);
+                check_results.push(result);
+            } else {
+                tracing::error!("Check task panicked");
+                check_results.push(Err(crate::SimulationError::InvalidState(
+                    "Check task panicked".to_string(),
+                )));
             }
         }
-        final_workloads
+        (final_workloads, check_results)
     }
 
     /// Build per-workload [`SimContext`]s for the run/check phases.

--- a/crates/moonpool-sim/src/runner/workload.rs
+++ b/crates/moonpool-sim/src/runner/workload.rs
@@ -55,6 +55,9 @@ pub trait Workload: Send + Sync + 'static {
     /// Check phase: validate correctness after quiescence.
     ///
     /// Called after all runs complete and pending events drain.
+    /// Its verdict is part of the iteration's result: an `Err` (or a panic)
+    /// fails the seed exactly as a failing `run()` does, even when every
+    /// `run()` returned `Ok`.
     /// Default implementation is a no-op.
     async fn check(&mut self, _ctx: &SimContext) -> SimulationResult<()> {
         Ok(())

--- a/crates/moonpool-sim/tests/check_phase.rs
+++ b/crates/moonpool-sim/tests/check_phase.rs
@@ -1,0 +1,124 @@
+//! Regression: a `Workload::check()` verdict is part of the seed's result.
+//!
+//! The check phase used to log a failing `check()` and discard it, and a
+//! `check()` that panicked was logged and its workload silently omitted.
+//! Either way the report kept the run phase's results unchanged, so a final
+//! consistency check could explicitly reject a run while CI received
+//! `successful_runs = 1, failed_runs = 0`.
+
+use async_trait::async_trait;
+
+use moonpool_sim::{SimContext, SimulationBuilder, SimulationError, SimulationResult, Workload};
+
+/// `run()` succeeds, `check()` rejects the final state.
+struct CheckRejects;
+
+#[async_trait]
+impl Workload for CheckRejects {
+    fn name(&self) -> &'static str {
+        "check_rejects"
+    }
+
+    async fn run(&mut self, _ctx: &SimContext) -> SimulationResult<()> {
+        Ok(())
+    }
+
+    async fn check(&mut self, _ctx: &SimContext) -> SimulationResult<()> {
+        Err(SimulationError::InvalidState(
+            "final state rejected by check".to_string(),
+        ))
+    }
+}
+
+/// `run()` succeeds, `check()` panics (an ordinary assertion failure).
+struct CheckPanics;
+
+#[async_trait]
+impl Workload for CheckPanics {
+    fn name(&self) -> &'static str {
+        "check_panics"
+    }
+
+    async fn run(&mut self, _ctx: &SimContext) -> SimulationResult<()> {
+        Ok(())
+    }
+
+    async fn check(&mut self, _ctx: &SimContext) -> SimulationResult<()> {
+        panic!("check phase assertion failure");
+    }
+}
+
+/// Neither `run()` nor `check()` complains; the control case.
+struct CheckPasses;
+
+#[async_trait]
+impl Workload for CheckPasses {
+    fn name(&self) -> &'static str {
+        "check_passes"
+    }
+
+    async fn run(&mut self, _ctx: &SimContext) -> SimulationResult<()> {
+        Ok(())
+    }
+}
+
+#[test]
+fn check_error_fails_the_iteration() {
+    let report = SimulationBuilder::new()
+        .workload(CheckRejects)
+        .set_debug_seeds(vec![1])
+        .set_iterations(1)
+        .run();
+
+    assert_eq!(report.iterations, 1);
+    assert_eq!(
+        report.successful_runs, 0,
+        "a rejected check is not a success"
+    );
+    assert_eq!(report.failed_runs, 1, "a rejected check fails the seed");
+    assert_eq!(report.seeds_failing, vec![1]);
+}
+
+#[test]
+fn check_panic_fails_the_iteration() {
+    let report = SimulationBuilder::new()
+        .workload(CheckPanics)
+        .set_debug_seeds(vec![1])
+        .set_iterations(1)
+        .run();
+
+    assert_eq!(report.iterations, 1);
+    assert_eq!(
+        report.successful_runs, 0,
+        "a panicking check is not a success"
+    );
+    assert_eq!(report.failed_runs, 1, "a panicking check fails the seed");
+    assert_eq!(report.seeds_failing, vec![1]);
+}
+
+#[test]
+fn one_rejecting_check_fails_the_seed_for_all_workloads() {
+    let report = SimulationBuilder::new()
+        .workload(CheckPasses)
+        .workload(CheckRejects)
+        .set_debug_seeds(vec![1])
+        .set_iterations(1)
+        .run();
+
+    assert_eq!(report.iterations, 1);
+    assert_eq!(report.successful_runs, 0);
+    assert_eq!(report.failed_runs, 1, "one failing check is enough");
+}
+
+#[test]
+fn passing_check_stays_a_success() {
+    let report = SimulationBuilder::new()
+        .workload(CheckPasses)
+        .set_debug_seeds(vec![1])
+        .set_iterations(1)
+        .run();
+
+    assert_eq!(report.iterations, 1);
+    assert_eq!(report.successful_runs, 1);
+    assert_eq!(report.failed_runs, 0);
+}


### PR DESCRIPTION
Closes #220

## Problem

A workload whose `run()` succeeded but whose `check()` returned `Err(SimulationError::InvalidState(..))` was still reported as `successful_runs = 1, failed_runs = 0`. A `check()` that panicked produced the same green report.

- `run_check_phase` logged the check error and discarded it, returning only the workload.
- A panicked check task was logged and its workload silently omitted.
- `finalize_orchestration` returned the run-phase `results` unchanged, so `record_iteration` never saw the verdict.

A final database-consistency check could explicitly reject a run while CI received a successful simulation report.

## Fix

- `run_check_phase` now returns one `SimulationResult<()>` per workload beside the workloads themselves. A panicked check task yields an `Err("Check task panicked")` in its slot, so the verdict is never lost with the instance.
- `finalize_orchestration` extends the iteration's `results` with the check results before building `OrchestrateOutput`. Because `record_iteration`, exploration's `root_failed`, and the exploration job callback all scan `output.results` for any `Err`, a failing `check()` now fails the seed everywhere a failing `run()` does.
- The `Workload::check` doc comment and the book's workload chapter state the contract.

## Tests

New `crates/moonpool-sim/tests/check_phase.rs` pins the contract by name:

- `check_error_fails_the_iteration`: `run()` ok, `check()` returns `Err` → `failed_runs = 1`, `seeds_failing = [seed]`.
- `check_panic_fails_the_iteration`: `run()` ok, `check()` panics → same.
- `one_rejecting_check_fails_the_seed_for_all_workloads`: one passing and one rejecting workload → the seed fails.
- `passing_check_stays_a_success`: control case.

Red→green: with the orchestrator change stashed, the three failing cases fail and the control passes; with it, all four pass.

Validation run locally: `cargo fmt`, `cargo clippy -p moonpool-sim --all-targets -- -D warnings`, `cargo clippy -p moonpool-sim --no-default-features --all-targets -- -D warnings`, and the full `moonpool-sim` test suite (all green).

One note unrelated to this change: `tests/determinism.rs` shares a process-wide static trace between its two tests, so under `cargo test`'s threaded harness they can race and fail; single-threaded and under nextest (one process per test) both pass. Left as is here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013CytnDdK8Nsp66srsvuvdE

---
_Generated by [Claude Code](https://claude.ai/code/session_013CytnDdK8Nsp66srsvuvdE)_