### PR TITLE
fix(moonpool-sim): own endpoints — refuse unbound connects, reject double binds

### DIFF
--- a/book/src/part4-networking/01-simulating-network.md
+++ b/book/src/part4-networking/01-simulating-network.md
@@ -71,6 +71,14 @@ recording a fault. The coordinator applies those actions, releases its lock,
 then wakes tasks. Keeping wake calls outside the lock lets a re-entrant waker
 poll network state without deadlocking.
 
+Endpoints are owned. A `bind` holds its address until the listener is
+dropped or its process is killed, so a second `bind` of a live address fails
+with `AddrInUse`, and a `connect` is refused with `ConnectionRefused` when
+nothing is listening at the address by the time the connection arrives. The
+address-in-use and connection-refused paths of startup, shutdown and
+misconfiguration therefore happen in simulation exactly as they do against
+the kernel. Port zero is ephemeral, as everywhere: such binds never collide.
+
 Delayed bind and connect futures are cancellation-safe. Accept reserves one
 backlogged connection while its latency elapses, and dropping the future
 returns that reservation to the front of the backlog. Shutdown fails delayed

--- a/crates/moonpool-sim/src/network/sim/engine.rs
+++ b/crates/moonpool-sim/src/network/sim/engine.rs
@@ -22,8 +22,8 @@ use super::{
     ConnectionId, ListenerId, NetworkEvent,
     event::NetworkOperationId,
     state::{
-        ClogState, CloseReason, ConnectionFlags, ConnectionState, InFlight, InFlightPayload,
-        NetworkState, PartitionState, SendWindow,
+        BoundListener, ClogState, CloseReason, ConnectionFlags, ConnectionState, InFlight,
+        InFlightPayload, NetworkState, PartitionState, SendWindow,
     },
 };
 
@@ -127,11 +127,73 @@ impl NetworkSimulation {
         self.localities = localities;
     }
 
