### PR TITLE
fix(moonpool-sim): refuse a seek before byte zero instead of clamping

### DIFF
--- a/crates/moonpool-sim/src/storage/file.rs
+++ b/crates/moonpool-sim/src/storage/file.rs
@@ -303,22 +303,27 @@ impl AsyncSeek for SimStorageFile {
         let current_position = sim.file_position(self.handle_id)?;
         let file_size = sim.file_size(self.handle_id)?;
 
-        let target = match pos {
-            SeekFrom::Start(p) => p,
-            SeekFrom::End(offset) => {
-                if offset >= 0 {
-                    file_size.saturating_add(offset.unsigned_abs())
-                } else {
-                    file_size.saturating_sub(offset.unsigned_abs())
-                }
-            }
-            SeekFrom::Current(offset) => {
-                if offset >= 0 {
-                    current_position.saturating_add(offset.unsigned_abs())
-                } else {
-                    current_position.saturating_sub(offset.unsigned_abs())
-                }
-            }
+        // A seek that would land before byte zero, or past what an offset can
+        // hold, is refused with the position left where it was — what
+        // `lseek` answers with `EINVAL`. Clamping to zero instead would let an
+        // offset arithmetic bug stay hidden in simulation and surface only on
+        // the production filesystem, or quietly move later I/O to the wrong
+        // place.
+        let (base, offset) = match pos {
+            SeekFrom::Start(p) => (p, 0),
+            SeekFrom::End(offset) => (file_size, offset),
+            SeekFrom::Current(offset) => (current_position, offset),
+        };
+        let target = if offset >= 0 {
+            base.checked_add(offset.unsigned_abs())
+        } else {
+            base.checked_sub(offset.unsigned_abs())
+        };
+        let Some(target) = target else {
+            return Poll::Ready(Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "invalid seek to a negative or overflowing position",
+            )));
         };
 
         sim.set_file_position(self.handle_id, target)?;

--- a/crates/moonpool-sim/tests/storage/parity.rs
+++ b/crates/moonpool-sim/tests/storage/parity.rs
@@ -18,9 +18,10 @@
 //! before the operating system sees it, and the simulator used to honor the
 //! truncation on the way to a successful open.
 
-use futures::io::AsyncWriteExt;
+use futures::io::{AsyncSeekExt, AsyncWriteExt};
 use moonpool_core::{DirectIo, OpenOptions, StorageFile, StorageProvider, TokioStorageProvider};
 use moonpool_sim::{SimWorld, StorageConfiguration};
+use std::io::SeekFrom;
 use std::net::IpAddr;
 use tempfile::TempDir;
 
@@ -453,6 +454,90 @@ fn the_simulator_refuses_the_open_flags_production_refuses() {
                     "contradictory flags are InvalidInput, at {:?}",
                     step.label
                 );
+            }
+        }
+    });
+}
+
+/// What one seek answered, and where the cursor stood afterwards.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SeekStep {
+    label: &'static str,
+    result: Result<u64, std::io::ErrorKind>,
+    position_after: u64,
+}
+
+/// Seeks that land before byte zero, with a legal control between them,
+/// against a file of [`SEED_BYTES`].
+async fn seek_contract<P: StorageProvider>(
+    provider: P,
+    prefix: String,
+) -> std::io::Result<Vec<SeekStep>> {
+    let path = format!("{prefix}seek.db");
+    let mut file = provider
+        .open(&path, OpenOptions::create_new_write())
+        .await?;
+    file.write_all(SEED_BYTES).await?;
+    file.sync_all().await?;
+    drop(file);
+
+    let mut file = provider.open(&path, OpenOptions::read_only()).await?;
+    // Only seeks *before byte zero* are asked of both backends: how far past
+    // the end a file may be positioned is the filesystem's ceiling, not the
+    // contract's (ext4 refuses an offset past its maximum file size where
+    // others accept it), so overflow stays a simulator-only refusal.
+    let seeks: [(&'static str, SeekFrom); 5] = [
+        ("start 5", SeekFrom::Start(5)),
+        ("current -10 from 5", SeekFrom::Current(-10)),
+        ("end -3", SeekFrom::End(-3)),
+        ("end -100", SeekFrom::End(-100)),
+        ("current +3 from 9", SeekFrom::Current(3)),
+    ];
+    let mut log = Vec::with_capacity(seeks.len());
+    for (label, pos) in seeks {
+        let result = file.seek(pos).await.map_err(|e| e.kind());
+        let position_after = file.stream_position().await?;
+        log.push(SeekStep {
+            label,
+            result,
+            position_after,
+        });
+    }
+    Ok(log)
+}
+
+/// `lseek` refuses a negative or overflowing result with `EINVAL` and leaves
+/// the cursor alone. The simulator used to clamp the target to zero and
+/// report success, so a seek arithmetic bug stayed invisible until the
+/// production filesystem.
+#[test]
+fn the_simulator_refuses_the_seeks_production_refuses() {
+    local_runtime().block_on(async {
+        let dir = TempDir::new().expect("temp dir");
+        let prefix = format!("{}/", dir.path().to_str().expect("temp path is UTF-8"));
+        let production = seek_contract(TokioStorageProvider::new(), prefix)
+            .await
+            .expect("the production scenarios must run");
+
+        let mut sim = SimWorld::new();
+        sim.set_storage_config(StorageConfiguration::fast_local());
+        let simulated = run_storage_test(sim, |provider| seek_contract(provider, String::new()))
+            .await
+            .expect("the simulated scenarios must run");
+
+        assert_eq!(
+            production, simulated,
+            "the simulated provider must refuse exactly the seeks production refuses"
+        );
+        for step in &production {
+            match step.label {
+                "current -10 from 5" | "end -100" => assert_eq!(
+                    step.result,
+                    Err(std::io::ErrorKind::InvalidInput),
+                    "at {:?}",
+                    step.label
+                ),
+                _ => assert_eq!(step.result, Ok(step.position_after), "at {:?}", step.label),
             }
         }
     });


### PR DESCRIPTION
Closes #229

## Problem

A `SeekFrom::Current` or `SeekFrom::End` that would land before the start of a simulated file used saturating subtraction, installed position zero and returned `Ok`. `lseek` answers the same request with `EINVAL` and leaves the cursor where it was. So an offset arithmetic bug stayed hidden in simulation, or quietly moved later I/O to byte zero, and surfaced only on the production filesystem.

## Fix

`SimStorageFile::poll_seek` computes the target with checked arithmetic and refuses a negative or overflowing result with `io::ErrorKind::InvalidInput`, position unchanged.

## Tests

`tests/storage/parity.rs` gains `the_simulator_refuses_the_seeks_production_refuses`: the same seeks run against `TokioStorageProvider` and the simulator on a seeded file. Both must refuse the same seeks before byte zero with the same error kind, and the cursor must stay put. Only the negative direction is asked of production, because how far past the end a file may be positioned is the filesystem's ceiling rather than the contract's (ext4 refuses an offset past its maximum file size where other filesystems accept it), so overflow stays a simulator-only refusal.

Red→green: with the change stashed, the simulator answered `Ok(0)` to both refused seeks and moved the cursor to zero. With it, both backends agree exactly.

Validation run locally: `cargo fmt`, `cargo clippy -p moonpool-core -p moonpool-sim --all-targets -- -D warnings`, and the `moonpool-sim` storage and block-file suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013CytnDdK8Nsp66srsvuvdE

---
_Generated by [Claude Code](https://claude.ai/code/session_013CytnDdK8Nsp66srsvuvdE)_