### PR TITLE
fix(moonpool-sim): kill a process's spawned tasks when the process is killed

### DIFF
--- a/book/src/part2-foundations/09-process.md
+++ b/book/src/part2-foundations/09-process.md
@@ -18,7 +18,7 @@ pub trait Process: Send + Sync + 'static {
 
 Two methods. `name()` identifies this process type for reporting. `run()` is where your server logic lives. All Process impls are **`Send + Sync + 'static`**, which makes them composable with `tokio::spawn` and `Arc`-based shared state like `Arc<RwLock<…>>` or `DashMap`. The runtime itself is still single-thread for determinism, but your code reads like ordinary tokio code.
 
-When `run()` returns `Ok(())` or an `Err`, the process has exited voluntarily. When the simulation kills the process, the future is cancelled and `run()` never returns at all. When `run()` **panics**, the seed fails: the panic is caught and recorded against the process's IP, and the iteration is reported as failed even if every workload returned `Ok`, so an assertion firing inside a server (or one of its dependencies) never disappears from the report.
+When `run()` returns `Ok(())` or an `Err`, the process has exited voluntarily. When the simulation kills the process, the future is cancelled and `run()` never returns at all, and so is every task the process spawned through `ctx.task().spawn_task()`, however deep: a crash ends the whole process, not just its root future, so a background worker never survives to run beside the rebooted process's own. When `run()` **panics**, the seed fails: the panic is caught and recorded against the process's IP, and the iteration is reported as failed even if every workload returned `Ok`, so an assertion firing inside a server (or one of its dependencies) never disappears from the report.
 
 ## The Factory Pattern
 

--- a/crates/moonpool-sim/src/providers/sim_providers.rs
+++ b/crates/moonpool-sim/src/providers/sim_providers.rs
@@ -60,10 +60,22 @@ impl SimProviders {
         Self {
             network: SimNetworkProvider::new(sim.clone(), ip),
             time: SimTimeProvider::new(sim.clone()),
-            task: SimTaskProvider,
+            task: SimTaskProvider::default(),
             random: SimRandomProvider::new(),
             storage: SimStorageProvider::new(sim, ip),
         }
+    }
+
+    /// Bind every task spawned through this bundle's task provider to
+    /// `scope`: cancelling it drops them all, descendants included.
+    ///
+    /// The runner gives each process boot its own scope and cancels it when
+    /// the process is killed, so a crash ends the process's background work
+    /// along with its root future. Workloads get no scope.
+    #[must_use]
+    pub(crate) fn with_task_scope(mut self, scope: tokio_util::sync::CancellationToken) -> Self {
+        self.task = SimTaskProvider::scoped(scope);
+        self
     }
 }
 

--- a/crates/moonpool-sim/src/providers/task.rs
+++ b/crates/moonpool-sim/src/providers/task.rs
@@ -1,8 +1,11 @@
 //! Task provider backed by the moonpool deterministic executor.
 
 use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 
 use moonpool_core::TaskProvider;
+use tokio_util::sync::{CancellationToken, WaitForCancellationFutureOwned};
 use tracing::Instrument as _;
 
 /// Task provider that spawns onto the [deterministic
@@ -24,12 +27,33 @@ use tracing::Instrument as _;
 /// as one emitted from the actor's root future does, rather than being
 /// dropped for lacking a source.
 ///
+/// # Ownership
+///
+/// A process's provider carries the **scope** of the boot it belongs to
+/// ([`SimProviders::with_task_scope`](crate::SimProviders::with_task_scope)):
+/// every task spawned through it, and every task those spawn in turn, is
+/// dropped when the process is killed. A crash therefore ends the whole
+/// process — a detached worker does not survive it to run beside the
+/// rebooted process's own, as it would if the child were merely handed to
+/// the shared executor. A killed scope is checked *before* the child future
+/// is polled, so no application work runs after the kill. Workload providers
+/// carry no scope: a workload survives everything.
+///
 /// # Panics
 ///
 /// `spawn_task` panics when used outside `Executor::block_on` (mirroring
 /// `tokio::spawn` outside a runtime).
 #[derive(Clone, Debug, Default)]