-    pub(crate) fn create_listener(&mut self) -> ListenerId {
+    /// Bind `addr` for `owner`, or `None` when a live listener already holds
+    /// it (`AddrInUse`). A port-zero address is ephemeral on every runtime and
+    /// never conflicts: each such bind gets its own listener.
+    pub(crate) fn bind_listener(&mut self, addr: &str, owner: IpAddr) -> Option<ListenerId> {
+        if !addr.ends_with(":0") && self.state.bound.contains_key(addr) {
+            return None;
+        }
         let id = ListenerId(self.state.next_listener_id);
         self.state.next_listener_id += 1;
-        self.state.listeners.insert(id);
-        id
+        self.state
+            .bound
+            .insert(addr.to_string(), BoundListener { id, owner });
+        Some(id)
+    }
+
+    /// Release the address `id` holds, if it still holds it (a later bind may
+    /// have taken the address after a shutdown cleared the registry).
+    /// Connections that arrived and were never accepted are reset: nobody will
+    /// ever accept them.
+    pub(crate) fn unbind_listener(&mut self, id: ListenerId) -> WakeBatch {
+        let Some(addr) = self
+            .state
+            .bound
+            .iter()
+            .find_map(|(addr, bound)| (bound.id == id).then(|| addr.clone()))
+        else {
+            return WakeBatch::default();
+        };
+        self.state.bound.remove(&addr);
+        self.abort_backlog(&addr)
+    }
+
+    /// Release every listener `ip` owns: what a crash does to a process's
+    /// sockets.
+    pub(crate) fn unbind_listeners_for_ip(&mut self, ip: IpAddr) -> WakeBatch {
+        let ids: Vec<ListenerId> = self
+            .state
+            .bound
+            .values()
+            .filter(|bound| bound.owner == ip)
+            .map(|bound| bound.id)
+            .collect();
+        let mut wakes = WakeBatch::default();
+        for id in ids {
+            wakes.append(self.unbind_listener(id));
+        }
+        wakes
+    }
+
+    /// Whether a live listener holds `addr`.
+    pub(crate) fn is_bound(&self, addr: &str) -> bool {
+        self.state.bound.contains_key(addr)
+    }
+
+    /// Reset the connections queued on `addr` that no accept ever took.
+    fn abort_backlog(&mut self, addr: &str) -> WakeBatch {
+        let queued: Vec<ConnectionId> = self
+            .state
+            .pending_connections
+            .remove(addr)
+            .map(Vec::from)
+            .unwrap_or_default();
+        let mut wakes = WakeBatch::default();
+        for id in queued {
+            wakes.append(self.close_aborted(id));
+        }
+        wakes
     }
 
     /// Drain up to `buf.len()` bytes from `connection_id`'s receive buffer.
@@ -410,7 +472,20 @@ impl NetworkSimulation {
         WakeBatch::default()
     }
 
-    pub(crate) fn store_pending(&mut self, addr: &str, connection_id: ConnectionId) -> WakeBatch {
+    /// Publish an arriving connection to the listener on `addr`, or `None`
+    /// when nobody is listening there: the connection is refused.
+    pub(crate) fn store_pending(
+        &mut self,
+        addr: &str,
+        connection_id: ConnectionId,
+    ) -> Option<WakeBatch> {
+        if !self.is_bound(addr) {
+            return None;
+        }
+        Some(self.publish_pending(addr, connection_id))
+    }
+
+    fn publish_pending(&mut self, addr: &str, connection_id: ConnectionId) -> WakeBatch {
         if let Some((waiter_id, waker)) = self.take_next_accept(addr) {
             self.accept_reservations.insert(
                 waiter_id,
@@ -1057,6 +1132,9 @@ impl NetworkSimulation {
             wakes.extend([reservation.waker]);
         }
         self.state.pending_connections.clear();
+        // The world is over: every listener is dead, and a listener bound
+        // after the shutdown must not collide with a leftover of it.
+        self.state.bound.clear();
         let connections = self.state.connections.keys().copied().collect::<Vec<_>>();
         for connection in connections {
             wakes.append(self.close_aborted(connection));

--- a/crates/moonpool-sim/src/network/sim/facade.rs
+++ b/crates/moonpool-sim/src/network/sim/facade.rs
@@ -41,8 +41,15 @@ impl SimWorld {
         inner.apply_network(actions);
     }
 
-    pub(crate) fn create_listener(&self) -> ListenerId {
-        self.inner.write().network.create_listener()
+    /// Bind `addr` for the process at `owner`; `None` when it is in use.
+    pub(crate) fn bind_listener(&self, addr: &str, owner: IpAddr) -> Option<ListenerId> {
+        self.inner.write().network.bind_listener(addr, owner)
+    }
+
+    /// Release the address a dropped listener held.
+    pub(crate) fn unbind_listener(&self, id: ListenerId) {
+        let wakes = self.inner.write().network.unbind_listener(id);
+        wakes.wake();
     }
 
     pub(crate) fn read_from_connection(
@@ -115,9 +122,17 @@ impl SimWorld {
         wakes.wake();
     }
 
-    pub(crate) fn store_pending_connection(&self, addr: &str, id: ConnectionId) {
+    /// Publish an arriving connection to the listener on `addr`. Returns
+    /// `false`, publishing nothing, when nobody is listening there.
+    pub(crate) fn store_pending_connection(&self, addr: &str, id: ConnectionId) -> bool {
         let wakes = self.inner.write().network.store_pending(addr, id);
-        wakes.wake();
+        match wakes {
+            Some(wakes) => {
+                wakes.wake();
+                true
+            }
+            None => false,
+        }
     }
 
     pub(crate) fn return_pending_connection(&self, addr: &str, id: ConnectionId) {
@@ -461,6 +476,9 @@ impl SimWorld {
             for id in ids {
                 wakes.append(inner.network.close_aborted(id));
             }
+            // A dead process listens on nothing: its addresses are free and
+            // a connect to them is refused until something binds them again.
+            wakes.append(inner.network.unbind_listeners_for_ip(ip));
             wakes
         };
         wakes.wake();

--- a/crates/moonpool-sim/src/network/sim/provider.rs
+++ b/crates/moonpool-sim/src/network/sim/provider.rs
@@ -81,9 +81,16 @@ impl NetworkProvider for SimNetworkProvider {
             .map_err(io::Error::other)?
             .await
             .map_err(io::Error::other)?;
-        sim.create_listener();
+        // One live listener per address, as the operating system enforces:
+        // a second bind fails with `AddrInUse` until the first is dropped.
+        let id = sim.bind_listener(addr, self.local_ip).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::AddrInUse,
+                format!("address already in use: {addr}"),
+            )
+        })?;
 
-        let listener = SimTcpListener::new(self.sim.clone(), addr.to_string());
+        let listener = SimTcpListener::new(self.sim.clone(), addr.to_string(), id);
         Ok(listener)
     }
 
@@ -163,8 +170,17 @@ impl NetworkProvider for SimNetworkProvider {
             .await
             .map_err(io::Error::other)?;
 
-        // Only publish the server endpoint after connection establishment.
-        sim.store_pending_connection(addr, server_id);
+        // Only publish the server endpoint after connection establishment —
+        // and only to a live listener. Nobody listening when the connection
+        // arrives is a refused connection: the pair is discarded (the guard
+        // stays armed) and the caller gets what the kernel would answer.
+        if !sim.store_pending_connection(addr, server_id) {
+            tracing::debug!(addr = %addr, "connection refused: nothing is listening");
+            return Err(io::Error::new(
+                io::ErrorKind::ConnectionRefused,
+                format!("connection refused: nothing is listening on {addr}"),
+            ));
+        }
         pending_pair.disarm();
 
         let stream = SimTcpStream::new(self.sim.clone(), client_id);

--- a/crates/moonpool-sim/src/network/sim/state.rs
+++ b/crates/moonpool-sim/src/network/sim/state.rs
@@ -25,7 +25,7 @@
 //! buffer are the peer's: nothing on the wire can take them back.
 
 use std::{
-    collections::{BTreeMap, BTreeSet, VecDeque},
+    collections::{BTreeMap, VecDeque},
     net::IpAddr,
     time::Duration,
 };
@@ -325,13 +325,23 @@ impl SendWindow {
 }
 
 /// Protocol state owned exclusively by the simulated network engine.
+/// A live listener on one address.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct BoundListener {
+    pub(crate) id: ListenerId,
+    pub(crate) owner: IpAddr,
+}
+
 #[derive(Debug)]
 pub(crate) struct NetworkState {
     pub(crate) next_connection_id: u64,
     pub(crate) next_listener_id: u64,
     pub(crate) config: NetworkConfiguration,
     pub(crate) connections: BTreeMap<ConnectionId, ConnectionState>,
-    pub(crate) listeners: BTreeSet<ListenerId>,
+    /// The bound endpoints: which listener owns each address, and which
+    /// process owns the listener. A `connect` to an address absent here is
+    /// refused, a `bind` to one present fails with `AddrInUse`.
+    pub(crate) bound: BTreeMap<String, BoundListener>,
     pub(crate) pending_connections: BTreeMap<String, VecDeque<ConnectionId>>,
     pub(crate) connection_clogs: BTreeMap<ConnectionId, ClogState>,
     pub(crate) read_clogs: BTreeMap<ConnectionId, ClogState>,
@@ -350,7 +360,7 @@ impl NetworkState {
             next_listener_id: 0,
             config,
             connections: BTreeMap::new(),
-            listeners: BTreeSet::new(),
+            bound: BTreeMap::new(),
             pending_connections: BTreeMap::new(),
             connection_clogs: BTreeMap::new(),
             read_clogs: BTreeMap::new(),

--- a/crates/moonpool-sim/src/network/sim/stream.rs
+++ b/crates/moonpool-sim/src/network/sim/stream.rs
@@ -1,4 +1,7 @@
-use super::{AcceptWaiterId, CloseReason, NetworkDelay, types::ConnectionId};
+use super::{
+    AcceptWaiterId, CloseReason, NetworkDelay,
+    types::{ConnectionId, ListenerId},
+};
 use crate::{TcpListenerTrait, WeakSimWorld};
 use futures::io::{AsyncRead, AsyncWrite};
 use std::{
@@ -637,12 +640,27 @@ impl Drop for AcceptFuture {
 pub struct SimTcpListener {
     sim: WeakSimWorld,
     local_addr: String,
+    id: ListenerId,
 }
 
 impl SimTcpListener {
     /// Create a new simulated TCP listener
-    pub(crate) fn new(sim: WeakSimWorld, local_addr: String) -> Self {
-        Self { sim, local_addr }
+    pub(crate) fn new(sim: WeakSimWorld, local_addr: String, id: ListenerId) -> Self {
+        Self {
+            sim,
+            local_addr,
+            id,
+        }
+    }
+}
+
+impl Drop for SimTcpListener {
+    fn drop(&mut self) {
+        // Dropping the socket releases the address: later binds succeed and
+        // later connects are refused, as with a real listener.
+        if let Ok(sim) = self.sim.upgrade() {
+            sim.unbind_listener(self.id);
+        }
     }
 }
 

--- a/crates/moonpool-sim/src/sim/world.rs
+++ b/crates/moonpool-sim/src/sim/world.rs
@@ -861,8 +861,12 @@ mod tests {
             sim.poll_accept("reserved", waiter_id, waiter.clone()),
             Ok(None)
         ));
+        let owner: std::net::IpAddr = "127.0.0.1".parse().expect("valid IP");
+        let _listener = sim
+            .bind_listener("reserved", owner)
+            .expect("the address is free");
         let (_, server) = sim.create_connection_pair("127.0.0.1:1", "127.0.0.1:2");
-        sim.store_pending_connection("reserved", server);
+        assert!(sim.store_pending_connection("reserved", server));
 
         sim.schedule_event(Event::Shutdown, Duration::ZERO);
         assert!(!sim.step());
@@ -891,8 +895,12 @@ mod tests {
             sim.poll_accept("fifo", second, waiter.clone()),
             Ok(None)
         ));
+        let owner: std::net::IpAddr = "127.0.0.1".parse().expect("valid IP");
+        let _listener = sim
+            .bind_listener("fifo", owner)
+            .expect("the address is free");
         let (_, server) = sim.create_connection_pair("127.0.0.1:1", "127.0.0.1:2");
-        sim.store_pending_connection("fifo", server);
+        assert!(sim.store_pending_connection("fifo", server));
 
         sim.cancel_accept("fifo", first);
 

--- a/crates/moonpool-sim/tests/network.rs
+++ b/crates/moonpool-sim/tests/network.rs
@@ -2,6 +2,8 @@
 //!
 //! Contains tests for network simulation and configuration.
 
+#[path = "network/endpoints.rs"]
+mod endpoints;
 #[path = "network/half_close.rs"]
 mod half_close;
 #[path = "network/in_flight.rs"]

--- a/crates/moonpool-sim/tests/network/endpoints.rs
+++ b/crates/moonpool-sim/tests/network/endpoints.rs
@@ -1,0 +1,157 @@
+//! Endpoint ownership: a bind holds an address, a connect needs a listener.
+//!
+//! The engine used to keep only a set of listener ids: `bind` never checked
+//! the address, `connect` published its connection after the delay without
+//! looking for a live listener, and dropping a listener released nothing. So
+//! a connection to an address nobody had bound succeeded, two listeners
+//! could hold one address, and the connection-refused / address-in-use
+//! behaviour every startup, shutdown and misconfiguration path depends on
+//! never happened in simulation.
+
+use futures::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    task::noop_waker,
+};
+use moonpool_sim::{
+    NetworkConfiguration, NetworkProvider, SimWorld, TcpListenerTrait, buggify_reset,
+};
+use std::{
+    future::Future,
+    io,
+    net::IpAddr,
+    pin::pin,
+    task::{Context, Poll},
+};
+
+const MAX_DRIVER_STEPS: usize = 10_000;
+const SERVER: &str = "10.0.1.2:8080";
+
+fn client_ip() -> IpAddr {
+    "10.0.1.1".parse().expect("valid test IP")
+}
+
+fn server_ip() -> IpAddr {
+    "10.0.1.2".parse().expect("valid test IP")
+}
+
+fn drive<F: Future>(sim: &mut SimWorld, future: F) -> F::Output {
+    let mut future = pin!(future);
+    let waker = noop_waker();
+    let mut context = Context::from_waker(&waker);
+    for _ in 0..MAX_DRIVER_STEPS {
+        if let Poll::Ready(output) = future.as_mut().poll(&mut context) {
+            return output;
+        }
+        assert!(
+            sim.has_pending_events(),
+            "simulation-backed future stalled without a pending event"
+        );
+        sim.step();
+    }
+    panic!("simulation-backed future exceeded {MAX_DRIVER_STEPS} events")
+}
+
+fn world() -> SimWorld {
+    buggify_reset();
+    SimWorld::new_with_network_config_and_seed(NetworkConfiguration::fast_local(), 20_260_911)
+}
+
+fn kind_of<T>(result: io::Result<T>) -> Option<io::ErrorKind> {
+    result.err().map(|error| error.kind())
+}
+
+/// Nobody bound the address: the connect is refused, as the kernel refuses
+/// a SYN to a closed port.
+#[test]
+fn a_connect_to_an_unbound_address_is_refused() {
+    let mut sim = world();
+    let client = sim.network_provider(client_ip());
+    assert_eq!(
+        kind_of(drive(&mut sim, client.connect(SERVER))),
+        Some(io::ErrorKind::ConnectionRefused)
+    );
+}
+
+/// A second bind of a live address fails; once the first listener is
+/// dropped the address is free again.
+#[test]
+fn a_second_bind_of_a_live_address_is_in_use_until_the_first_is_dropped() {
+    let mut sim = world();
+    let server = sim.network_provider(server_ip());
+    let first = drive(&mut sim, server.bind(SERVER)).expect("first bind");
+    assert_eq!(
+        kind_of(drive(&mut sim, server.bind(SERVER))),
+        Some(io::ErrorKind::AddrInUse),
+        "two live listeners cannot hold one address"
+    );
+    drop(first);
+    let second = drive(&mut sim, server.bind(SERVER));
+    assert!(
+        second.is_ok(),
+        "the address is free once its listener is gone"
+    );
+}
+
+/// Port zero is ephemeral: every bind gets its own listener.
+#[test]
+fn port_zero_binds_never_collide() {
+    let mut sim = world();
+    let server = sim.network_provider(server_ip());
+    let _one = drive(&mut sim, server.bind("10.0.1.2:0")).expect("first ephemeral bind");
+    let _two = drive(&mut sim, server.bind("10.0.1.2:0")).expect("second ephemeral bind");
+}
+
+/// The whole life of an endpoint: bound, serving, dropped, refusing.
+#[test]
+fn dropping_the_listener_refuses_later_connects() {
+    let mut sim = world();
+    let server = sim.network_provider(server_ip());
+    let client = sim.network_provider(client_ip());
+    let listener = drive(&mut sim, server.bind(SERVER)).expect("bind");
+
+    let mut stream = drive(&mut sim, client.connect(SERVER)).expect("connect while bound");
+    let (mut accepted, _) = drive(&mut sim, listener.accept()).expect("accept");
+    drive(&mut sim, stream.write_all(b"hi")).expect("write");
+    let mut buf = [0_u8; 2];
+    drive(&mut sim, accepted.read_exact(&mut buf)).expect("read");
+    assert_eq!(&buf, b"hi");
+
+    drop(listener);
+    assert_eq!(
+        kind_of(drive(&mut sim, client.connect(SERVER))),
+        Some(io::ErrorKind::ConnectionRefused),
+        "nothing listens once the listener is dropped"
+    );
+    // The established connection is unaffected by the listener going away.
+    drive(&mut sim, stream.write_all(b"!!")).expect("write after unbind");
+    drive(&mut sim, accepted.read_exact(&mut buf)).expect("read after unbind");
+    assert_eq!(&buf, b"!!");
+}
+
+/// A crashed process listens on nothing: its address refuses connects and
+/// can be bound again, and the dead listener's eventual drop must not steal
+/// the address back from the new one.
+#[test]
+fn a_crashed_process_releases_its_listeners() {
+    let mut sim = world();
+    let server = sim.network_provider(server_ip());
+    let client = sim.network_provider(client_ip());
+    let dead = drive(&mut sim, server.bind(SERVER)).expect("bind before the crash");
+
+    sim.abort_all_connections_for_ip(server_ip());
+    assert_eq!(
+        kind_of(drive(&mut sim, client.connect(SERVER))),
+        Some(io::ErrorKind::ConnectionRefused),
+        "a crashed process's address refuses connects"
+    );
+
+    let reborn = drive(&mut sim, server.bind(SERVER)).expect("the rebooted process binds again");
+    drop(dead);
+    let stream = drive(&mut sim, client.connect(SERVER)).expect("connect to the new listener");
+    let accepted = drive(&mut sim, reborn.accept());
+    assert!(
+        accepted.is_ok(),
+        "the new listener serves; the old one's drop released nothing"
+    );
+    drop(stream);
+}


### PR DESCRIPTION
Closes #225

## Problem

The engine kept only a set of listener ids. `bind` never looked at the address, `connect` published its connection after the delay without checking for a live listener, and dropping a listener released nothing. So a connection to an address nobody had bound succeeded, two listeners could hold one address, and the connection-refused and address-in-use behaviour that startup, shutdown and misconfiguration paths depend on never happened in simulation.

## Fix

The engine now keeps a bind registry, address → (listener, owning process):

- `bind` fails with `AddrInUse` while a live listener holds the address. Port zero is ephemeral, as on every runtime, and never collides.
- Dropping the listener releases the address and resets any connection queued on it that no `accept` took.
- A process kill (`abort_all_connections_for_ip`) releases every listener the process owned; a later drop of the dead listener object does not steal the address back from a new bind.
- Shutdown clears the registry, so a bind after the shutdown does not collide with a leftover.
- `connect` is refused with `ConnectionRefused` when nothing is listening at the address by the time the connection arrives (after the connect delay, where the SYN would land). The pair is discarded.
- The book's networking chapter states the rule.

## Tests

`tests/network/endpoints.rs` pins the five behaviours: an unbound connect is refused; a second bind is in use until the first listener drops; port zero never collides; a dropped listener refuses later connects while established connections live on; a crashed process's address refuses connects, can be bound again, and the dead listener's later drop does not steal it back. Four of the five are red on the previous engine. Two world unit tests that published a connection without a bind now bind first.

Validation run locally: `cargo fmt`, both clippy gates, the full `moonpool-sim` suite, `moonpool-hyper` tests, and all seven example simulations via `cargo xtask sim run-all` (the examples already tolerate a failed connect, so a client racing its server's bind now sees a refusal it retries past, as it would against the kernel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013CytnDdK8Nsp66srsvuvdE

---
_Generated by [Claude Code](https://claude.ai/code/session_013CytnDdK8Nsp66srsvuvdE)_