### PR TITLE
fix(moonpool-sim): fail the seed when a process panics

### DIFF
--- a/book/src/part2-foundations/09-process.md
+++ b/book/src/part2-foundations/09-process.md
@@ -18,7 +18,7 @@ pub trait Process: Send + Sync + 'static {
 
 Two methods. `name()` identifies this process type for reporting. `run()` is where your server logic lives. All Process impls are **`Send + Sync + 'static`**, which makes them composable with `tokio::spawn` and `Arc`-based shared state like `Arc<RwLock<…>>` or `DashMap`. The runtime itself is still single-thread for determinism, but your code reads like ordinary tokio code.
 
-When `run()` returns `Ok(())`, the process has exited voluntarily. When the simulation kills the process, the future is cancelled and `run()` never returns at all.
+When `run()` returns `Ok(())` or an `Err`, the process has exited voluntarily. When the simulation kills the process, the future is cancelled and `run()` never returns at all. When `run()` **panics**, the seed fails: the panic is caught and recorded against the process's IP, and the iteration is reported as failed even if every workload returned `Ok`, so an assertion firing inside a server (or one of its dependencies) never disappears from the report.
 
 ## The Factory Pattern
 

--- a/crates/moonpool-sim/src/runner/orchestrator.rs
+++ b/crates/moonpool-sim/src/runner/orchestrator.rs
@@ -22,7 +22,9 @@ use crate::runner::workload::Workload;
 use crate::sim::ProcessKillKind;
 use crate::{SimulationResult, assert_reachable};
 
-use super::process_manager::{ProcessConfig, ProcessManager, RestartEnv};
+use super::process_manager::{
+    ProcessConfig, ProcessManager, ProcessPanics, RestartEnv, spawn_process,
+};
 use super::report::SimulationMetrics;
 use super::stall::{RunStallGuard, StallOutcome};
 
