### PR TITLE
fix(moonpool-sim): run provider-spawned tasks inside the spawner's span

### DIFF
--- a/book/src/part3-building/17-events-and-invariants.md
+++ b/book/src/part3-building/17-events-and-invariants.md
@@ -28,7 +28,7 @@ Three rules:
 
 That's the whole convention. Sim time is stamped automatically from the simulation clock, so do not include a `time_ms` field.
 
-**Where does the source come from?** The orchestrator wraps every process and workload task in a tracing span carrying its `ip` (`info_span!("process", ip = %ip)`). When an event fires inside that task, the capture layer walks the span scope and attributes the event to the nearest enclosing actor. In production the same role is played by host or pod attributes on your trace resource. Events emitted outside any actor span (runtime internals, the orchestrator itself) are not captured.
+**Where does the source come from?** The orchestrator wraps every process and workload task in a tracing span carrying its `ip` (`info_span!("process", ip = %ip)`). When an event fires inside that task, the capture layer walks the span scope and attributes the event to the nearest enclosing actor. A task spawned through `ctx.task().spawn_task()` runs inside the span that was current when it was spawned, exactly as `tokio::spawn` does, so a background request handler's events carry the same `ip` as the actor that spawned it, however deep the spawning goes. In production the same role is played by host or pod attributes on your trace resource. Events emitted outside any actor span (runtime internals, the orchestrator itself) are not captured.
 
 Each captured event is a `TraceEvent`:
 

--- a/crates/moonpool-sim/src/providers/task.rs
+++ b/crates/moonpool-sim/src/providers/task.rs
@@ -3,6 +3,7 @@
 use std::future::Future;
 
 use moonpool_core::TaskProvider;
+use tracing::Instrument as _;
 
 /// Task provider that spawns onto the [deterministic
 /// executor](crate::executor) driving the current simulation iteration.
@@ -12,6 +13,16 @@ use moonpool_core::TaskProvider;
 /// [`Executor::block_on`](crate::executor::Executor::block_on): scheduling
 /// order is a seeded-random, fully reproducible function of the iteration
 /// seed.
+///
+/// # Attribution
+///
+/// A spawned task runs inside the span that was current when it was spawned,
+/// as `tokio::spawn` does. That span is (or descends from) the `process` /
+/// `workload` span the orchestrator wraps around each actor, which is how
+/// the observability layer attributes an event to its actor: an event emitted
+/// from a background request handler reaches the invariant timeline exactly
+/// as one emitted from the actor's root future does, rather than being
+/// dropped for lacking a source.
 ///
 /// # Panics
 ///
