### PR TITLE
fix(moonpool-sim): refuse the open flags std refuses instead of truncating

### DIFF
--- a/book/src/part2-foundations/07-provider-traits.md
+++ b/book/src/part2-foundations/07-provider-traits.md
@@ -208,7 +208,13 @@ delete, rename, and the directory sync that makes those durable — while the
 `std::fs::OpenOptions` does not name portably: `direct_io(DirectIo)`. That is
 deliberately an option on opening an ordinary file rather than a second
 provider stack — there is no `BlockProvider` and no `DirectIoProvider`, and a
-journal or pager is written directly against `StorageFile`.
+journal or pager is written directly against `StorageFile`. The flags obey
+`std`'s rules too, on both backends: `truncate`, `create` and `create_new`
+need `write` or `append`, `append` and `truncate` contradict each other, and a
+combination `std` refuses with `InvalidInput` (`OpenOptions::validate`) is
+refused by the simulator before it touches the file, so a read-only
+`truncate` destroys nothing in simulation that it would not destroy in
+production.
 
 `read_at`/`write_at` are positioned: they take `&self`, never touch the stream
 cursor, and return the number of bytes moved, so non-overlapping ranges can be

--- a/crates/moonpool-core/src/lib.rs
+++ b/crates/moonpool-core/src/lib.rs
@@ -96,8 +96,8 @@ pub use random::RandomProvider;
 #[cfg(feature = "tokio-random")]
 pub use random::TokioRandomProvider;
 pub use storage::{
-    AlignedBuf, DirectIo, IoConstraints, OpenOptions, StorageFile, StorageProvider,
-    stream_io_unsupported,
+    AlignedBuf, DirectIo, InvalidOpenOptions, IoConstraints, OpenOptions, StorageFile,
+    StorageProvider, stream_io_unsupported,
 };
 #[cfg(feature = "tokio-fs")]
 pub use storage::{TokioStorageFile, TokioStorageProvider};

--- a/crates/moonpool-core/src/storage/mod.rs
+++ b/crates/moonpool-core/src/storage/mod.rs
@@ -45,7 +45,7 @@ use futures::io::{AsyncRead, AsyncSeek, AsyncWrite};
 use std::io;
 
 pub use align::{AlignedBuf, IoConstraints};
-pub use options::{DirectIo, OpenOptions};
+pub use options::{DirectIo, InvalidOpenOptions, OpenOptions};
 
 /// The error a file with I/O constraints returns from the stream API.
 ///

--- a/crates/moonpool-core/src/storage/options.rs
+++ b/crates/moonpool-core/src/storage/options.rs
@@ -185,6 +185,70 @@ flag_getters! {
     is_append => FLAG_APPEND,
 }
 