-pub struct SimTaskProvider;
+pub struct SimTaskProvider {
+    scope: Option<CancellationToken>,
+}
+
+impl SimTaskProvider {
+    /// A provider whose spawned tasks live no longer than `scope`.
+    pub(crate) fn scoped(scope: CancellationToken) -> Self {
+        Self { scope: Some(scope) }
+    }
+}
 
 impl TaskProvider for SimTaskProvider {
     type JoinHandle = crate::executor::JoinHandle<()>;
@@ -42,10 +66,47 @@ impl TaskProvider for SimTaskProvider {
         // name would otherwise be lost): the executor stores the name in
         // TaskMeta and traces every poll of the task with it. The child does
         // inherit the spawner's span, so its events keep their actor.
-        crate::executor::spawn(name, future.instrument(tracing::Span::current()))
+        let future = future.instrument(tracing::Span::current());
+        match &self.scope {
+            Some(scope) => crate::executor::spawn(name, Scoped::new(scope.clone(), future)),
+            None => crate::executor::spawn(name, future),
+        }
     }
 
     async fn yield_now(&self) {
         crate::executor::yield_now().await;
+    }
+}
+
+/// A task future bound to a process boot: completes, dropping the inner
+/// future unpolled, as soon as the boot's scope is cancelled.
+///
+/// The cancellation is polled *first* on every poll. A kill wakes every
+/// task waiting on the scope; when the executor next runs the child, it
+/// finds the scope cancelled and drops the application future without
+/// giving it another poll, which is the "no application work after the
+/// kill" rule the process manager keeps for the root future by aborting it.
+struct Scoped<F> {
+    cancelled: Pin<Box<WaitForCancellationFutureOwned>>,
+    inner: Pin<Box<F>>,
+}
+
+impl<F: Future<Output = ()>> Scoped<F> {
+    fn new(scope: CancellationToken, inner: F) -> Self {
+        Self {
+            cancelled: Box::pin(scope.cancelled_owned()),
+            inner: Box::pin(inner),
+        }
+    }
+}
+
+impl<F: Future<Output = ()>> Future for Scoped<F> {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+        if self.cancelled.as_mut().poll(cx).is_ready() {
+            return Poll::Ready(());
+        }
+        self.inner.as_mut().poll(cx)
     }
 }

--- a/crates/moonpool-sim/src/runner/orchestrator.rs
+++ b/crates/moonpool-sim/src/runner/orchestrator.rs
@@ -23,7 +23,7 @@ use crate::sim::ProcessKillKind;
 use crate::{SimulationResult, assert_reachable};
 
 use super::process_manager::{
-    ProcessConfig, ProcessManager, ProcessPanics, RestartEnv, spawn_process,
+    ProcessBoot, ProcessConfig, ProcessManager, ProcessPanics, RestartEnv, spawn_process,
 };
 use super::report::SimulationMetrics;
 use super::stall::{RunStallGuard, StallOutcome};
@@ -41,8 +41,8 @@ type SetupTaskOutput = (Box<dyn Workload>, SimContext, SimulationResult<()>);
 /// Handle to a spawned `setup()` task.
 type SetupHandle = crate::executor::JoinHandle<SetupTaskOutput>;
 
-/// Per-process join handles (in option slots so they can be drained).
-type ProcessHandleSlots = Vec<Option<crate::executor::JoinHandle<()>>>;
+/// Per-process boots (in option slots so they can be drained).
+type ProcessHandleSlots = Vec<Option<ProcessBoot>>;
 
 /// Per-process cancellation tokens (in option slots so they can be drained).
 type ProcessTokenSlots = Vec<Option<tokio_util::sync::CancellationToken>>;
@@ -922,7 +922,9 @@ impl WorkloadOrchestrator {
                 group_registry: pc.group_registry.clone(),
                 shutdown_signal: process_token.clone(),
             });
