### PR TITLE
fix(moonpool-sim): make AsyncWrite::close a write shutdown, not a close

### DIFF
--- a/book/src/part3-building/10-network-faults.md
+++ b/book/src/part3-building/10-network-faults.md
@@ -188,6 +188,8 @@ When a connection closes, moonpool models two distinct TCP behaviors:
 
 **Graceful close** implements TCP half-close semantics. The closing side marks its send direction as closed and puts a FIN on the wire behind every byte still queued or in flight, so it lands after all of them and is held by a partition with them. The remote side continues reading buffered data normally and sees EOF only after the FIN arrives. What the closing side itself never read is discarded and its window returned to the peer's writer, as a kernel frees a closed socket's receive buffer. This models a clean `shutdown(SHUT_WR)` followed by `close()`.
 
+**Write shutdown** is what `AsyncWrite::close` does, on both backends: the production provider's compat wrapper maps it onto tokio's `poll_shutdown`, that is `shutdown(SHUT_WR)`, and the simulated stream does the same. The FIN goes out behind the queued bytes and further writes fail with `BrokenPipe`, but the read half stays open and nothing is discarded, so the reply to an EOF-delimited request still lands and is still readable. Dropping the stream is what closes the connection, and a drop after a shutdown adds the receive half without sending a second FIN.
+
 **Abort close** immediately terminates both directions. No FIN, no buffer drain: the send queue, the flight, and the unread bytes are gone. The remote side gets a connection reset error on its next read or write, and a writer parked on a full window is woken to that error rather than left waiting on credits nothing can return. This models a crashed process or a force-killed connection.
 
 ## Flow control

--- a/crates/moonpool-sim/src/network/sim/engine.rs
+++ b/crates/moonpool-sim/src/network/sim/engine.rs
@@ -1748,6 +1748,55 @@ impl NetworkSimulation {
             .is_some_and(|connection| connection.flags.send_black_holed())
     }
 