+/// An [`OpenOptions`] whose flags contradict each other.
+///
+/// Converts into an [`io::Error`](std::io::Error) of kind
+/// [`InvalidInput`](std::io::ErrorKind::InvalidInput), which is what the
+/// operating system answers such an open with.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InvalidOpenOptions(&'static str);
+
+impl std::fmt::Display for InvalidOpenOptions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.0)
+    }
+}
+
+impl std::error::Error for InvalidOpenOptions {}
+
+impl From<InvalidOpenOptions> for std::io::Error {
+    fn from(error: InvalidOpenOptions) -> Self {
+        Self::new(std::io::ErrorKind::InvalidInput, error)
+    }
+}
+
+impl OpenOptions {
+    /// Check that the flags make sense together, the way `std::fs::OpenOptions`
+    /// does before it ever reaches the operating system.
+    ///
+    /// The rules, which every provider must refuse alike so that simulated
+    /// code cannot depend on an open production rejects:
+    ///
+    /// - one of `read`, `write` or `append` must be set;
+    /// - `truncate`, `create` and `create_new` need `write` or `append`;
+    /// - `append` and `truncate` contradict each other, unless `create_new`
+    ///   makes the truncation moot.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`InvalidOpenOptions`] naming the contradiction.
+    pub fn validate(&self) -> Result<(), InvalidOpenOptions> {
+        if !self.is_read() && !self.is_write() && !self.is_append() {
+            return Err(InvalidOpenOptions(
+                "open options must set at least one of read, write or append",
+            ));
+        }
+        if !self.is_write() && !self.is_append() {
+            if self.is_truncate() {
+                return Err(InvalidOpenOptions(
+                    "truncate requires write access: a read-only open cannot truncate",
+                ));
+            }
+            if self.is_create() || self.is_create_new() {
+                return Err(InvalidOpenOptions(
+                    "create and create_new require write or append access",
+                ));
+            }
+        }
+        if self.is_append() && self.is_truncate() && !self.is_create_new() {
+            return Err(InvalidOpenOptions(
+                "append and truncate contradict each other",
+            ));
+        }
+        Ok(())
+    }
+}
+
 impl OpenOptions {
     /// Create options for read-only access.
     #[must_use]
@@ -217,6 +281,46 @@ impl OpenOptions {
 #[cfg(test)]
 mod tests {
     use super::{DirectIo, OpenOptions};
+
+    #[test]
+    fn validate_accepts_the_shapes_std_accepts() {
+        for options in [
+            OpenOptions::read_only(),
+            OpenOptions::read_write(),
+            OpenOptions::create_write(),
+            OpenOptions::create_new_write(),
+            OpenOptions::new().append(true),
+            OpenOptions::new().append(true).create(true),
+            OpenOptions::new()
+                .append(true)
+                .truncate(true)
+                .create_new(true),
+            OpenOptions::new().read(true).append(true),
+        ] {
+            assert_eq!(options.validate(), Ok(()), "{options:?}");
+        }
+    }
+
+    #[test]
+    fn validate_refuses_the_shapes_std_refuses() {
+        for options in [
+            OpenOptions::new(),
+            OpenOptions::new().truncate(true),
+            OpenOptions::read_only().truncate(true),
+            OpenOptions::read_only().create(true),
+            OpenOptions::read_only().create_new(true),
+            OpenOptions::new().append(true).truncate(true),
+            OpenOptions::new().write(true).append(true).truncate(true),
+        ] {
+            let error = options.validate().expect_err("must be refused");
+            let io_error: std::io::Error = error.into();
+            assert_eq!(
+                io_error.kind(),
+                std::io::ErrorKind::InvalidInput,
+                "{options:?}"
+            );
+        }
+    }
 
     #[test]
     fn flags_round_trip() {

--- a/crates/moonpool-sim/src/storage/error.rs
+++ b/crates/moonpool-sim/src/storage/error.rs
@@ -44,6 +44,18 @@ pub enum StorageError {
         operation: &'static str,
     },
 
+    /// The open's flags contradict each other (a read-only truncate, a
+    /// create without write access, an append that truncates).
+    ///
+    /// Refused before the namespace is touched, exactly as `std` refuses it
+    /// before reaching the operating system, so the simulator never honors an
+    /// open production rejects — nor destroys bytes on the way.
+    #[error("invalid open options: {reason}")]
+    InvalidOpenOptions {
+        /// Which rule the flags broke.
+        reason: String,
+    },
+
     /// An open asked for direct I/O the disk cannot provide.
     #[error("direct I/O is not supported by this disk")]
     DirectIoUnsupported,
@@ -130,9 +142,9 @@ impl From<StorageError> for io::Error {
                 io::ErrorKind::BrokenPipe
             }
             StorageError::PermissionDenied { .. } => io::ErrorKind::PermissionDenied,
-            StorageError::InvalidOperation { .. } | StorageError::InvalidOperationData { .. } => {
-                io::ErrorKind::InvalidInput
-            }
+            StorageError::InvalidOperation { .. }
+            | StorageError::InvalidOperationData { .. }
+            | StorageError::InvalidOpenOptions { .. } => io::ErrorKind::InvalidInput,
             StorageError::DirectIoUnsupported | StorageError::DirectIoCreate { .. } => {
                 io::ErrorKind::Unsupported
             }

--- a/crates/moonpool-sim/src/storage/sim/engine.rs
+++ b/crates/moonpool-sim/src/storage/sim/engine.rs
@@ -154,6 +154,14 @@ impl StorageEngine {
         owner_ip: IpAddr,
     ) -> Result<HandleId, StorageError> {
         let path = path.to_string();
+        // Contradictory flags are refused before anything else, as `std` does:
+        // a read-only `truncate` must not reach the branch below that would
+        // honor the truncation on a file it then had no right to write.
+        options
+            .validate()
+            .map_err(|error| StorageError::InvalidOpenOptions {
+                reason: error.to_string(),
+            })?;
         let (constraints, direct_io) = self.resolve_direct_io(&options, owner_ip)?;
         if options.is_create_new() && self.state.path_to_file.contains_key(&path) {
             return Err(StorageError::AlreadyExists { path });

--- a/crates/moonpool-sim/tests/storage/parity.rs
+++ b/crates/moonpool-sim/tests/storage/parity.rs
@@ -12,7 +12,13 @@
 //! behind a real `O_DIRECT` open, the simulator settles the capability before
 //! it touches its namespace at all. So the scenarios below are written once
 //! and run against both.
+//!
+//! The flag rules are the second such gap: `std` refuses a contradictory
+//! `OpenOptions` (a read-only `truncate`, a `create` without write access)
+//! before the operating system sees it, and the simulator used to honor the
+//! truncation on the way to a successful open.
 
+use futures::io::AsyncWriteExt;
 use moonpool_core::{DirectIo, OpenOptions, StorageFile, StorageProvider, TokioStorageProvider};
 use moonpool_sim::{SimWorld, StorageConfiguration};
 use std::net::IpAddr;
@@ -339,6 +345,115 @@ fn the_simulator_answers_the_required_contract_exactly_as_production_does() {
                 "the simulated provider must answer the Required contract exactly as production \
                  does"
             );
+        }
+    });
+}
+
+/// One entry of the flag contract: what the open answered, and what the file
+/// held afterwards, so a refusal that nonetheless truncated is caught.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct FlagStep {
+    label: &'static str,
+    observation: Observation,
+    size_after: u64,
+}
+
+const SEED_BYTES: &[u8] = b"twelve bytes";
+
+/// Every `OpenOptions` shape `std` refuses as contradictory, plus a legal
+/// control at each end, run against a file whose bytes must survive the
+/// refusals.
+async fn flag_contract<P: StorageProvider>(
+    provider: P,
+    prefix: String,
+) -> std::io::Result<Vec<FlagStep>> {
+    let path = format!("{prefix}flags.db");
+    let mut seed = provider
+        .open(&path, OpenOptions::create_new_write())
+        .await?;
+    seed.write_all(SEED_BYTES).await?;
+    seed.sync_all().await?;
+    drop(seed);
+
+    let shapes: [(&'static str, OpenOptions); 7] = [
+        ("read-only", OpenOptions::read_only()),
+        (
+            "read-only + truncate",
+            OpenOptions::read_only().truncate(true),
+        ),
+        ("read-only + create", OpenOptions::read_only().create(true)),
+        (
+            "read-only + create_new",
+            OpenOptions::read_only().create_new(true),
+        ),
+        ("no access mode", OpenOptions::new()),
+        (
+            "append + truncate",
+            OpenOptions::new().append(true).truncate(true),
+        ),
+        ("read-write", OpenOptions::read_write()),
+    ];
+
+    let mut log = Vec::with_capacity(shapes.len());
+    for (label, options) in shapes {
+        let observation = observe(provider.open(&path, options).await);
+        let probe = provider.open(&path, OpenOptions::read_only()).await?;
+        let size_after = probe.size().await?;
+        drop(probe);
+        log.push(FlagStep {
+            label,
+            observation,
+            size_after,
+        });
+    }
+    Ok(log)
+}
+
+/// The flag rules are `std`'s and platform-independent, so here the two
+/// backends must agree exactly: the same shapes refused, with the same error
+/// kind, and the seeded bytes intact after every one of them.
+#[test]
+fn the_simulator_refuses_the_open_flags_production_refuses() {
+    local_runtime().block_on(async {
+        let dir = TempDir::new().expect("temp dir");
+        let prefix = format!("{}/", dir.path().to_str().expect("temp path is UTF-8"));
+        let production = flag_contract(TokioStorageProvider::new(), prefix)
+            .await
+            .expect("the production scenarios must run");
+
+        let mut sim = SimWorld::new();
+        sim.set_storage_config(StorageConfiguration::fast_local());
+        let simulated = run_storage_test(sim, |provider| flag_contract(provider, String::new()))
+            .await
+            .expect("the simulated scenarios must run");
+
+        assert_eq!(
+            production, simulated,
+            "the simulated provider must refuse exactly the open flags production refuses"
+        );
+        for step in &production {
+            assert_eq!(
+                step.size_after,
+                SEED_BYTES.len() as u64,
+                "a refused open must not truncate, at {:?}",
+                step.label
+            );
+            let legal = matches!(step.label, "read-only" | "read-write");
+            assert_eq!(
+                permitted(step.observation),
+                legal,
+                "unexpected verdict at {:?}: {:?}",
+                step.label,
+                step.observation
+            );
+            if !legal {
+                assert_eq!(
+                    step.observation,
+                    Observation::Refused(std::io::ErrorKind::InvalidInput),
+                    "contradictory flags are InvalidInput, at {:?}",
+                    step.label
+                );
+            }
         }
     });
 }


### PR DESCRIPTION
Closes #228

## Problem

Opening an existing file with `OpenOptions::read_only().truncate(true)` succeeded in simulation and emptied the file. The production provider forwards the flags to tokio, hence std, which refuses the combination with `InvalidInput` before the operating system ever sees it. The same held for a `create` without write access, an open with no access mode at all, and an `append` that truncates: the simulator honored each and destroyed the bytes on the way.

The sim engine's `open_file` applied `truncate` on the existing-file branch before any permission was considered.

## Fix

- `OpenOptions::validate()` in moonpool-core encodes std's rules: one of `read`/`write`/`append` is required, `truncate`/`create`/`create_new` need `write` or `append`, and `append` contradicts `truncate` unless `create_new` makes it moot. The new `InvalidOpenOptions` error converts to an `io::Error` of kind `InvalidInput`.
- The sim engine calls it first thing in `open_file`, before it touches its namespace, and reports `StorageError::InvalidOpenOptions` mapped to `InvalidInput`.
- The book's provider chapter states the rule.

## Tests

- Unit tests on `OpenOptions::validate` for the accepted and refused shapes.
- `tests/storage/parity.rs` gains `the_simulator_refuses_the_open_flags_production_refuses`: seven shapes run against both `TokioStorageProvider` and the simulator on a seeded 12-byte file. Both must refuse the same shapes with the same error kind, and the bytes must survive every refusal.

Red→green: with the engine change stashed, the simulator opened five of the seven shapes and truncated the file to zero on the first refused one. With it, both backends agree exactly.

Validation run locally: `cargo fmt`, `cargo clippy -p moonpool-core -p moonpool-sim --all-targets -- -D warnings`, moonpool-core unit tests, and the full `moonpool-sim` storage suite plus lib tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013CytnDdK8Nsp66srsvuvdE

---
_Generated by [Claude Code](https://claude.ai/code/session_013CytnDdK8Nsp66srsvuvdE)_