-            let providers = crate::SimProviders::new(sim.downgrade(), ip_addr);
+            let scope = tokio_util::sync::CancellationToken::new();
+            let providers =
+                crate::SimProviders::new(sim.downgrade(), ip_addr).with_task_scope(scope.clone());
             let ctx = SimContext::new(
                 providers,
                 topology,
@@ -930,8 +932,8 @@ impl WorkloadOrchestrator {
                 obs.clone(),
                 metrics.clone(),
             );
-            let handle = spawn_process(process, ctx, ip, panics);
-            process_handles.push(Some(handle));
+            let boot = spawn_process(process, ctx, ip, panics, scope);
+            process_handles.push(Some(boot));
             process_tokens.push(Some(process_token));
             tracing::debug!("Booted process {} at {}", i, ip);
         }

--- a/crates/moonpool-sim/src/runner/process_manager.rs
+++ b/crates/moonpool-sim/src/runner/process_manager.rs
@@ -86,8 +86,28 @@ fn panic_message(payload: &(dyn Any + Send)) -> String {
     }
 }
 
+/// One boot of a process: its root task, and the scope every task it spawns
+/// through its provider is bound to.
+///
+/// Killing the boot is both halves: abort the root and cancel the scope, so
+/// the descendants a crash would otherwise leave running die with it.
+pub(crate) struct ProcessBoot {
+    handle: crate::executor::JoinHandle<()>,
+    scope: tokio_util::sync::CancellationToken,
+}
+
+impl ProcessBoot {
+    /// Stop the boot: the root task now, its spawned tasks before their next
+    /// poll.
+    fn kill(self) {
+        self.handle.abort();
+        self.scope.cancel();
+    }
+}
+
 /// Spawn `process` as its own task, inside the `process` span the
-/// observability layer attributes events by.
+/// observability layer attributes events by, with `scope` as the boot's
+/// task scope (the one its `ctx` providers were built with).
 ///
 /// A panic in [`Process::run`] is caught *here*, at the one place that knows
 /// which process it was, and recorded in `panics`; the seed then fails at the
@@ -102,11 +122,12 @@ pub(crate) fn spawn_process(
     ctx: SimContext,
     ip: &str,
     panics: &ProcessPanics,
-) -> crate::executor::JoinHandle<()> {
+    scope: tokio_util::sync::CancellationToken,
+) -> ProcessBoot {
     let ip = ip.to_string();
     let span_ip = ip.clone();
     let panics = Arc::clone(panics);
-    crate::executor::spawn(
+    let handle = crate::executor::spawn(
         &format!("process@{span_ip}"),
         async move {
             let outcome = AssertUnwindSafe(process.run(&ctx)).catch_unwind().await;
@@ -126,14 +147,15 @@ pub(crate) fn spawn_process(
             }
         }
         .instrument(tracing::info_span!("process", ip = %span_ip)),
-    )
+    );
+    ProcessBoot { handle, scope }
 }
 
 /// Owns running process tasks and their restart state.
 pub(crate) struct ProcessManager<'a> {
     /// Per-process factories, parallel to `ips` (empty without processes).
     factories: Vec<ProcessFactory<'a>>,
-    handles: Vec<Option<crate::executor::JoinHandle<()>>>,
+    handles: Vec<Option<ProcessBoot>>,
     process_tokens: Vec<Option<tokio_util::sync::CancellationToken>>,
     ips: Vec<String>,
     tag_registry: TagRegistry,
