### PR TITLE
fix(moonpool-sim): keep open files alive across unlink and rename-over

### DIFF
--- a/book/src/part2-foundations/07-provider-traits.md
+++ b/book/src/part2-foundations/07-provider-traits.md
@@ -201,7 +201,12 @@ pub trait StorageFile: AsyncRead + AsyncWrite + AsyncSeek + Unpin + Send + Sync 
 Storage is the newest provider, and the one with the richest fault model. The
 split is that the **provider owns the filesystem namespace** — open, exists,
 delete, rename, and the directory sync that makes those durable — while the
-**file owns already-open bytes**.
+**file owns already-open bytes**. The two never cross: a `delete`, or a
+`rename` over a name, removes the name and nothing else, so a file opened
+before it keeps reading and writing the same bytes, exactly as on Unix, and
+the bytes are freed only when the last name and the last handle are both
+gone. Log rotation and atomic replacement lean on that in production, and
+the simulator holds to it too.
 
 `OpenOptions` mirrors `std::fs::OpenOptions` with `read`, `write`, `create`,
 `truncate`, and `append`, plus the one thing a database needs that

--- a/crates/moonpool-sim/src/storage/sim/engine.rs
+++ b/crates/moonpool-sim/src/storage/sim/engine.rs
@@ -269,6 +269,13 @@ impl StorageEngine {
         self.state.path_to_file.contains_key(path)
     }
 
+    /// Remove a name from the namespace — `unlink(2)`.
+    ///
+    /// A namespace operation never reaches already-open bytes: a handle
+    /// opened before the unlink keeps reading and writing the same image, as
+    /// on the production (Unix) backend, and the image is freed only when its
+    /// last name and its last handle are both gone. Log rotation, compaction
+    /// and atomic replacement depend on exactly that.
     pub(crate) fn delete_file(&mut self, path: &str) -> Result<StorageActions, StorageError> {
         let Some(file_id) = self.state.path_to_file.remove(path) else {
             return Err(StorageError::NotFound {
@@ -276,22 +283,28 @@ impl StorageEngine {
             });
         };
         self.drop_file_if_unlinked(file_id);
-        let mut actions = StorageActions::default();
-        self.invalidate_file_handles(file_id, &mut actions, false);
-        Ok(actions)
+        Ok(StorageActions::default())
     }
 
-    /// Forget a file's contents once no name — visible or durable — reaches
-    /// it any more. A file whose only remaining link is the durable one is
-    /// still on the disk: a crash before the directory sync brings it back.
+    /// Forget a file's contents once nothing reaches it any more: no name,
+    /// visible or durable, and no open handle. A file whose only remaining
+    /// link is the durable one is still on the disk: a crash before the
+    /// directory sync brings it back. A file whose only remaining link is an
+    /// open handle is an unlinked-but-open file, freed when that handle
+    /// closes.
     fn drop_file_if_unlinked(&mut self, file_id: FileId) {
-        let linked = self
+        let named = self
             .state
             .path_to_file
             .values()
             .chain(self.state.durable_paths.values())
             .any(|id| *id == file_id);
-        if !linked {
+        let open = self
+            .state
+            .handles
+            .values()
+            .any(|handle| handle.file_id == file_id && !handle.is_closed);
+        if !named && !open {
             self.state.files.remove(&file_id);
         }
     }
@@ -316,16 +329,16 @@ impl StorageEngine {
                 path: from.to_string(),
             });
         };
-        let mut actions = StorageActions::default();
+        // The replaced file loses its name, nothing more: handles opened on
+        // it before the rename keep its image, as `rename(2)` guarantees.
         if let Some(replaced_id) = self.state.path_to_file.remove(to) {
             self.drop_file_if_unlinked(replaced_id);
-            self.invalidate_file_handles(replaced_id, &mut actions, false);
         }
         if let Some(file) = self.state.files.get_mut(&file_id) {
             file.path = to.to_string();
         }
         self.state.path_to_file.insert(to.to_string(), file_id);
-        Ok(actions)
+        Ok(StorageActions::default())
     }
 
     /// Install the eligibility mask consulted before any random fault damages
@@ -1299,6 +1312,8 @@ impl StorageEngine {
             actions.cancel(operation_id);
             actions.wakes.push(self.wakers.take(&operation_id));
         }
+        // The last handle on an unlinked file frees its image.
+        self.drop_file_if_unlinked(handle.file_id);
         actions
     }
 
@@ -1346,6 +1361,13 @@ impl StorageEngine {
         for handle_id in handle_ids {
             self.fail_handle_operations(handle_id, &mut actions, close_files);
         }
+        // A crash closes every handle the process held, so an unlinked file
+        // it was still reading is gone with it.
+        if close_files {
+            for file_id in file_ids {
+                self.drop_file_if_unlinked(file_id);
+            }
+        }
         actions.fault(SimFaultEvent::StorageCrash { ip: ip.to_string() });
         actions
     }