@@ -29,8 +40,9 @@ impl TaskProvider for SimTaskProvider {
     {
         // No lifecycle-trace wrapper (unlike TokioTaskProvider, where the
         // name would otherwise be lost): the executor stores the name in
-        // TaskMeta and traces every poll of the task with it.
-        crate::executor::spawn(name, future)
+        // TaskMeta and traces every poll of the task with it. The child does
+        // inherit the spawner's span, so its events keep their actor.
+        crate::executor::spawn(name, future.instrument(tracing::Span::current()))
     }
 
     async fn yield_now(&self) {

--- a/crates/moonpool-sim/tests/child_task_attribution.rs
+++ b/crates/moonpool-sim/tests/child_task_attribution.rs
@@ -1,0 +1,106 @@
+//! Regression: events from provider-spawned child tasks keep their actor.
+//!
+//! The observability layer attributes an event to the `ip` of the nearest
+//! enclosing `process` / `workload` span and drops events that have none.
+//! Root actors are instrumented with that span by the orchestrator, but a
+//! task spawned through `ctx.task().spawn_task()` used to be handed to the
+//! executor bare, so its polls never entered the actor span and every
+//! correctness fact a background handler emitted vanished from the invariant
+//! timeline.
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+
+use moonpool_sim::{
+    Process, SimContext, SimulationBuilder, SimulationError, SimulationResult, TaskProvider,
+    TimeProvider, TraceQuery, Workload,
+};
+
+const ROOT_EVENT: &str = "root_event";
+const CHILD_EVENT: &str = "child_event";
+const GRANDCHILD_EVENT: &str = "grandchild_event";
+
+/// Emits one event from its root future, one from a spawned child, and one
+/// from a child of that child.
+struct SpawningProcess;
+
+#[async_trait]
+impl Process for SpawningProcess {
+    fn name(&self) -> &'static str {
+        "spawning_process"
+    }
+
+    async fn run(&mut self, ctx: &SimContext) -> SimulationResult<()> {
+        tracing::info!(target: "attribution", "root_event");
+        let task = ctx.task().clone();
+        let handle = ctx.task().spawn_task("child", async move {
+            tracing::info!(target: "attribution", "child_event");
+            let grandchild = task.spawn_task("grandchild", async move {
+                tracing::info!(target: "attribution", "grandchild_event");
+            });
+            let _ = grandchild.await;
+        });
+        let _ = handle.await;
+        // Stay alive so the run has a server for its whole duration.
+        std::future::pending::<()>().await;
+        Ok(())
+    }
+}
+
+/// Waits for the process to have done its work, then reads the timeline.
+struct TimelineWorkload;
+
+#[async_trait]
+impl Workload for TimelineWorkload {
+    fn name(&self) -> &'static str {
+        "timeline_workload"
+    }
+
+    async fn run(&mut self, ctx: &SimContext) -> SimulationResult<()> {
+        let _ = ctx.time().sleep(Duration::from_millis(50)).await;
+        Ok(())
+    }
+
+    async fn check(&mut self, ctx: &SimContext) -> SimulationResult<()> {
+        let server = ctx
+            .topology()
+            .all_process_ips()
+            .first()
+            .cloned()
+            .ok_or_else(|| SimulationError::InvalidState("no server".to_string()))?;
+        let q: &dyn TraceQuery = ctx.observability();
+        for name in [ROOT_EVENT, CHILD_EVENT, GRANDCHILD_EVENT] {
+            let events = q.snapshot(name);
+            if events.len() != 1 {
+                return Err(SimulationError::InvalidState(format!(
+                    "{name}: expected one captured event, found {}",
+                    events.len()
+                )));
+            }
+            if events[0].source != server {
+                return Err(SimulationError::InvalidState(format!(
+                    "{name}: attributed to {:?}, expected the server {server:?}",
+                    events[0].source
+                )));
+            }
+        }
+        Ok(())
+    }
+}
+
+#[test]
+fn events_from_spawned_child_tasks_are_attributed_to_their_process() {
+    let report = SimulationBuilder::new()
+        .processes(1, || Box::new(SpawningProcess))
+        .workload(TimelineWorkload)
+        .set_debug_seeds(vec![1])
+        .set_iterations(1)
+        .run();
+
+    assert_eq!(report.iterations, 1);
+    assert_eq!(
+        report.failed_runs, 0,
+        "every event, root or spawned, must reach the timeline with its actor"
+    );
+}


### PR DESCRIPTION
Closes #224

## Problem

The observability layer attributes an event to the `ip` of the nearest enclosing `process` / `workload` span and drops events that have none. Root actors are instrumented with that span by the orchestrator, but a task spawned through `ctx.task().spawn_task()` was handed to the executor bare: its polls never entered the actor span, so every correctness fact a background request handler emitted vanished from the invariant timeline. An invariant watching for a consistency violation could never see it.

## Fix

`SimTaskProvider::spawn_task` instruments the child future with `tracing::Span::current()`, the span in force at the spawn, exactly as `tokio::spawn` does. Children of children inherit it the same way. A span draws no randomness, so seeds replay as before. The book's events chapter states the rule.

## Tests

`tests/child_task_attribution.rs`: a process emits one event from its root future, one from a spawned child and one from that child's child; the workload's `check()` reads the timeline and requires all three to be present and attributed to the process's IP.

Red→green: without the provider change the child and grandchild events are missing from the timeline. With it, all three are captured with the right source.

Validation run locally: `cargo fmt`, `cargo clippy -p moonpool-sim --all-targets -- -D warnings`, the `--no-default-features` clippy gate, and the full `moonpool-sim` suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013CytnDdK8Nsp66srsvuvdE

---
_Generated by [Claude Code](https://claude.ai/code/session_013CytnDdK8Nsp66srsvuvdE)_