@@ -166,7 +188,7 @@ impl<'a> ProcessManager<'a> {
 
     pub(crate) fn new(
         config: ProcessConfig<'a>,
-        handles: Vec<Option<crate::executor::JoinHandle<()>>>,
+        handles: Vec<Option<ProcessBoot>>,
         process_tokens: Vec<Option<tokio_util::sync::CancellationToken>>,
         all_entities: Vec<(String, String)>,
         panics: ProcessPanics,
@@ -249,8 +271,8 @@ impl<'a> ProcessManager<'a> {
             tracing::warn!(%ip, "ProcessForceKill for unknown IP");
             return;
         };
-        if let Some(handle) = self.handles[index].take() {
-            handle.abort();
+        if let Some(boot) = self.handles[index].take() {
+            boot.kill();
             tracing::info!(%ip, index, "force-killed process");
         }
         self.process_tokens[index] = None;
@@ -274,11 +296,12 @@ impl<'a> ProcessManager<'a> {
             return;
         };
 
-        if let Some(handle) = self.handles[index].take() {
-            handle.abort();
+        if let Some(boot) = self.handles[index].take() {
+            boot.kill();
         }
 
         let process_token = shutdown_signal.child_token();
+        let scope = tokio_util::sync::CancellationToken::new();
         self.process_tokens[index] = Some(process_token.clone());
         let process = factory();
         // A process is numbered within its own group, exactly as on first boot.
@@ -300,14 +323,14 @@ impl<'a> ProcessManager<'a> {
             shutdown_signal: process_token,
         });
         let ctx = SimContext::new(
-            crate::SimProviders::new(sim.clone(), ip),
+            crate::SimProviders::new(sim.clone(), ip).with_task_scope(scope.clone()),
             topology,
             state.clone(),
             obs.clone(),
             metrics.clone(),
         );
-        let handle = spawn_process(process, ctx, &ip_string, &self.panics);
-        self.handles[index] = Some(handle);
+        let boot = spawn_process(process, ctx, &ip_string, &self.panics, scope);
+        self.handles[index] = Some(boot);
         self.dead
             .lock()
             .expect("Mutex poisoned: prior task panicked")
@@ -317,9 +340,9 @@ impl<'a> ProcessManager<'a> {
     }
 
     pub(crate) fn abort_all(&mut self) {
-        for handle in &mut self.handles {
-            if let Some(handle) = handle.take() {
-                handle.abort();
+        for boot in &mut self.handles {
+            if let Some(boot) = boot.take() {
+                boot.kill();
             }
         }
     }

--- a/crates/moonpool-sim/tests/process_task_scope.rs
+++ b/crates/moonpool-sim/tests/process_task_scope.rs
@@ -1,0 +1,149 @@
+//! Regression: a crashed process's spawned tasks die with it.
+//!
+//! A process spawns a background worker through `ctx.task().spawn_task()`,
+//! drops the join handle, and parks. Crashing the process used to abort only
+//! the root future: the task provider was stateless and spawned straight into
+//! the shared executor, so the worker kept running through the hold-down and
+//! beside the rebooted process's own worker afterwards — a "crash" that
+//! preserved application work and in-memory state, which no recovery test
+//! can trust.
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use moonpool_sim::{
+    FaultContext, FaultInjector, Process, SimContext, SimulationBuilder, SimulationError,
+    SimulationResult, TaskProvider, TimeProvider, Workload, assert_always,
+};
+
+/// Spawns a detached worker that bumps a per-IP counter every 10ms, then
+/// parks until shut down. All of its work happens in the child task.
+struct WorkerProcess;
+
+#[async_trait]
+impl Process for WorkerProcess {
+    fn name(&self) -> &'static str {
+        "worker_process"
+    }
+
+    async fn run(&mut self, ctx: &SimContext) -> SimulationResult<()> {
+        let key = format!("worker_ticks:{}", ctx.my_ip());
+        let time = ctx.time().clone();
+        let state = ctx.state().clone();
+        ctx.task()
+            .spawn_task("worker", async move {
+                loop {
+                    if time.sleep(Duration::from_millis(10)).await.is_err() {
+                        return;
+                    }
+                    let ticks: u64 = state.get(&key).unwrap_or(0);
+                    state.publish(&key, ticks + 1);
+                }
+            })
+            .detach();
+        ctx.shutdown().cancelled().await;
+        Ok(())
+    }
+}
+
+/// Keeps the run alive long enough for the script to play out.
+struct PatientWorkload;
+
+#[async_trait]
+impl Workload for PatientWorkload {
+    fn name(&self) -> &'static str {
+        "patient"
+    }
+
+    async fn run(&mut self, ctx: &SimContext) -> SimulationResult<()> {
+        for _ in 0..200 {
+            ctx.time()
+                .sleep(Duration::from_millis(5))
+                .await
+                .map_err(|e| SimulationError::InvalidState(format!("sleep failed: {e}")))?;
+        }
+        Ok(())
+    }
+}
+
+/// Crash process 0, hold it down, and require its worker to have stopped;
+/// then restart it and require a worker to be ticking again.
+struct CrashAndWatchWorker;
+
+impl CrashAndWatchWorker {
+    async fn pause(ctx: &FaultContext, ms: u64) -> SimulationResult<bool> {
+        if ctx.chaos_shutdown().is_cancelled() {
+            return Ok(false);
+        }
+        ctx.time()
+            .sleep(Duration::from_millis(ms))
+            .await
+            .map_err(|e| SimulationError::InvalidState(format!("sleep failed: {e}")))?;
+        Ok(!ctx.chaos_shutdown().is_cancelled())
+    }
+}
+
+#[async_trait]
+impl FaultInjector for CrashAndWatchWorker {
+    fn name(&self) -> &'static str {
+        "crash_and_watch_worker"
+    }
+
+    async fn inject(&mut self, ctx: &FaultContext) -> SimulationResult<()> {
+        if !Self::pause(ctx, 100).await? {
+            return Ok(());
+        }
+        let target = ctx.process_ips()[0].clone();
+        let key = format!("worker_ticks:{target}");
+        assert_always!(
+            ctx.state().get::<u64>(&key).unwrap_or(0) > 0,
+            "the worker ticked before the crash"
+        );
+
+        ctx.crash(&target)?;
+        if !Self::pause(ctx, 30).await? {
+            return Ok(());
+        }
+        let held: u64 = ctx.state().get(&key).unwrap_or(0);
+        if !Self::pause(ctx, 200).await? {
+            return Ok(());
+        }
+        assert_always!(
+            ctx.state().get::<u64>(&key).unwrap_or(0) == held,
+            "a crashed process's spawned tasks must stop with it"
+        );
+
+        ctx.restart(&target)?;
+        let mut recovered = false;
+        for _ in 0..20 {
+            if !Self::pause(ctx, 20).await? {
+                break;
+            }
+            if ctx.state().get::<u64>(&key).unwrap_or(0) > held {
+                recovered = true;
+                break;
+            }
+        }
+        assert_always!(recovered, "the restarted process's worker ticks again");
+        Ok(())
+    }
+}
+
+#[test]
+fn a_crash_stops_the_tasks_the_process_spawned() {
+    let report = SimulationBuilder::new()
+        .processes(1, || Box::new(WorkerProcess))
+        .workload_factory(|| Box::new(PatientWorkload))
+        .fault_factory(|| Box::new(CrashAndWatchWorker))
+        .chaos_duration(Duration::from_secs(30))
+        .set_iterations(3)
+        .set_debug_seeds(vec![7, 11, 13])
+        .run();
+
+    assert_eq!(report.iterations, 3);
+    assert_eq!(
+        report.failed_runs, 0,
+        "no spawned task may outlive its process's crash"
+    );
+    assert_eq!(report.successful_runs, 3);
+}


### PR DESCRIPTION
Closes #221

## Problem

A process that spawned a background task through `ctx.task().spawn_task()`, dropped the join handle and parked kept that task running after the process was crashed. `SimTaskProvider` was stateless and spawned straight into the shared executor, and the process manager aborted only the root handle. A crash therefore preserved application work and in-memory state, and a reboot left the old worker running beside the new process's own, which no recovery test can trust.

## Fix

- Every process boot now owns a **task scope** (a `CancellationToken`) that its `SimProviders` bundle carries into the task provider (`SimProviders::with_task_scope`, `SimTaskProvider::scoped`).
- A task spawned through a scoped provider, and every task those spawn in turn, is wrapped in a `Scoped` future that polls the scope *before* the application future on every poll. A cancelled scope completes the task and drops the application future without giving it another poll, the same "no application work after the kill" rule the root future gets from `abort`.
- `ProcessBoot` pairs the root handle with its scope; force kill, restart and end-of-run all `kill()` the boot (abort root, cancel scope).
- Workload providers carry no scope: a workload survives everything, and its `check()` may still spawn.
- The book's process chapter states the rule.

## Tests

`tests/process_task_scope.rs` runs a scripted crash / hold-down / restart with a fault injector: the worker a process spawned must stop ticking while its process is held down, and a restarted process's worker must tick again.

Red→green: red on all three seeds before the change (the worker kept ticking through the hold-down), green after. The full `moonpool-sim` suite, both clippy gates and formatting pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013CytnDdK8Nsp66srsvuvdE

---
_Generated by [Claude Code](https://claude.ai/code/session_013CytnDdK8Nsp66srsvuvdE)_