@@ -1365,7 +1387,7 @@ impl StorageEngine {
             self.state.path_to_file.remove(&path);
             self.state.durable_paths.retain(|_, id| *id != file_id);
             let _ = path;
-            self.invalidate_file_handles(file_id, &mut actions, true);
+            self.invalidate_file_handles(file_id, &mut actions);
         }
         actions.fault(SimFaultEvent::StorageWipe { ip: ip.to_string() });
         actions
@@ -1429,12 +1451,9 @@ impl StorageEngine {
         }
     }
 
-    fn invalidate_file_handles(
-        &mut self,
-        file_id: FileId,
-        actions: &mut StorageActions,
-        remove_handles: bool,
-    ) {
+    /// Destroy every handle on `file_id`: the file's bytes are gone (a
+    /// wipe), so no handle can keep reaching them.
+    fn invalidate_file_handles(&mut self, file_id: FileId, actions: &mut StorageActions) {
         let handle_ids = self
             .state
             .handles
@@ -1443,9 +1462,7 @@ impl StorageEngine {
             .collect::<Vec<_>>();
         for handle_id in handle_ids {
             self.fail_handle_operations(handle_id, actions, true);
-            if remove_handles {
-                self.state.handles.remove(&handle_id);
-            }
+            self.state.handles.remove(&handle_id);
         }
     }
 

--- a/crates/moonpool-sim/tests/storage/basic.rs
+++ b/crates/moonpool-sim/tests/storage/basic.rs
@@ -333,12 +333,14 @@ fn deleted_path_can_be_reused_as_rename_target() {
     });
 }
 
+/// `rename(2)` over an existing name replaces the name only: a handle opened
+/// on the replaced file keeps its image, as on the production backend.
 #[test]