+    /// Shut down the send direction only — `shutdown(SHUT_WR)`.
+    ///
+    /// The FIN goes on the wire behind every byte still queued or in flight
+    /// and further writes fail with `BrokenPipe`; the receive direction is
+    /// untouched, so what the peer sends after seeing EOF (the reply of an
+    /// EOF-delimited request/response protocol) still lands and is still
+    /// readable. Nothing is discarded. Returns without effect once the send
+    /// side is already shut or the connection closed.
+    pub(crate) fn shutdown_send(
+        &mut self,
+        id: ConnectionId,
+        now: Duration,
+    ) -> (NetworkActions, WakeBatch) {
+        let mut actions = NetworkActions::default();
+        let mut wakes = WakeBatch::default();
+        let Some((send_closed, is_closed, send_in_progress, queue_empty)) = self.close_snapshot(id)
+        else {
+            return (actions, wakes);
+        };
+        if send_closed || is_closed {
+            return (actions, wakes);
+        }
+        if let Some(c) = self.state.connections.get_mut(&id) {
+            c.flags.set_send_closed(true);
+            if send_in_progress || !queue_empty {
+                c.flags.set_graceful_close_pending(true);
+            }
+        }
+        // A writer parked on the window must wake to the shut send side.
+        Self::take_waiter(&mut self.waiters.send_buffers, id, &mut wakes);
+        if !send_in_progress && queue_empty {
+            self.put_fin_in_flight(id, now, &mut actions);
+        }
+        (actions, wakes)
+    }
+
+    /// `(send_closed, is_closed, send_in_progress, send queue empty)`, or
+    /// `None` for an unknown connection.
+    fn close_snapshot(&self, id: ConnectionId) -> Option<(bool, bool, bool, bool)> {
+        self.state.connections.get(&id).map(|c| {
+            (
+                c.flags.send_closed(),
+                c.flags.is_closed(),
+                c.flags.send_in_progress(),
+                c.send_buffer.is_empty(),
+            )
+        })
+    }
+
     pub(crate) fn close_graceful(
         &mut self,
         id: ConnectionId,
@@ -1755,25 +1804,22 @@ impl NetworkSimulation {
     ) -> (NetworkActions, WakeBatch) {
         let mut actions = NetworkActions::default();
         let mut wakes = WakeBatch::default();
-        let Some(snapshot) = self.state.connections.get(&id).map(|c| {
-            (
-                c.flags.send_closed(),
-                c.flags.is_closed(),
-                c.flags.send_in_progress(),
-                c.send_buffer.is_empty(),
-            )
-        }) else {
+        let Some((send_closed, is_closed, send_in_progress, queue_empty)) = self.close_snapshot(id)
+        else {
             return (actions, wakes);
         };
-        let (send_closed, is_closed, send_in_progress, queue_empty) = snapshot;
-        if send_closed || is_closed {
+        if is_closed {
             return (actions, wakes);
         }
+        // A send side already shut (`shutdown_send`) has its FIN on the wire
+        // or pending behind the queue; the close adds the receive half and
+        // must not send a second FIN.
+        let fin_sent = send_closed;
         if let Some(c) = self.state.connections.get_mut(&id) {
             c.flags.set_is_closed(true);
             c.flags.set_send_closed(true);
             c.close_reason = CloseReason::Graceful;
-            if send_in_progress || !queue_empty {
+            if !fin_sent && (send_in_progress || !queue_empty) {
                 c.flags.set_graceful_close_pending(true);
             }
         }
@@ -1783,7 +1829,7 @@ impl NetworkSimulation {
         self.discard_receive_buffer(id, &mut wakes);
         // The FIN goes on the wire behind whatever is already in flight; it
         // can never overtake the stream's last bytes.
-        if !send_in_progress && queue_empty {
+        if !fin_sent && !send_in_progress && queue_empty {
             self.put_fin_in_flight(id, now, &mut actions);
         }
         (actions, wakes)

--- a/crates/moonpool-sim/src/network/sim/facade.rs
+++ b/crates/moonpool-sim/src/network/sim/facade.rs
@@ -318,6 +318,19 @@ impl SimWorld {
         wakes.wake();
     }
 
+    /// Shuts down the send direction of a connection (`shutdown(SHUT_WR)`):
+    /// a FIN behind the queued bytes, the receive direction left open.
+    pub fn shutdown_send(&self, id: ConnectionId) {
+        let wakes = {
+            let mut inner = self.inner.write();
+            let now = inner.now();
+            let (actions, wakes) = inner.network.shutdown_send(id, now);
+            inner.apply_network(actions);
+            wakes
+        };
+        wakes.wake();
+    }
+
     /// Aborts a connection with RST semantics.
     pub fn close_connection_abort(&self, id: ConnectionId) {
         let wakes = self.inner.write().network.close_aborted(id);

--- a/crates/moonpool-sim/src/network/sim/stream.rs
+++ b/crates/moonpool-sim/src/network/sim/stream.rs
@@ -530,12 +530,16 @@ impl AsyncWrite for SimTcpStream {
     fn poll_close(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
         let sim = self.sim.upgrade().map_err(|_| sim_shutdown_error())?;
 
-        // Close the connection in the simulation when close is called
+        // `AsyncWrite::close` is a *write* shutdown, as the production
+        // provider's compat wrapper maps it onto tokio's `poll_shutdown`
+        // (`shutdown(SHUT_WR)`): the FIN goes out behind the queued bytes and
+        // the read half stays open, so an EOF-delimited request still gets
+        // its reply. Dropping the stream is what closes the connection.
         tracing::debug!(
-            "SimTcpStream::poll_close closing connection {}",
+            "SimTcpStream::poll_close shutting down the send side of connection {}",
             self.connection_id.0
         );
-        sim.close_connection(self.connection_id);
+        sim.shutdown_send(self.connection_id);
 
         Poll::Ready(Ok(()))
     }

--- a/crates/moonpool-sim/tests/flow_control.rs
+++ b/crates/moonpool-sim/tests/flow_control.rs
@@ -304,18 +304,20 @@ fn an_abort_wakes_a_writer_parked_on_the_window() {
 }
 
 /// A peer that closes with the window's bytes unread frees them: the writer
-/// is woken and, on its next write, told the stream is gone.
+/// is woken and, on its next write, told the stream is gone. The close is
+/// the drop of the stream; `AsyncWrite::close` is only a write shutdown and
+/// frees nothing the peer has not read.
 #[test]
 fn a_peer_close_with_unread_bytes_frees_the_window() {
     const WINDOW: usize = 1024;
-    let (mut sim, mut client, mut server) = connected(config(WINDOW, Duration::from_micros(1)));
+    let (mut sim, mut client, server) = connected(config(WINDOW, Duration::from_micros(1)));
     assert_eq!(fill_window(&mut client, 4096), WINDOW);
     sim.run_until_empty();
     assert_eq!(sim.unread_bytes(server.connection_id()), WINDOW);
     let (wake_count, waker) = counting_waker();
     assert!(poll_write_with(&mut client, b"x", &waker).is_pending());
 
-    assert!(matches!(poll_close_once(&mut server), Poll::Ready(Ok(()))));
+    drop(server);
 
     assert_eq!(
         wake_count.0.load(Ordering::Relaxed),

--- a/crates/moonpool-sim/tests/network.rs
+++ b/crates/moonpool-sim/tests/network.rs
@@ -2,6 +2,8 @@
 //!
 //! Contains tests for network simulation and configuration.
 
+#[path = "network/half_close.rs"]
+mod half_close;
 #[path = "network/in_flight.rs"]
 mod in_flight;
 #[path = "network/latency.rs"]

--- a/crates/moonpool-sim/tests/network/half_close.rs
+++ b/crates/moonpool-sim/tests/network/half_close.rs
@@ -1,0 +1,158 @@
+//! `AsyncWrite::close` is a write shutdown, not a connection close.
+//!
+//! The production provider wraps `tokio::net::TcpStream` in a compat layer
+//! that maps `poll_close` onto tokio's `poll_shutdown`, i.e. `shutdown(SHUT_WR)`:
+//! a FIN behind the queued bytes, the read half left open. The simulated
+//! stream used to close the whole connection instead — marking the endpoint
+//! closed and discarding its receive buffer — so an EOF-delimited
+//! request/response protocol that works in production lost its reply in
+//! simulation.
+
+use futures::{
+    io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
+    task::noop_waker,
+};
+use moonpool_sim::{
+    NetworkConfiguration, NetworkProvider, SimWorld, TcpListenerTrait, buggify_reset,
+    network::sim::SimTcpStream,
+};
+use std::{
+    future::Future,
+    io,
+    net::IpAddr,
+    pin::{Pin, pin},
+    task::{Context, Poll},
+};
+
+const MAX_DRIVER_STEPS: usize = 10_000;
+
+fn client_ip() -> IpAddr {
+    "10.0.1.1".parse().expect("valid test IP")
+}
+
+fn server_ip() -> IpAddr {
+    "10.0.1.2".parse().expect("valid test IP")
+}
+
+/// Poll a simulation-backed future, advancing virtual time whenever it parks.
+fn drive<F: Future>(sim: &mut SimWorld, future: F) -> F::Output {
+    let mut future = pin!(future);
+    let waker = noop_waker();
+    let mut context = Context::from_waker(&waker);
+    for _ in 0..MAX_DRIVER_STEPS {
+        if let Poll::Ready(output) = future.as_mut().poll(&mut context) {
+            return output;
+        }
+        assert!(
+            sim.has_pending_events(),
+            "simulation-backed future stalled without a pending event"
+        );
+        sim.step();
+    }
+    panic!("simulation-backed future exceeded {MAX_DRIVER_STEPS} events")
+}
+
+fn poll_write_once(stream: &mut (impl AsyncWrite + Unpin), data: &[u8]) -> Poll<io::Result<usize>> {
+    let waker = noop_waker();
+    let mut context = Context::from_waker(&waker);
+    Pin::new(stream).poll_write(&mut context, data)
+}
+
+fn poll_read_once(
+    stream: &mut (impl AsyncRead + Unpin),
+    data: &mut [u8],
+) -> Poll<io::Result<usize>> {
+    let waker = noop_waker();
+    let mut context = Context::from_waker(&waker);
+    Pin::new(stream).poll_read(&mut context, data)
+}
+
+/// An established, settled connection between `10.0.1.1` and `10.0.1.2`.
+fn connected() -> (SimWorld, SimTcpStream, SimTcpStream) {
+    buggify_reset();
+    let mut sim =
+        SimWorld::new_with_network_config_and_seed(NetworkConfiguration::fast_local(), 20_260_911);
+    let server_provider = sim.network_provider(server_ip());
+    let listener = drive(&mut sim, server_provider.bind("10.0.1.2:8080")).expect("bind");
+    let client_provider = sim.network_provider(client_ip());
+    let client = drive(&mut sim, client_provider.connect("10.0.1.2:8080")).expect("connect");
+    let (server, _) = drive(&mut sim, listener.accept()).expect("accept");
+    sim.run_until_empty();
+    assert_eq!(sim.pending_event_count(), 0, "the handshake has settled");
+    (sim, client, server)
+}
+
+/// The EOF-delimited protocol: the client sends its request and shuts down
+/// its write side; the server reads to EOF, answers, and closes; the client
+/// reads the whole answer.
+#[test]
+fn a_write_shutdown_keeps_the_read_half_open_for_the_reply() {
+    const REQUEST: &[u8] = b"GET /the-thing";
+    const REPLY: &[u8] = b"here is the thing";
+    let (mut sim, mut client, mut server) = connected();
+
+    drive(&mut sim, client.write_all(REQUEST)).expect("request accepted");
+    drive(&mut sim, client.close()).expect("write shutdown succeeds");
+
+    let mut request = Vec::new();
+    drive(&mut sim, server.read_to_end(&mut request)).expect("the server reads to EOF");
+    assert_eq!(request, REQUEST, "the request lands whole, then EOF");
+
+    drive(&mut sim, server.write_all(REPLY)).expect("the reply is accepted after the peer's FIN");
+    drop(server);
+
+    let mut reply = Vec::new();
+    drive(&mut sim, client.read_to_end(&mut reply)).expect("the client reads to EOF");
+    assert_eq!(
+        reply, REPLY,
+        "the reply must survive the client's own write shutdown"
+    );
+}
+
+/// After the shutdown the send side is shut, exactly as after `SHUT_WR`.
+#[test]
+fn a_write_after_the_shutdown_is_refused() {
+    let (mut sim, mut client, mut server) = connected();
+    drive(&mut sim, client.close()).expect("write shutdown succeeds");
+
+    let error = match poll_write_once(&mut client, b"late") {
+        Poll::Ready(Err(error)) => error,
+        other => panic!("a write after shutdown must fail, got {other:?}"),
+    };
+    assert_eq!(error.kind(), io::ErrorKind::BrokenPipe);
+
+    // The peer still sees exactly one EOF, and can still write back.
+    let mut byte = [0_u8; 1];
+    assert_eq!(drive(&mut sim, server.read(&mut byte)).expect("EOF"), 0);
+    drive(&mut sim, server.write_all(b"still open this way")).expect("peer writes back");
+    let mut reply = vec![0_u8; 19];
+    drive(&mut sim, client.read_exact(&mut reply)).expect("and the client still reads");
+    assert_eq!(&reply, b"still open this way");
+}
+
+/// Dropping a stream whose send side is already shut completes the close:
+/// the connection is closed, and no second FIN reaches the peer.
+#[test]
+fn dropping_after_the_shutdown_closes_the_connection_once() {
+    let (mut sim, mut client, mut server) = connected();
+    let id = client.connection_id();
+    drive(&mut sim, client.close()).expect("write shutdown succeeds");
+    assert!(
+        !sim.is_connection_closed(id),
+        "a write shutdown leaves the connection open"
+    );
+
+    drop(client);
+    assert!(
+        sim.is_connection_closed(id),
+        "the drop closes the connection"
+    );
+    sim.run_until_empty();
+
+    let mut byte = [0_u8; 1];
+    assert_eq!(drive(&mut sim, server.read(&mut byte)).expect("EOF"), 0);
+    assert!(
+        matches!(poll_read_once(&mut server, &mut byte), Poll::Ready(Ok(0))),
+        "EOF is sticky, never a second event"
+    );
+}


### PR DESCRIPTION
Closes #226

## Problem

`SimTcpStream::poll_close` closed the whole connection: the endpoint was marked closed and its receive buffer discarded. The production provider wraps tokio's `TcpStream` in a compat layer that maps `poll_close` onto `poll_shutdown`, i.e. `shutdown(SHUT_WR)`: a FIN behind the queued bytes with the read half left open. So an EOF-delimited request/response protocol that works in production lost its reply in simulation.

## Fix

- `poll_close` now calls a new `NetworkSimulation::shutdown_send`: the send side is shut (further writes fail with `BrokenPipe`, a writer parked on the window is woken), the FIN goes on the wire behind whatever is queued or in flight, and the receive direction is untouched. Nothing is discarded, and the peer's reply still lands and reads.
- Dropping the stream remains the close. `close_graceful` now finishes a connection whose send side is already shut by adding the receive half without a second FIN, instead of returning early and leaving it open forever.
- The book's network-faults chapter gains a "write shutdown" paragraph beside graceful and abort close.

## Tests

`tests/network/half_close.rs` pins three things: the protocol (request, shutdown, server reads to EOF and replies, client reads the reply), the refused write after the shutdown with the peer still able to write back, and the drop-after-shutdown close with a single EOF at the peer. All three are red on the previous stream. The flow-control test that modelled "the peer closes" with `poll_close` now drops the stream, which is the close it meant.

Validation run locally: `cargo fmt`, both clippy gates, the full `moonpool-sim` suite, `moonpool-hyper` tests, and all seven example simulations via `cargo xtask sim run-all`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013CytnDdK8Nsp66srsvuvdE

---
_Generated by [Claude Code](https://claude.ai/code/session_013CytnDdK8Nsp66srsvuvdE)_