@@ -539,6 +541,16 @@ impl WorkloadOrchestrator {
 
         // === 5. ABORT ALL PROCESSES ===
         process_manager.abort_all();
+        // A process that panicked is a failed run, whether or not a workload
+        // noticed the dead server: the panic was recorded where it happened
+        // (`spawn_process`), and here it becomes part of the seed's verdict.
+        let mut results = results;
+        for panic in process_manager.take_panics() {
+            results.push(Err(crate::SimulationError::InvalidState(format!(
+                "process at {} panicked: {}",
+                panic.ip, panic.message
+            ))));
+        }
 
         // === 6. SETTLE ===
         if let Some(settle_err) = Self::settle_phase(sim) {
@@ -569,7 +581,6 @@ impl WorkloadOrchestrator {
         // A `check()` verdict is part of the iteration's result: a workload
         // whose `run()` succeeded but whose final validation returned `Err`
         // (or panicked) fails the seed exactly as a failing `run()` does.
-        let mut results = results;
         results.extend(check_results);
         // Scraped last, after `check()` has run: a workload that drives its
         // final requests from `check()` still has them counted.
@@ -844,12 +855,17 @@ impl WorkloadOrchestrator {
         all_entities: &[(String, String)],
         env: &ProcessBootEnv<'_>,
     ) -> Result<ProcessManager<'pm>, ()> {
+        let panics = ProcessPanics::default();
         let (process_handles, process_tokens) =
-            Self::boot_processes(process_config.as_ref(), all_entities, env)?;
+            Self::boot_processes(process_config.as_ref(), all_entities, env, &panics)?;
         Ok(match process_config {
-            Some(pc) => {
-                ProcessManager::new(pc, process_handles, process_tokens, all_entities.to_vec())
-            }
+            Some(pc) => ProcessManager::new(
+                pc,
+                process_handles,
+                process_tokens,
+                all_entities.to_vec(),
+                panics,
+            ),
             None => ProcessManager::empty(),
         })
     }
@@ -865,6 +881,7 @@ impl WorkloadOrchestrator {
         process_config: Option<&ProcessConfig<'_>>,
         all_entities: &[(String, String)],
         env: &ProcessBootEnv<'_>,
+        panics: &ProcessPanics,
     ) -> Result<(ProcessHandleSlots, ProcessTokenSlots), ()> {
         let ProcessBootEnv {
             sim,
@@ -879,7 +896,7 @@ impl WorkloadOrchestrator {
             return Ok((process_handles, process_tokens));
         };
         for (i, ip) in pc.ips.iter().enumerate() {
-            let mut process = (pc.factories[i])();
+            let process = (pc.factories[i])();
             let ip_addr: std::net::IpAddr = ip.parse().map_err(|_| ())?;
             // A process is numbered within its own group, so a role can index
             // its instances without knowing what the other groups drew.
@@ -913,17 +930,7 @@ impl WorkloadOrchestrator {
                 obs.clone(),
                 metrics.clone(),
             );
-            let ip_for_log = ip.clone();
-            let span_ip = ip.clone();
-            let handle = crate::executor::spawn(
-                &format!("process@{span_ip}"),
-                async move {
-                    if let Err(e) = process.run(&ctx).await {
-                        tracing::debug!("Process at {} exited: {}", ip_for_log, e);
-                    }
-                }
-                .instrument(tracing::info_span!("process", ip = %span_ip)),
-            );
+            let handle = spawn_process(process, ctx, ip, panics);
             process_handles.push(Some(handle));
             process_tokens.push(Some(process_token));
             tracing::debug!("Booted process {} at {}", i, ip);

--- a/crates/moonpool-sim/src/runner/process_manager.rs
+++ b/crates/moonpool-sim/src/runner/process_manager.rs
@@ -1,8 +1,11 @@
 //! Process lifecycle state for simulation runs.
 
+use std::any::Any;
 use std::collections::BTreeSet;
+use std::panic::AssertUnwindSafe;
 use std::sync::{Arc, Mutex};
 
+use futures::FutureExt as _;
 use tracing::Instrument as _;
 
 use crate::chaos::state_handle::StateHandle;
@@ -59,6 +62,73 @@ pub(crate) struct RestartEnv<'a> {
     pub(crate) shutdown_signal: &'a tokio_util::sync::CancellationToken,
 }
 
+/// A panic that killed a process task: which process, and what it said.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ProcessPanic {
+    /// The process's IP, as the topology names it.
+    pub(crate) ip: String,
+    /// The panic payload, when it was a string; a placeholder otherwise.
+    pub(crate) message: String,
+}
+
+/// The panics recorded across every process task of one iteration, shared
+/// between the boot-time spawns and the restarts the manager performs.
+pub(crate) type ProcessPanics = Arc<Mutex<Vec<ProcessPanic>>>;
+
+/// The text of a panic payload, for the failure it becomes.
+fn panic_message(payload: &(dyn Any + Send)) -> String {
+    if let Some(message) = payload.downcast_ref::<&str>() {
+        (*message).to_string()
+    } else if let Some(message) = payload.downcast_ref::<String>() {
+        message.clone()
+    } else {
+        "non-string panic payload".to_string()
+    }
+}
+
+/// Spawn `process` as its own task, inside the `process` span the
+/// observability layer attributes events by.
+///
+/// A panic in [`Process::run`] is caught *here*, at the one place that knows
+/// which process it was, and recorded in `panics`; the seed then fails at the
+/// end of the iteration ([`ProcessManager::take_panics`]). Nothing else
+/// observes a process task's outcome — the manager aborts handles without
+/// awaiting them — so without this a panicking process was simply a process
+/// that stopped, and a run whose workloads did not notice reported success.
+/// An ordinary `Err` from `run` is still an exit, not a failure: a process may
+/// legitimately stop.
+pub(crate) fn spawn_process(
+    mut process: Box<dyn Process>,
+    ctx: SimContext,
+    ip: &str,
+    panics: &ProcessPanics,
+) -> crate::executor::JoinHandle<()> {
+    let ip = ip.to_string();
+    let span_ip = ip.clone();
+    let panics = Arc::clone(panics);
+    crate::executor::spawn(
+        &format!("process@{span_ip}"),
+        async move {
+            let outcome = AssertUnwindSafe(process.run(&ctx)).catch_unwind().await;
+            match outcome {
+                Ok(Ok(())) => {}
+                Ok(Err(error)) => {
+                    tracing::debug!(%error, %ip, "process exited");
+                }
+                Err(payload) => {
+                    let message = panic_message(payload.as_ref());
+                    tracing::error!(%ip, %message, "process panicked");
+                    panics
+                        .lock()
+                        .expect("Mutex poisoned: prior task panicked")
+                        .push(ProcessPanic { ip, message });
+                }
+            }
+        }
+        .instrument(tracing::info_span!("process", ip = %span_ip)),
+    )
+}
+
 /// Owns running process tasks and their restart state.
 pub(crate) struct ProcessManager<'a> {
     /// Per-process factories, parallel to `ips` (empty without processes).
@@ -74,6 +144,8 @@ pub(crate) struct ProcessManager<'a> {
     /// with every [`FaultContext`](crate::FaultContext) so injectors can
     /// budget their kills per victim pool.
     dead: DeadSet,
+    /// Every panic a process task of this iteration died of.
+    panics: ProcessPanics,
 }
 
 impl<'a> ProcessManager<'a> {
@@ -88,6 +160,7 @@ impl<'a> ProcessManager<'a> {
             group_registry: GroupRegistry::default(),
             all_entities: Vec::new(),
             dead: Arc::new(Mutex::new(BTreeSet::new())),
+            panics: Arc::default(),
         }
     }
 
@@ -96,6 +169,7 @@ impl<'a> ProcessManager<'a> {
         handles: Vec<Option<crate::executor::JoinHandle<()>>>,
         process_tokens: Vec<Option<tokio_util::sync::CancellationToken>>,
         all_entities: Vec<(String, String)>,
+        panics: ProcessPanics,
     ) -> Self {
         let ProcessConfig {
             factories,
@@ -115,7 +189,18 @@ impl<'a> ProcessManager<'a> {
             group_registry,
             all_entities,
             dead: Arc::new(Mutex::new(BTreeSet::new())),
+            panics,
         }
+    }
+
+    /// Take the panics recorded so far, leaving the ledger empty.
+    pub(crate) fn take_panics(&self) -> Vec<ProcessPanic> {
+        std::mem::take(
+            &mut *self
+                .panics
+                .lock()
+                .expect("Mutex poisoned: prior task panicked"),
+        )
     }
 
     /// Snapshot the process metadata needed by a fault injector.
@@ -195,7 +280,7 @@ impl<'a> ProcessManager<'a> {
 
         let process_token = shutdown_signal.child_token();
         self.process_tokens[index] = Some(process_token.clone());
-        let mut process = factory();
+        let process = factory();
         // A process is numbered within its own group, exactly as on first boot.
         let (client_id, client_count) = self
             .group_registry
@@ -221,16 +306,7 @@ impl<'a> ProcessManager<'a> {
             obs.clone(),
             metrics.clone(),
         );
-        let log_ip = ip_string.clone();
-        let handle = crate::executor::spawn(
-            &format!("process@{ip_string}"),
-            async move {
-                if let Err(error) = process.run(&ctx).await {
-                    tracing::debug!(%error, ip = %log_ip, "restarted process exited");
-                }
-            }
-            .instrument(tracing::info_span!("process", ip = %ip_string)),
-        );
+        let handle = spawn_process(process, ctx, &ip_string, &self.panics);
         self.handles[index] = Some(handle);
         self.dead
             .lock()

--- a/crates/moonpool-sim/tests/process_panic.rs
+++ b/crates/moonpool-sim/tests/process_panic.rs
@@ -1,0 +1,94 @@
+//! Regression: a panic inside `Process::run` fails the seed.
+//!
+//! The executor catches a task's panic and parks it in the join result, but
+//! nothing ever awaited a process handle: the process manager aborts and
+//! drops them. So a server that panicked on its first poll, beside a workload
+//! that slept and returned `Ok`, produced a successful simulation report — an
+//! assertion in a dependency could disappear from failure accounting unless
+//! a workload independently noticed the dead server.
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+
+use moonpool_sim::{
+    Process, SimContext, SimulationBuilder, SimulationError, SimulationResult, TimeProvider,
+    Workload,
+};
+
+/// Panics as soon as it is polled.
+struct PanickingProcess;
+
+#[async_trait]
+impl Process for PanickingProcess {
+    fn name(&self) -> &'static str {
+        "panicking_process"
+    }
+
+    async fn run(&mut self, _ctx: &SimContext) -> SimulationResult<()> {
+        panic!("server assertion failed");
+    }
+}
+
+/// Returns an error, which is an ordinary exit and not a failure.
+struct ExitingProcess;
+
+#[async_trait]
+impl Process for ExitingProcess {
+    fn name(&self) -> &'static str {
+        "exiting_process"
+    }
+
+    async fn run(&mut self, _ctx: &SimContext) -> SimulationResult<()> {
+        Err(SimulationError::InvalidState(
+            "server chose to stop".to_string(),
+        ))
+    }
+}
+
+/// Never looks at the servers; sleeps and reports success.
+struct ObliviousWorkload;
+
+#[async_trait]
+impl Workload for ObliviousWorkload {
+    fn name(&self) -> &'static str {
+        "oblivious_workload"
+    }
+
+    async fn run(&mut self, ctx: &SimContext) -> SimulationResult<()> {
+        let _ = ctx.time().sleep(Duration::from_millis(50)).await;
+        Ok(())
+    }
+}
+
+#[test]
+fn a_panicking_process_fails_the_iteration() {
+    let report = SimulationBuilder::new()
+        .processes(1, || Box::new(PanickingProcess))
+        .workload(ObliviousWorkload)
+        .set_debug_seeds(vec![1])
+        .set_iterations(1)
+        .run();
+
+    assert_eq!(report.iterations, 1);
+    assert_eq!(
+        report.successful_runs, 0,
+        "a panicking server is not a success"
+    );
+    assert_eq!(report.failed_runs, 1, "a panicking server fails the seed");
+    assert_eq!(report.seeds_failing, vec![1]);
+}
+
+#[test]
+fn a_process_that_exits_with_an_error_is_not_a_failure() {
+    let report = SimulationBuilder::new()
+        .processes(1, || Box::new(ExitingProcess))
+        .workload(ObliviousWorkload)
+        .set_debug_seeds(vec![1])
+        .set_iterations(1)
+        .run();
+
+    assert_eq!(report.iterations, 1);
+    assert_eq!(report.successful_runs, 1);
+    assert_eq!(report.failed_runs, 0);
+}


### PR DESCRIPTION
Closes #222

## Problem

A `Process::run()` that panicked, beside a workload that slept and returned `Ok`, produced a successful simulation report. The executor catches the panic and parks it in the task's join result, but nothing ever awaited a process handle: the process manager aborts and drops them at the end of the run. So an assertion firing inside a server, or inside one of its dependencies, disappeared from failure accounting unless a workload independently noticed the dead server.

## Fix

- Both spawn sites (first boot in the orchestrator, restart in the process manager) now go through one `spawn_process` helper that runs `Process::run` under `catch_unwind`, logs the panic against the process's IP and records it in a `ProcessPanics` ledger the process manager owns.
- `finalize_orchestration` turns every recorded panic into a failed result for the seed, alongside the workload results.
- An ordinary `Err` from `run()` stays what it was: an exit, not a failure.
- The book's process chapter states the rule.

## Tests

`tests/process_panic.rs` pins both halves: a panicking process fails the iteration (`failed_runs = 1`, `seeds_failing = [seed]`), and a process that exits with an error does not.

Red→green: with the runner changes stashed, the panicking case reported `successful_runs = 1`. With them, it fails as it should.

Validation run locally: `cargo fmt`, `cargo clippy -p moonpool-core -p moonpool-sim --all-targets -- -D warnings`, the `--no-default-features` clippy gate, and the full `moonpool-sim` test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013CytnDdK8Nsp66srsvuvdE

---
_Generated by [Claude Code](https://claude.ai/code/session_013CytnDdK8Nsp66srsvuvdE)_