-fn rename_replaces_existing_target_and_invalidates_its_handles() {
+fn rename_replaces_existing_target_and_keeps_its_open_handles() {
     local_runtime().block_on(async {
         let result: std::io::Result<()> = run_storage_test(fast_sim(), |provider| async move {
             let mut old_target = provider
-                .open("target.txt", OpenOptions::create_write())
+                .open("target.txt", OpenOptions::create_write().read(true))
                 .await?;
             old_target.write_all(b"old").await?;
             old_target.sync_all().await?;
@@ -351,11 +353,15 @@ fn rename_replaces_existing_target_and_invalidates_its_handles() {
             drop(source);
 
             provider.rename("source.txt", "target.txt").await?;
-            let error = old_target
-                .size()
-                .await
-                .expect_err("replaced handle must close");
-            assert_eq!(error.kind(), std::io::ErrorKind::BrokenPipe);
+            assert_eq!(
+                old_target.size().await?,
+                3,
+                "the replaced file's handle still reaches its image"
+            );
+            old_target.seek(SeekFrom::Start(0)).await?;
+            let mut old_contents = Vec::new();
+            old_target.read_to_end(&mut old_contents).await?;
+            assert_eq!(old_contents, b"old");
 
             let mut target = provider
                 .open("target.txt", OpenOptions::read_only())

--- a/crates/moonpool-sim/tests/storage/parity.rs
+++ b/crates/moonpool-sim/tests/storage/parity.rs
@@ -542,3 +542,151 @@ fn the_simulator_refuses_the_seeks_production_refuses() {
         }
     });
 }
+
+/// One step of the open-file contract: what a read through a handle, or a
+/// namespace query, answered.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct NameStep {
+    label: &'static str,
+    outcome: Result<Vec<u8>, std::io::ErrorKind>,
+}
+
+async fn read_all<F: StorageFile>(file: &F, len: usize) -> Result<Vec<u8>, std::io::ErrorKind> {
+    let mut bytes = vec![0_u8; len];
+    let mut read = 0;
+    while read < len {
+        match file.read_at(read as u64, &mut bytes[read..]).await {
+            Ok(0) => break,
+            Ok(n) => read += n,
+            Err(error) => return Err(error.kind()),
+        }
+    }
+    bytes.truncate(read);
+    Ok(bytes)
+}
+
+/// Unlink and rename-over with handles held open: the handles keep the old
+/// image, the names answer for the new one.
+async fn open_file_contract<P: StorageProvider>(
+    provider: P,
+    prefix: String,
+) -> std::io::Result<Vec<NameStep>> {
+    let mut log = Vec::new();
+    let mut step = |label: &'static str, outcome: Result<Vec<u8>, std::io::ErrorKind>| {
+        log.push(NameStep { label, outcome });
+    };
+    let exists = |present: bool| Ok(vec![u8::from(present)]);
+
+    // unlink: the open handle outlives the name.
+    let alpha = format!("{prefix}alpha.db");
+    let mut writer = provider
+        .open(&alpha, OpenOptions::create_new_write())
+        .await?;
+    writer.write_all(b"alpha-bytes").await?;
+    writer.sync_all().await?;
+    drop(writer);
+    let held = provider.open(&alpha, OpenOptions::read_write()).await?;
+    provider.delete(&alpha).await?;
+    step(
+        "alpha exists after unlink",
+        exists(provider.exists(&alpha).await?),
+    );
+    step("held handle reads after unlink", read_all(&held, 64).await);
+    step(
+        "held handle writes after unlink",
+        held.write_at(0, b"ALPHA")
+            .await
+            .map(|n| vec![u8::try_from(n).unwrap_or(u8::MAX)])
+            .map_err(|e| e.kind()),
+    );
+    step("held handle reads its write", read_all(&held, 64).await);
+    drop(held);
+    step(
+        "alpha exists once the handle is gone",
+        exists(provider.exists(&alpha).await?),
+    );
+
+    // rename over: the handle on the replaced file keeps the replaced image.
+    let bravo = format!("{prefix}bravo.db");
+    let charlie = format!("{prefix}charlie.db");
+    let mut writer = provider
+        .open(&bravo, OpenOptions::create_new_write())
+        .await?;
+    writer.write_all(b"bravo-bytes").await?;
+    writer.sync_all().await?;
+    drop(writer);
+    let mut writer = provider
+        .open(&charlie, OpenOptions::create_new_write())
+        .await?;
+    writer.write_all(b"charlie").await?;
+    writer.sync_all().await?;
+    drop(writer);
+    let old = provider.open(&bravo, OpenOptions::read_only()).await?;
+    provider.rename(&charlie, &bravo).await?;
+    step(
+        "charlie exists after rename",
+        exists(provider.exists(&charlie).await?),
+    );
+    step(
+        "old handle reads the replaced image",
+        read_all(&old, 64).await,
+    );
+    let new = provider.open(&bravo, OpenOptions::read_only()).await?;
+    step("the name reads the new image", read_all(&new, 64).await);
+    drop(old);
+    drop(new);
+    step("bravo still exists", exists(provider.exists(&bravo).await?));
+    Ok(log)
+}
+
+/// `unlink(2)` and `rename(2)` are namespace operations and never reach an
+/// open file; the simulator used to invalidate every handle on the way.
+#[test]
+fn the_simulator_keeps_open_files_alive_across_unlink_and_rename() {
+    local_runtime().block_on(async {
+        let dir = TempDir::new().expect("temp dir");
+        let prefix = format!("{}/", dir.path().to_str().expect("temp path is UTF-8"));
+        let production = open_file_contract(TokioStorageProvider::new(), prefix)
+            .await
+            .expect("the production scenarios must run");
+
+        let mut sim = SimWorld::new();
+        sim.set_storage_config(StorageConfiguration::fast_local());
+        let simulated =
+            run_storage_test(sim, |provider| open_file_contract(provider, String::new()))
+                .await
+                .expect("the simulated scenarios must run");
+
+        assert_eq!(
+            production, simulated,
+            "an open file must outlive its name on both backends alike"
+        );
+        let outcome = |label: &str| {
+            production
+                .iter()
+                .find(|step| step.label == label)
+                .map_or_else(
+                    || panic!("no step labelled {label:?}"),
+                    |step| step.outcome.clone(),
+                )
+        };
+        assert_eq!(
+            outcome("held handle reads after unlink"),
+            Ok(b"alpha-bytes".to_vec())
+        );
+        assert_eq!(
+            outcome("held handle reads its write"),
+            Ok(b"ALPHA-bytes".to_vec())
+        );
+        assert_eq!(
+            outcome("old handle reads the replaced image"),
+            Ok(b"bravo-bytes".to_vec())
+        );
+        assert_eq!(
+            outcome("the name reads the new image"),
+            Ok(b"charlie".to_vec())
+        );
+        assert_eq!(outcome("alpha exists after unlink"), Ok(vec![0]));
+        assert_eq!(outcome("charlie exists after rename"), Ok(vec![0]));
+    });
+}


### PR DESCRIPTION
Closes #227

## Problem

Deleting a file, or replacing its directory entry with `rename`, invalidated every handle already open on it and dropped its image as soon as no name reached it. On the production (Unix) backend those handles keep referencing the old image, so log rotation, compaction and atomic file replacement that work in production failed in simulation. That violates the documented split between namespace operations and already-open bytes.

## Fix

- `delete_file` and `rename_file` remove the name and nothing else.
- A file's image is dropped only when nothing reaches it any more: no visible or durable name **and** no open handle (`drop_file_if_unlinked` now counts handles). The last close of an unlinked file frees it, and a crash that closes a process's handles frees the unlinked files it was still reading.
- `invalidate_file_handles` is now only what a wipe needs, where the bytes really are gone.
- The book's provider chapter states the rule.

## Tests

`tests/storage/parity.rs` gains an open-file contract run against both `TokioStorageProvider` and the simulator: a handle held across an unlink still reads and writes the same bytes while the name is gone; a handle held on a file renamed over still reads the replaced image while the name serves the new one. Red on the previous engine (`BrokenPipe` on every read through the handle), green after, and both backends agree exactly. The old `rename_replaces_existing_target_and_invalidates_its_handles` test asserted the wrong behaviour and now asserts the Unix one.

Validation run locally: `cargo fmt`, both clippy gates, the full `moonpool-sim` suite, and all seven example simulations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013CytnDdK8Nsp66srsvuvdE

---
_Generated by [Claude Code](https://claude.ai/code/session_013CytnDdK8Nsp66srsvuvdE)_