### PR TITLE
fix(moonpool-sim): give each process its own file namespace

### DIFF
--- a/book/src/part2-foundations/07-provider-traits.md
+++ b/book/src/part2-foundations/07-provider-traits.md
@@ -206,7 +206,11 @@ delete, rename, and the directory sync that makes those durable — while the
 before it keeps reading and writing the same bytes, exactly as on Unix, and
 the bytes are freed only when the last name and the last handle are both
 gone. Log rotation and atomic replacement lean on that in production, and
-the simulator holds to it too.
+the simulator holds to it too. And the namespace is **per process**: a
+provider is created for one process IP, so two processes opening `data.db`
+open two files on two disks, one node's `delete` or `rename` never reaches
+another's, and a `sync_dir` commits only the syncing node's directory
+entries, as it would on two machines.
 
 `OpenOptions` mirrors `std::fs::OpenOptions` with `read`, `write`, `create`,
 `truncate`, and `append`, plus the one thing a database needs that

--- a/crates/moonpool-sim/src/sim/storage_ops.rs
+++ b/crates/moonpool-sim/src/sim/storage_ops.rs
@@ -101,22 +101,27 @@ impl SimWorld {
         self.inner.read().storage.handle_is_direct_io(handle_id)
     }
 
-    pub(crate) fn file_exists(&self, path: &str) -> bool {
-        self.inner.read().storage.file_exists(path)
+    pub(crate) fn file_exists(&self, owner_ip: IpAddr, path: &str) -> bool {
+        self.inner.read().storage.file_exists(owner_ip, path)
     }
 
-    pub(crate) fn delete_file(&self, path: &str) -> Result<(), StorageError> {
+    pub(crate) fn delete_file(&self, owner_ip: IpAddr, path: &str) -> Result<(), StorageError> {
         let mut inner = self.inner.write();
-        let actions = inner.storage.delete_file(path)?;
+        let actions = inner.storage.delete_file(owner_ip, path)?;
         let wakes = apply_storage_actions(&mut inner, actions);
         drop(inner);
         wakes.wake();
         Ok(())
     }
 
-    pub(crate) fn rename_file(&self, from: &str, to: &str) -> Result<(), StorageError> {
+    pub(crate) fn rename_file(
+        &self,
+        owner_ip: IpAddr,
+        from: &str,
+        to: &str,
+    ) -> Result<(), StorageError> {
         let mut inner = self.inner.write();
-        let actions = inner.storage.rename_file(from, to)?;
+        let actions = inner.storage.rename_file(owner_ip, from, to)?;
         let wakes = apply_storage_actions(&mut inner, actions);
         drop(inner);
         wakes.wake();

--- a/crates/moonpool-sim/src/storage/provider.rs
+++ b/crates/moonpool-sim/src/storage/provider.rs
@@ -64,18 +64,18 @@ impl StorageProvider for SimStorageProvider {
 
     async fn exists(&self, path: &str) -> io::Result<bool> {
         let sim = self.sim()?;
-        Ok(sim.file_exists(path))
+        Ok(sim.file_exists(self.owner_ip, path))
     }
 
     async fn delete(&self, path: &str) -> io::Result<()> {
         let sim = self.sim()?;
-        sim.delete_file(path)?;
+        sim.delete_file(self.owner_ip, path)?;
         Ok(())
     }
 
     async fn rename(&self, from: &str, to: &str) -> io::Result<()> {
         let sim = self.sim()?;
-        sim.rename_file(from, to)?;
+        sim.rename_file(self.owner_ip, from, to)?;
         Ok(())
     }
 

--- a/crates/moonpool-sim/src/storage/sim/engine.rs
+++ b/crates/moonpool-sim/src/storage/sim/engine.rs
@@ -10,6 +10,8 @@ use std::{
 
 use moonpool_core::{DirectIo, IoConstraints, OpenOptions};
 
+use super::state::Name;
+
 use super::{
     DiskDegradationState, DiskEpisodeKind, FileId, HandleId, OperationId, StorageEvent,
     state::{FileState, HandleState, PendingOpType, PendingStorageOp, StorageState},
@@ -154,6 +156,7 @@ impl StorageEngine {
         owner_ip: IpAddr,
     ) -> Result<HandleId, StorageError> {
         let path = path.to_string();
+        let name = (owner_ip, path.clone());
         // Contradictory flags are refused before anything else, as `std` does:
         // a read-only `truncate` must not reach the branch below that would
         // honor the truncation on a file it then had no right to write.
@@ -163,20 +166,20 @@ impl StorageEngine {
                 reason: error.to_string(),
             })?;
         let (constraints, direct_io) = self.resolve_direct_io(&options, owner_ip)?;
-        if options.is_create_new() && self.state.path_to_file.contains_key(&path) {
+        if options.is_create_new() && self.state.path_to_file.contains_key(&name) {
             return Err(StorageError::AlreadyExists { path });
         }
         // `Required` opens a file that is already there. Refusing to create
         // one keeps the simulated provider honest about what production does,
         // and keeps file bootstrap in the caller's protocol where it belongs.
         if options.requested_direct_io() == DirectIo::Required
-            && !self.state.path_to_file.contains_key(&path)
+            && !self.state.path_to_file.contains_key(&name)
             && (options.is_create() || options.is_create_new())
         {
             return Err(StorageError::DirectIoCreate { path });
         }
 
-        let file_id = if let Some(existing_id) = self.state.path_to_file.get(&path).copied() {
+        let file_id = if let Some(existing_id) = self.state.path_to_file.get(&name).copied() {
             if options.is_truncate()
                 && let Some(file) = self.state.files.get_mut(&existing_id)
             {
@@ -204,7 +207,7 @@ impl StorageEngine {
                     owner_ip,
                 },
             );
-            self.state.path_to_file.insert(path, file_id);
+            self.state.path_to_file.insert(name, file_id);
             file_id
         };
 
@@ -265,8 +268,10 @@ impl StorageEngine {
         Ok(self.open_handle(handle_id)?.direct_io)
     }
 
-    pub(crate) fn file_exists(&self, path: &str) -> bool {
-        self.state.path_to_file.contains_key(path)
+    pub(crate) fn file_exists(&self, owner_ip: IpAddr, path: &str) -> bool {
+        self.state
+            .path_to_file
+            .contains_key(&(owner_ip, path.to_string()))
     }
 
     /// Remove a name from the namespace — `unlink(2)`.
@@ -276,8 +281,16 @@ impl StorageEngine {
     /// on the production (Unix) backend, and the image is freed only when its
     /// last name and its last handle are both gone. Log rotation, compaction
     /// and atomic replacement depend on exactly that.
-    pub(crate) fn delete_file(&mut self, path: &str) -> Result<StorageActions, StorageError> {
-        let Some(file_id) = self.state.path_to_file.remove(path) else {
+    pub(crate) fn delete_file(
+        &mut self,
+        owner_ip: IpAddr,
+        path: &str,
+    ) -> Result<StorageActions, StorageError> {
+        let Some(file_id) = self
+            .state
+            .path_to_file
+            .remove(&(owner_ip, path.to_string()))
+        else {
             return Err(StorageError::NotFound {
                 path: path.to_string(),
             });
@@ -311,33 +324,36 @@ impl StorageEngine {
 
     pub(crate) fn rename_file(
         &mut self,
+        owner_ip: IpAddr,
         from: &str,
         to: &str,
     ) -> Result<StorageActions, StorageError> {
+        let from_name = (owner_ip, from.to_string());
         if from == to {
             return self
                 .state
                 .path_to_file
-                .contains_key(from)
+                .contains_key(&from_name)
                 .then(StorageActions::default)
                 .ok_or_else(|| StorageError::NotFound {
                     path: from.to_string(),
                 });
         }
-        let Some(file_id) = self.state.path_to_file.remove(from) else {
+        let Some(file_id) = self.state.path_to_file.remove(&from_name) else {
             return Err(StorageError::NotFound {
                 path: from.to_string(),
             });
         };
+        let to_name = (owner_ip, to.to_string());
         // The replaced file loses its name, nothing more: handles opened on
         // it before the rename keep its image, as `rename(2)` guarantees.
-        if let Some(replaced_id) = self.state.path_to_file.remove(to) {
+        if let Some(replaced_id) = self.state.path_to_file.remove(&to_name) {
             self.drop_file_if_unlinked(replaced_id);
         }
         if let Some(file) = self.state.files.get_mut(&file_id) {
             file.path = to.to_string();
         }
-        self.state.path_to_file.insert(to.to_string(), file_id);
+        self.state.path_to_file.insert(to_name, file_id);
         Ok(StorageActions::default())
     }
 
@@ -363,7 +379,9 @@ impl StorageEngine {
         path: &str,
         sectors: Range<u64>,
     ) -> Result<(), StorageError> {
-        self.file_mut(path)?.image.corrupt(sectors);
+        for file in self.files_named(path)? {
+            file.image.corrupt(sectors.clone());
+        }
         Ok(())
     }
 
@@ -374,7 +392,9 @@ impl StorageEngine {
         sectors: Range<u64>,
         target: EioTarget,
     ) -> Result<(), StorageError> {
-        self.file_mut(path)?.image.fail_with_eio(sectors, target);
+        for file in self.files_named(path)? {
+            file.image.fail_with_eio(sectors.clone(), target);
+        }
         Ok(())
     }
 
@@ -384,7 +404,9 @@ impl StorageEngine {
         path: &str,
         target: EioTarget,
     ) -> Result<(), StorageError> {
-        self.file_mut(path)?.image.clear_eio(target);
+        for file in self.files_named(path)? {
+            file.image.clear_eio(target);
+        }
         Ok(())
     }
 
@@ -395,25 +417,37 @@ impl StorageEngine {
         path: &str,
         sector: u64,
     ) -> Result<(), StorageError> {
-        self.file_mut(path)?
-            .image
-            .corrupt_committed_out_of_band(sector);
+        for file in self.files_named(path)? {
+            file.image.corrupt_committed_out_of_band(sector);
+        }
         Ok(())
     }
 
-    fn file_mut(&mut self, path: &str) -> Result<&mut FileState, StorageError> {
-        let file_id =
-            self.state
-                .path_to_file
-                .get(path)
-                .copied()
-                .ok_or_else(|| StorageError::NotFound {
-                    path: path.to_string(),
-                })?;
-        self.state
+    /// Every file currently named `path`, on whichever process's disk: a
+    /// targeted injection is addressed by file and sector, and a path names
+    /// one file per process that has it.
+    ///
+    /// # Errors
+    ///
+    /// [`StorageError::NotFound`] when no process has a file at `path`.
+    fn files_named(&mut self, path: &str) -> Result<Vec<&mut FileState>, StorageError> {
+        let file_ids: Vec<FileId> = self
+            .state
+            .path_to_file
+            .iter()
+            .filter_map(|((_, name), file_id)| (name == path).then_some(*file_id))
+            .collect();
+        if file_ids.is_empty() {
+            return Err(StorageError::NotFound {
+                path: path.to_string(),
+            });
+        }
+        Ok(self
+            .state
             .files
-            .get_mut(&file_id)
-            .ok_or(StorageError::MissingFile { file_id })
+            .iter_mut()
+            .filter_map(|(file_id, file)| file_ids.contains(file_id).then_some(file))
+            .collect())
     }
 
     /// Make every directory entry directly under `path` durable.
@@ -447,13 +481,17 @@ impl StorageEngine {
             });
         }
 
+        // One process's directory sync commits that process's entries and
+        // nobody else's: another disk's metadata is not made durable by it.
         let directory = normalize_directory(path);
         self.state
             .durable_paths
-            .retain(|entry, _| parent_directory(entry) != directory);
-        for (entry, file_id) in &self.state.path_to_file {
-            if parent_directory(entry) == directory {
-                self.state.durable_paths.insert(entry.clone(), *file_id);
+            .retain(|(owner, entry), _| *owner != owner_ip || parent_directory(entry) != directory);
+        for ((owner, entry), file_id) in &self.state.path_to_file {
+            if *owner == owner_ip && parent_directory(entry) == directory {
+                self.state
+                    .durable_paths
+                    .insert((*owner, entry.clone()), *file_id);
             }
         }
         Ok(actions)
@@ -487,15 +525,15 @@ impl StorageEngine {
         self.state
             .durable_paths
             .retain(|_, file_id| !mine.contains(file_id));
-        let surviving: Vec<(String, FileId)> = self
+        let surviving: Vec<(Name, FileId)> = self
             .state
             .path_to_file
             .iter()
             .filter(|(_, file_id)| mine.contains(file_id))
-            .map(|(path, file_id)| (path.clone(), *file_id))
+            .map(|(name, file_id)| (name.clone(), *file_id))
             .collect();
-        for (path, file_id) in surviving {
-            self.state.durable_paths.insert(path, file_id);
+        for (name, file_id) in surviving {
+            self.state.durable_paths.insert(name, file_id);
         }
 
         // Contents no surviving name reaches are gone with the name.
@@ -515,29 +553,22 @@ impl StorageEngine {
     /// operations: a name created since the last directory sync may not be
     /// there, and one deleted or renamed away may still be.
     fn lose_unsynced_entries(&mut self, ip: IpAddr, probability: f64) {
-        let mine = self.files_owned_by(ip);
-        let mut paths: Vec<String> = self
+        // Only this process's own namespace is at risk.
+        let mut names: Vec<Name> = self
             .state
             .path_to_file
             .keys()
             .chain(self.state.durable_paths.keys())
+            .filter(|(owner, _)| *owner == ip)
             .cloned()
             .collect();
-        paths.sort_unstable();
-        paths.dedup();
+        names.sort_unstable();
+        names.dedup();
 
-        for path in paths {
-            let visible = self.state.path_to_file.get(&path).copied();
-            let durable = self.state.durable_paths.get(&path).copied();
+        for name in names {
+            let visible = self.state.path_to_file.get(&name).copied();
+            let durable = self.state.durable_paths.get(&name).copied();
             if visible == durable {
-                continue;
-            }
-            // Only this process's own entries are at risk.
-            if !visible
-                .iter()
-                .chain(durable.iter())
-                .any(|file_id| mine.contains(file_id))
-            {
                 continue;
             }
             if sim_random::<f64>() >= probability {
@@ -545,13 +576,13 @@ impl StorageEngine {
             }
             assert_reachable!("disk: crash lost an unsynced directory entry");
             self.state.record_fault(StorageFaultRecord {
-                path: path.clone(),
+                path: name.1.clone(),
                 kind: StorageFaultKind::DirEntryLost,
                 sectors: None,
             });
             match durable {
-                Some(file_id) => self.state.path_to_file.insert(path, file_id),
-                None => self.state.path_to_file.remove(&path),
+                Some(file_id) => self.state.path_to_file.insert(name, file_id),
+                None => self.state.path_to_file.remove(&name),
             };
         }
     }
@@ -968,7 +999,7 @@ impl StorageEngine {
         let Some(data) = pending.data else {
             return Err(StorageError::InvalidOperationData { operation_id });
         };
-        let (owner_ip, path, config) = self
+        let (owner_ip, path, config, file_size) = self
             .state
             .files
             .get(&pending.file_id)
@@ -977,16 +1008,12 @@ impl StorageEngine {
                     file.owner_ip,
                     file.path.clone(),
                     self.state.config_for(file.owner_ip).clone(),
+                    file.image.size(),
                 )
             })
             .ok_or(StorageError::InvalidFileHandle {
                 handle_id: pending.handle_id,
             })?;
-        let file_size = self
-            .state
-            .files
-            .get(&pending.file_id)
-            .map_or(0, |file| file.image.size());
         // Append mode is the stream cursor's business: a positioned write was
         // already told exactly where it goes.
         let offset = if pending.append {
@@ -995,7 +1022,8 @@ impl StorageEngine {
             pending.offset
         };
 
-        let landing = self.decide_write_landing(&path, offset, data.len(), file_size, &config);
+        let landing =
+            self.decide_write_landing(pending.file_id, offset, data.len(), file_size, &config);
         let mut fault_kind = None;
         match landing {
             WriteLanding::Eio => {
@@ -1080,7 +1108,7 @@ impl StorageEngine {
     /// installing a mask never shifts the random stream.
     fn decide_write_landing(
         &mut self,
-        path: &str,
+        file_id: FileId,
         offset: u64,
         len: usize,
         file_size: u64,
@@ -1088,9 +1116,11 @@ impl StorageEngine {
     ) -> WriteLanding {
         let sectors = sector_range(offset, len);
         let eio_roll = sim_random::<f64>();
-        let targeted = self
-            .image_at(path)
-            .is_some_and(|image| image.write_fails(sectors.clone()));
+        let (targeted, path) = self.state.files.get(&file_id).map_or_else(
+            || (false, String::new()),
+            |file| (file.image.write_fails(sectors.clone()), file.path.clone()),
+        );
+        let path = path.as_str();
         let random_eio =
             config.write_eio_probability > 0.0 && eio_roll < config.write_eio_probability;
         if targeted || (random_eio && self.state.eligible_range(path, sectors.clone())) {
@@ -1156,12 +1186,6 @@ impl StorageEngine {
             assert_reachable!("disk fault: write planted latent corruption");
         }
         corrupted
-    }
-
-    /// The image behind a path, if the path still names a file.
-    fn image_at(&self, path: &str) -> Option<&FileImage> {
-        let file_id = self.state.path_to_file.get(path)?;
-        self.state.files.get(file_id).map(|file| &file.image)
     }
 
     fn complete_sync(
@@ -1384,9 +1408,8 @@ impl StorageEngine {
         let mut actions = StorageActions::default();
         for (file_id, path) in files {
             self.state.files.remove(&file_id);
-            self.state.path_to_file.remove(&path);
+            self.state.path_to_file.remove(&(ip, path));
             self.state.durable_paths.retain(|_, id| *id != file_id);
-            let _ = path;
             self.invalidate_file_handles(file_id, &mut actions);
         }
         actions.fault(SimFaultEvent::StorageWipe { ip: ip.to_string() });

--- a/crates/moonpool-sim/src/storage/sim/state.rs
+++ b/crates/moonpool-sim/src/storage/sim/state.rs
@@ -101,6 +101,9 @@ pub(crate) struct PendingStorageOp {
     pub(crate) positioned: bool,
 }
 
+/// A name in a process's namespace: the owning process and the path.
+pub(crate) type Name = (IpAddr, String);
+
 /// Mutable storage data owned by [`super::StorageEngine`].
 #[derive(Debug)]
 pub(crate) struct StorageState {
@@ -115,14 +118,16 @@ pub(crate) struct StorageState {
     pub(crate) failed_disks: BTreeSet<IpAddr>,
     pub(crate) files: BTreeMap<FileId, FileState>,
     pub(crate) handles: BTreeMap<HandleId, HandleState>,
-    /// The namespace as it is now.
-    pub(crate) path_to_file: BTreeMap<String, FileId>,
+    /// The namespace as it is now, one per process: a name is a path *on a
+    /// process's disk*, so two processes resolving the same relative path
+    /// reach two files, as two machines would.
+    pub(crate) path_to_file: BTreeMap<Name, FileId>,
     /// The namespace as it would survive a crash: entries promoted here by a
     /// directory sync. A create, delete, or rename changes `path_to_file`
     /// immediately and reaches this map only when the directory holding it is
     /// synced — file data durability and directory-entry durability are two
     /// different things.
-    pub(crate) durable_paths: BTreeMap<String, FileId>,
+    pub(crate) durable_paths: BTreeMap<Name, FileId>,
     pub(crate) pending_ops: BTreeMap<OperationId, PendingStorageOp>,
     /// Consulted before any random fault damages a sector (see
     /// [`StorageEligibilityMask`]).

--- a/crates/moonpool-sim/tests/storage.rs
+++ b/crates/moonpool-sim/tests/storage.rs
@@ -22,6 +22,8 @@ mod disk_failure;
 mod faults;
 #[path = "storage/latency.rs"]
 mod latency;
+#[path = "storage/namespaces.rs"]
+mod namespaces;
 #[path = "storage/performance.rs"]
 mod performance;
 #[path = "storage/positioned.rs"]

--- a/crates/moonpool-sim/tests/storage/namespaces.rs
+++ b/crates/moonpool-sim/tests/storage/namespaces.rs
@@ -1,0 +1,163 @@
+//! One namespace per process: a path names a file *on a process's disk*.
+//!
+//! Providers for distinct process IPs used to resolve the same relative path
+//! to the same file, and a directory sync from one node committed another
+//! node's directory entries. Independent replicas could overwrite each
+//! other, share bytes, or make another disk's metadata durable — so
+//! replication and crash tests did not model independent storage.
+
+use futures::io::{AsyncReadExt, AsyncWriteExt};
+use moonpool_core::{OpenOptions, StorageFile, StorageProvider};
+use moonpool_sim::{SimStorageProvider, SimWorld, StorageConfiguration};
+use std::net::IpAddr;
+
+fn node_a() -> IpAddr {
+    "10.0.1.1".parse().expect("valid IP")
+}
+
+fn node_b() -> IpAddr {
+    "10.0.1.2".parse().expect("valid IP")
+}
+
+fn local_runtime() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .enable_time()
+        .build()
+        .expect("Failed to build local runtime")
+}
+
+/// A world whose crashes always lose an unsynced directory entry.
+fn losing_sim() -> SimWorld {
+    let mut config = StorageConfiguration::fast_local();
+    config.unsynced_dir_entry_loss_probability = 1.0;
+    let mut sim = SimWorld::new();
+    sim.set_storage_config(config);
+    sim
+}
+
+async fn run_as<F, Fut, T>(sim: &mut SimWorld, ip: IpAddr, f: F) -> T
+where
+    F: FnOnce(SimStorageProvider) -> Fut,
+    Fut: std::future::Future<Output = T> + Send + 'static,
+    T: Send + 'static,
+{
+    let provider = sim.storage_provider(ip);
+    let handle = tokio::spawn(f(provider));
+    while !handle.is_finished() {
+        while sim.pending_event_count() > 0 {
+            sim.step();
+        }
+        tokio::task::yield_now().await;
+    }
+    handle.await.expect("task panicked")
+}
+
+async fn write_file(
+    provider: &SimStorageProvider,
+    path: &str,
+    bytes: &[u8],
+) -> std::io::Result<()> {
+    let mut file = provider.open(path, OpenOptions::create_new_write()).await?;
+    file.write_all(bytes).await?;
+    file.sync_all().await
+}
+
+async fn read_file(provider: &SimStorageProvider, path: &str) -> std::io::Result<Vec<u8>> {
+    let mut file = provider.open(path, OpenOptions::read_only()).await?;
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes).await?;
+    Ok(bytes)
+}
+
+/// Two processes each create `data.db`: two files, each seeing its own
+/// bytes, each unaffected by the other's delete.
+#[test]
+fn each_process_resolves_a_path_on_its_own_disk() {
+    local_runtime().block_on(async {
+        let mut sim = SimWorld::new();
+        sim.set_storage_config(StorageConfiguration::fast_local());
+
+        run_as(&mut sim, node_a(), |provider| async move {
+            write_file(&provider, "data.db", b"from-a").await
+        })
+        .await
+        .expect("node A creates its file");
+
+        run_as(&mut sim, node_b(), |provider| async move {
+            // `create_new` on B must not collide with A's file of the same name.
+            write_file(&provider, "data.db", b"from-b").await
+        })
+        .await
+        .expect("node B creates its own file under the same path");
+
+        let a = run_as(&mut sim, node_a(), |provider| async move {
+            read_file(&provider, "data.db").await
+        })
+        .await
+        .expect("A reads");
+        assert_eq!(a, b"from-a", "A's bytes are A's, whatever B wrote");
+
+        run_as(&mut sim, node_b(), |provider| async move {
+            provider.delete("data.db").await?;
+            provider.exists("data.db").await
+        })
+        .await
+        .map(|exists| assert!(!exists, "B's name is gone"))
+        .expect("B deletes its file");
+
+        let still_there = run_as(&mut sim, node_a(), |provider| async move {
+            let exists = provider.exists("data.db").await?;
+            let bytes = read_file(&provider, "data.db").await?;
+            Ok::<_, std::io::Error>((exists, bytes))
+        })
+        .await
+        .expect("A still reads");
+        assert_eq!(
+            still_there,
+            (true, b"from-a".to_vec()),
+            "B's delete must not reach A's disk"
+        );
+    });
+}
+
+/// A's directory sync commits A's entries only: B's unsynced entry is still
+/// lost when B crashes.
+#[test]
+fn a_directory_sync_commits_only_the_syncing_processs_entries() {
+    local_runtime().block_on(async {
+        let mut sim = losing_sim();
+
+        for ip in [node_a(), node_b()] {
+            run_as(&mut sim, ip, |provider| async move {
+                write_file(&provider, "db/wal", b"entries").await
+            })
+            .await
+            .expect("each node creates its wal");
+        }
+        run_as(&mut sim, node_a(), |provider| async move {
+            provider.sync_dir("db").await
+        })
+        .await
+        .expect("A syncs its directory");
+
+        sim.simulate_crash_for_process(node_b(), true);
+
+        let b_exists = run_as(&mut sim, node_b(), |provider| async move {
+            provider.exists("db/wal").await
+        })
+        .await
+        .expect("exists");
+        assert!(
+            !b_exists,
+            "B never synced its directory: A's sync must not have saved B's entry"
+        );
+
+        let a_exists = run_as(&mut sim, node_a(), |provider| async move {
+            provider.exists("db/wal").await
+        })
+        .await
+        .expect("exists");
+        assert!(a_exists, "A's own entry is untouched by B's crash");
+    });
+}


### PR DESCRIPTION
Closes #223

## Problem

Storage providers for distinct process IPs resolved the same relative path to the same file: the namespace was indexed by path alone and reused the first creator's file and owner, `exists`/`delete`/`rename` carried no owner at all, and a directory sync promoted every entry under the directory whoever owned it. Independent replicas could overwrite each other's data, share bytes and fault ownership, or make another disk's metadata durable, so replication and crash tests did not model independent storage.

## Fix

- The namespace (visible and durable) is keyed by `(owner IP, path)`. `open`, `exists`, `delete` and `rename` act on the calling provider's namespace.
- `sync_dir` commits only the syncing process's entries, and the crash-time entry-loss roll considers only the crashing process's names.
- Targeted injections (`corrupt_file`, `fail_file_with_eio`, `clear_file_eio`, `corrupt_durable_out_of_band`) stay addressed by path and act on every process's file of that name, since a fault is a file plus a sector, not a name. The write-landing decision looks its file up by id rather than by path.
- The book's provider chapter states the rule.

## Tests

`tests/storage/namespaces.rs`: two processes create `data.db` (`create_new` on the second used to collide with the first's file), each reads its own bytes, and one's delete leaves the other's file; and with unsynced-entry loss armed, A's `sync_dir` must not save B's unsynced entry across B's crash. Both red on the previous engine.

Validation run locally: `cargo fmt`, both clippy gates, the full `moonpool-sim` suite, and all seven example simulations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013CytnDdK8Nsp66srsvuvdE

---
_Generated by [Claude Code](https://claude.ai/code/session_013CytnDdK8Nsp66srsvuvdE)_